### PR TITLE
Check Node.js version in build.js

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,4 +1,5 @@
 {
+    "requiredNodeMajorVersion": 15,
     "scope": "@polypoly-eu",
     "packages": [
         "aop-ts",


### PR DESCRIPTION
It happened two or three times now that someone (or something, i.e. a GitHub runner) ended up with an obscure error due to not being on Node.js 15.x (or more accurately NPM 7.x).

Didn't want to bother with checking the NPM version, but NPM 7.x comes with Node.js 15.x, so we just require that - that's how it's written in the README and the GitHub workflow.