### PR TITLE
Fix: Onboarding popup does not show up on Android

### DIFF
--- a/android/app/src/main/assets/container/container.html
+++ b/android/app/src/main/assets/container/container.html
@@ -6,7 +6,6 @@
     <title>Feature</title>
 </head>
 <body>
-    <script src="/pod.js"></script>
     <iframe id="harness"></iframe>
     <script src="container/container.js"></script>
 </body>

--- a/features/polyExplorer/src/fakePod.js
+++ b/features/polyExplorer/src/fakePod.js
@@ -40,12 +40,6 @@ function createFakeStorage() {
     };
 }
 
-// On Android, we currently expose the pod object in the container, but haven't
-// found a way yet to inject it into the feature with the right timing,
-// i.e. before any feature code is executed.
-if (navigator.userAgent.toLowerCase().includes("android"))
-    window.pod = window.parent.pod;
-
 export const pod =
     window.pod ||
     (() => {

--- a/features/polyExplorer/src/static/index.html
+++ b/features/polyExplorer/src/static/index.html
@@ -6,6 +6,7 @@
             content="width=device-width, initial-scale=1, user-scalable=no"
             charset="UTF-8"
         />
+        <script src="/pod.js"></script>
         <script src="react.development.js"></script>
         <script src="react-dom.development.js"></script>
         <link rel="stylesheet" href="css/bundle.css" />

--- a/ios/PolyPodApp/FeatureContainer/FeatureContainerView.swift
+++ b/ios/PolyPodApp/FeatureContainer/FeatureContainerView.swift
@@ -68,9 +68,9 @@ class FeatureWebView: WKWebView {
         )
         installUserScript(contentController, "podNav", forMainFrameOnly: false)
         
-        // The original idea was that the feature explicitly loads pod.js, but
-        // in order to still support the polyfill-based development approach,
-        // we explicitly inject it, at least for now.
+        // Requesting /pod.js from the feature does not appear to work, so
+        // in order to not break iOS in the fix for 1.1.1 on Android, we still
+        // inject pod.js here.
         installUserScript(contentController, "pod", forMainFrameOnly: false)
         
         installUserScript(


### PR DESCRIPTION
Turns out the window.parent workaround didn't work after all. The most
reliable fix is to revert things to a state where each feature
explicitly requests /pod.js.

This is aimed to go into the 1.1.1 release for Android. I still kept it working
on iOS, because why not.