### PR TITLE
Well, who'd known this...

### DIFF
--- a/core/communication/remote-pod/rollup.config.js
+++ b/core/communication/remote-pod/rollup.config.js
@@ -37,6 +37,7 @@ export default [
                 format: "iife"
             }
         ],
+        context: 'null',
         plugins: [
             resolve(),
             commonjs(),


### PR DESCRIPTION
It was the same error as in bubblewrap. Add context... Since #52 generates a different file from the same sources, it gets the same error too. Apparently, the fact that `this` does not become `null` causes the `sourcemap` error, which precisely pointed at the `this`.