### PR TITLE
Remove .stylelintrc from polyPinion

### DIFF
--- a/features/polyPinion/.stylelintrc
+++ b/features/polyPinion/.stylelintrc
@@ -1,1 +1,0 @@
-extends: "@polypoly-eu/stylelint-config-polypoly"


### PR DESCRIPTION
There's no reference either in package.json, or anywhere else.