### PR TITLE
Simplifies workflow run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
             - '**/*.?js'
             - '.editorconfig'
             - '.eslintrc.cjs'
-            polypod:
+            coreAndFeatures:
             - 'core/**'
             - 'features/**'
             - 'podjs/**'
@@ -44,10 +44,10 @@ jobs:
         if: steps.changes.outputs.js == 'true'
         run: ./build.js lint
       - name: Build core and features
-        if: steps.changes.outputs.polypod == 'true' || steps.changes.outputs.android == 'true'
+        if: steps.changes.outputs.coreAndFeatures == 'true' || steps.changes.outputs.android == 'true'
         run: ./build.js
       - name: Test core and features
-        if: steps.changes.outputs.polypod == 'true'
+        if: steps.changes.outputs.coreAndFeatures == 'true'
         run: xvfb-run --auto-servernum ./build.js test
       - uses: actions/setup-java@v1
         if: steps.changes.outputs.android == 'true'


### PR DESCRIPTION
The way it's set up now, it runs twice every push to a branch that is in a pull request. The simplification will make it run only when certain pull request events happen. This will save the vast majority of workflow runs that are happening now.
Also, paths have been internally set up so that only what's needed is actually run. For instance, if no JS file has been modified lint will not happen; if nothing is modified in core or features, there will be no build.
This reduces in cases such as this one, where we're only changing workflows, tests to less than 20 seconds. In other cases, your mileage may vary, depending on what you modify. If you don't modify any JS file (or configuration), you shave 20 seconds off your build; if you change only stuff in the android directory, you will save an additional 6 minutes from the polypod builds.
This is in part in accordance with PROD4POD-418, but there are better ways of doing it (which is where I'm aiming at in #77 )
