### PR TITLE
[Fix] Prevent "hangs" in lint, as well as avoid warnings

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,7 +21,7 @@ module.exports = {
     },
     settings: {
         react: {
-            version: "detect",
+            version: "latest",
         },
     },
     "ignorePatterns": [


### PR DESCRIPTION
This fixes a couple of things:
* The warning about not being able to detect react version because react was not installed
* @fhd informed me of `./build.js lint` taking a long time; it didn't happen in the github action, and I couldn't reproduce it locally... until I did. `eslint` was taking an unordinate amount of time examining bundles, node_modules and things like that, which caused a "hang-like" effect (actually, taking a few minutes). That shouldn't be happening now.