### PR TITLE
fix(prod4pod-576): check if the history.location has an state before to update the navigation

### DIFF
--- a/features/polyExplorer/src/context/explorer-context.jsx
+++ b/features/polyExplorer/src/context/explorer-context.jsx
@@ -123,7 +123,9 @@ export const ExplorerProvider = ({ children }) => {
     function handleBack() {
         if (currentPath != "/") {
             history.goBack();
-            changeNavigationState(history.location.state);
+            if (history.location.state) {
+                changeNavigationState(history.location.state);
+            }
         }
     }
 


### PR DESCRIPTION
Hey guys:

This is a small contribution to your work. I found a bug that escaped from my watch. If you press the ESC key to get to the first screen where the navigation started, the status of "history.location" in the last ESC is "undefined". When this "undefined" state was used to update the navigation state, an unhandled exception was thrown.

This small change avoids this uncontrolled exception.