### PR TITLE
feat(prod4pod-570): Using poly-button in lexicon

### DIFF
--- a/core/utils/poly-look/package.json
+++ b/core/utils/poly-look/package.json
@@ -4,8 +4,8 @@
   "description": "Webcomponent poly-look following open-wc recommendations",
   "author": "poly-look",
   "license": "MIT",
-  "main": "index.js",
-  "module": "index.js",
+  "main": "src/poly-look.js",
+  "module": "dist/poly-look.bundled.js",
   "scripts": {
     "lint": "eslint --ext .js,.html . --ignore-path .gitignore && prettier \"**/*.js\" --check --ignore-path .gitignore",
     "format": "eslint --ext .js,.html . --fix --ignore-path .gitignore && prettier \"**/*.js\" --write --ignore-path .gitignore",

--- a/core/utils/poly-look/src/buttons/button.js
+++ b/core/utils/poly-look/src/buttons/button.js
@@ -8,77 +8,89 @@ export class Button extends LitElement {
       globalTheme,
       css`
         .btn ::slotted(button) {
-          border: var(--poly-button-border, solid transparent 0px);
-          border-radius: var(--poly-button-border-radius, 4px);
-          font-weight: var(--poly-button-font-weight, 500);
+          border: var(--poly-button-border, solid transparent 0px) !important;
+          border-radius: var(--poly-button-border-radius, 4px) !important;
+          font-weight: var(--poly-button-font-weight, 500) !important;
         }
 
         .btn.dark ::slotted(button) {
           background-color: var(
             --poly-button-background-dark,
             var(--poly-background-dark)
-          );
-          color: var(--poly-button-text-light, var(--poly-color-text-light));
+          ) !important;
+          color: var(
+            --poly-button-text-light,
+            var(--poly-color-text-light)
+          ) !important;
         }
 
         .btn.dark.disabled ::slotted(button) {
           background-color: var(
             --poly-button-background-dark-disabled,
             rgba(0, 0, 0, 0.4)
-          );
+          ) !important;
         }
 
         .btn.light ::slotted(button) {
           background-color: var(
             --poly-button-background-light,
             var(--poly-background-light)
-          );
-          color: var(--poly-button-text-dark, var(--poly-color-text-dark));
+          ) !important;
+          color: var(
+            --poly-button-text-dark,
+            var(--poly-color-text-dark)
+          ) !important;
         }
 
         .btn.light.disabled ::slotted(button) {
           border: var(
             --poly-button-border-light-disabled,
             solid 1px rgba(0, 0, 0, 0.4)
-          );
-          color: var(--poly-button-text-dark-disabled, rgba(0, 0, 0, 0.4));
+          ) !important;
+          color: var(
+            --poly-button-text-dark-disabled,
+            rgba(0, 0, 0, 0.4)
+          ) !important;
         }
 
         .btn.big ::slotted(button) {
-          width: var(--poly-button-big-width, 328px);
-          height: var(--poly-button-big-height, 56px);
+          width: var(--poly-button-big-width, 328px) !important;
+          height: var(--poly-button-big-height, 56px) !important;
           font-size: var(
             --poly-button-big-font-size,
             var(--poly-button-font-size)
-          );
+          ) !important;
         }
 
         .btn.medium ::slotted(button) {
-          width: var(--poly-button-medium-width, 296px);
-          height: var(--poly-button-medium-height, 48px);
+          width: var(--poly-button-medium-width, 296px) !important;
+          height: var(--poly-button-medium-height, 48px) !important;
           font-size: var(
             --poly-button-medium-font-size,
             var(--poly-button-font-size)
-          );
+          ) !important;
         }
 
         .btn.small ::slotted(button) {
-          width: var(--poly-button-small-width, 90px);
-          height: var(--poly-button-small-width, 32px);
+          width: var(--poly-button-small-width, 90px) !important;
+          height: var(--poly-button-small-width, 32px) !important;
           font-size: var(
             --poly-button-small-font-size,
             var(--poly-button-small-font-size)
-          );
+          ) !important;
         }
 
         .btn.round ::slotted(button) {
-          width: var(--poly-button-round-width, 174px);
-          height: var(--poly-button-round-height, 32px);
-          border-radius: var(--poly-button-round-border-radious, 16px);
+          width: var(--poly-button-round-width, 174px) !important;
+          height: var(--poly-button-round-height, 32px) !important;
+          border-radius: var(
+            --poly-button-round-border-radious,
+            16px
+          ) !important;
           font-size: var(
             --poly-button-small-font-size,
             var(--poly-button-small-font-size)
-          );
+          ) !important;
         }
       `,
     ];

--- a/features/lexicon/package-lock.json
+++ b/features/lexicon/package-lock.json
@@ -10,10 +10,10 @@
       "dependencies": {
         "@polypoly-eu/silly-i18n": "file:../../core/utils/silly-i18n",
         "js-levenshtein": "^1.1.6",
+        "poly-look": "file:../../core/utils/poly-look",
         "sirv-cli": "^1.0.0"
       },
       "devDependencies": {
-        "@polypoly-eu/eslint-config": "file:../../eslint-config",
         "@polypoly-eu/podjs": "file:../../podjs",
         "@prismicio/client": "^4.0.0",
         "@rollup/plugin-commonjs": "^17.0.0",
@@ -41,17 +41,39 @@
         "svelte": "^3.0.0"
       }
     },
+    "../../core/utils/poly-look": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
+      },
+      "devDependencies": {
+        "@open-wc/testing": "^2.5.33",
+        "@web/dev-server": "^0.1.17",
+        "@web/dev-server-storybook": "^0.3.5",
+        "@web/test-runner": "^0.12.20",
+        "babel-eslint": "^10.1.0",
+        "eslint": "^7.26.0",
+        "eslint-config-prettier": "^7.2.0",
+        "prettier": "^2.2.1",
+        "rollup": "^2.48.0",
+        "rollup-plugin-filesize": "^9.1.1",
+        "rollup-plugin-node-resolve": "^5.2.0",
+        "rollup-plugin-terser": "^7.0.2"
+      }
+    },
     "../../core/utils/silly-i18n": {
       "name": "@polypoly-eu/silly-i18n",
       "devDependencies": {
         "@babel/core": "^7.14.3",
         "@babel/preset-env": "^7.14.2",
-        "@polypoly-eu/eslint-config": "file:../../../eslint-config",
         "@typescript-eslint/eslint-plugin": "^4.1.0",
         "babel-jest": "^26.6.3",
         "eslint": "^7.19.0",
-        "eslint-config-prettier": "^6.11.0",
-        "eslint-plugin-prettier": "^3.1.4",
+        "eslint-config-prettier": "^6.15.0",
+        "eslint-plugin-prettier": "^3.4.0",
+        "eslint-plugin-react": "^7.24.0",
         "jest": "^26.6.3",
         "prettier": "^2.2.1"
       }
@@ -59,7 +81,7 @@
     "../../eslint-config": {
       "name": "@polypoly-eu/eslint-config",
       "version": "0.0.4",
-      "dev": true,
+      "extraneous": true,
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^4.14.2",
         "@typescript-eslint/parser": "^4.14.2",
@@ -94,7 +116,6 @@
         "memfs": "^3.2.0"
       },
       "devDependencies": {
-        "@polypoly-eu/eslint-config": "file:../eslint-config",
         "@polypoly-eu/rdf-spec": "file:../core/api/rdf-spec",
         "@rollup/plugin-commonjs": "^17.0.0",
         "@rollup/plugin-node-resolve": "^11.1.0",
@@ -225,10 +246,6 @@
       "version": "1.0.0-next.12",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.12.tgz",
       "integrity": "sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ=="
-    },
-    "node_modules/@polypoly-eu/eslint-config": {
-      "resolved": "../../eslint-config",
-      "link": true
     },
     "node_modules/@polypoly-eu/podjs": {
       "resolved": "../../podjs",
@@ -2767,6 +2784,10 @@
         "node": ">=4"
       }
     },
+    "node_modules/poly-look": {
+      "resolved": "../../core/utils/poly-look",
+      "link": true
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3942,23 +3963,9 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.12.tgz",
       "integrity": "sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ=="
     },
-    "@polypoly-eu/eslint-config": {
-      "version": "file:../../eslint-config",
-      "requires": {
-        "@typescript-eslint/eslint-plugin": "^4.14.2",
-        "@typescript-eslint/parser": "^4.14.2",
-        "eslint": "^7.18.0",
-        "eslint-config-prettier": "^6.11.0",
-        "eslint-plugin-prettier": "^3.1.4",
-        "prettier": "^2.2.1",
-        "prettier-eslint": "^12.0.0",
-        "typescript": "^4.1.3"
-      }
-    },
     "@polypoly-eu/podjs": {
       "version": "file:../../podjs",
       "requires": {
-        "@polypoly-eu/eslint-config": "file:../eslint-config",
         "@polypoly-eu/fetch-spec": "file:../core/api/fetch-spec",
         "@polypoly-eu/pod-api": "file:../core/api/pod-api",
         "@polypoly-eu/rdf": "file:../core/api/rdf",
@@ -3991,12 +3998,12 @@
       "requires": {
         "@babel/core": "^7.14.3",
         "@babel/preset-env": "^7.14.2",
-        "@polypoly-eu/eslint-config": "file:../../../eslint-config",
         "@typescript-eslint/eslint-plugin": "^4.1.0",
         "babel-jest": "^26.6.3",
         "eslint": "^7.19.0",
-        "eslint-config-prettier": "^6.11.0",
-        "eslint-plugin-prettier": "^3.1.4",
+        "eslint-config-prettier": "^6.15.0",
+        "eslint-plugin-prettier": "^3.4.0",
+        "eslint-plugin-react": "^7.24.0",
         "jest": "^26.6.3",
         "prettier": "^2.2.1"
       }
@@ -5892,6 +5899,25 @@
       "dev": true,
       "requires": {
         "find-up": "^2.1.0"
+      }
+    },
+    "poly-look": {
+      "version": "file:../../core/utils/poly-look",
+      "requires": {
+        "@open-wc/testing": "^2.5.33",
+        "@web/dev-server": "^0.1.17",
+        "@web/dev-server-storybook": "^0.3.5",
+        "@web/test-runner": "^0.12.20",
+        "babel-eslint": "^10.1.0",
+        "eslint": "^7.26.0",
+        "eslint-config-prettier": "^7.2.0",
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1",
+        "prettier": "^2.2.1",
+        "rollup": "^2.48.0",
+        "rollup-plugin-filesize": "^9.1.1",
+        "rollup-plugin-node-resolve": "^5.2.0",
+        "rollup-plugin-terser": "^7.0.2"
       }
     },
     "prelude-ls": {

--- a/features/lexicon/package.json
+++ b/features/lexicon/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@polypoly-eu/silly-i18n": "file:../../core/utils/silly-i18n",
     "js-levenshtein": "^1.1.6",
+    "poly-look": "file:../../core/utils/poly-look",
     "sirv-cli": "^1.0.0"
   }
 }

--- a/features/lexicon/src/Lexicon.svelte
+++ b/features/lexicon/src/Lexicon.svelte
@@ -189,16 +189,6 @@ button {
     left: 0;
 }
 
-.term-description .back {
-    width: 100%;
-    height: 51px;
-    background-color: #0f1938;
-    color: #f7fafc;
-    box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.06), 0px 1px 3px rgba(0, 0, 0, 0.1);
-    border-radius: 4px;
-    font-size: 16px;
-}
-
 .clr {
     opacity: 0;
 }
@@ -223,6 +213,7 @@ button {
 
 <script>
 import i18n from "./i18n.js";
+import { polyButton } from "poly-look/src/constants";
 
 export let lexicon;
 let showTerm = null;
@@ -307,8 +298,9 @@ function setUpListNavigation() {
                 </div>
             </div>
             <div class="button-area">
-                <button class="back" on:click="{() => handleBack()}"
-                    >{i18n.t("common:back")}</button>
+                <poly-button type="{polyButton.types.DARK_BUTTON}" size="{polyButton.sizes.MEDIUM_BUTTON}">
+                    <button on:click="{() => handleBack()}">{i18n.t("common:back")}</button>
+                </poly-button>
             </div>
         </div>
     {:else}

--- a/features/lexicon/src/main.js
+++ b/features/lexicon/src/main.js
@@ -1,3 +1,5 @@
+import "poly-look";
+
 import LexiconView from "./Lexicon.svelte";
 import lexiconData from "./data/lexicon.json";
 import Lexicon from "./Lexicon.js";


### PR DESCRIPTION
Let's start using poly-button in the rest of the features. The first chosen is lexicon. I had to add `!important` to the poly-button CSS rules because the `::slotted` rules have the lower priority possible and the lexicon had general rules for background and color which I can not overwrite from the library. But I think this is not a big deal because the CSS rules of poly-look can be changed from the app just giving the desired style to the poly-button's CSS variables