### PR TITLE
Update eliminating references to no-longer-existing directory

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -8,9 +8,4 @@ This is the platform independent, shared code of the polyPod.
   APIs between polyPod and features.
 - [communication](communication) - Communication layer between polyPod and
   features.
-- [utils](utils) - Utility packages we felt the need to write. Nothing in there
-  is actually core logic, ideally we get rid of all of our own utilities in
-  favour of solid third party code.
-- [legacy](legacy) - Code we aim to remove, but keep working on for now, either
-  because it is still being used, or because we still want to retain parts of
-  it.
+- [utils](utils) - Utility packages we felt the need to write.


### PR DESCRIPTION
Looked up other references to "legacy", there seems to be none.