### PR TITLE
Fix app-breaking type bug

### DIFF
--- a/features/polyExplorer/src/model/entity.js
+++ b/features/polyExplorer/src/model/entity.js
@@ -35,6 +35,11 @@ export class Entity {
         });
     }
 
+    //Overwritten in Company, yet all entities need this for the matcher-comparison in the apply-function
+    industryCategoryName() {
+        return null;
+    }
+
     get i18n() {
         return this._i18n;
     }


### PR DESCRIPTION
I added a fallback function for all entities since otherwise the app will break as this function does not exists for products right now. When the filters try to compare (and filter the entities) it breaks right now.

Suggestions welcome ...