### PR TITLE
Fix Android pod initialisation race condition

### DIFF
--- a/android/app/src/main/assets/container/container.js
+++ b/android/app/src/main/assets/container/container.js
@@ -6,6 +6,11 @@
 const { port1, port2 } = new MessageChannel();
 let outerPort;
 
+/*
+For reasons we don't fully understand yet, we've seen the situation where the
+feature is sending messages before the pod is actually fully initialised. As
+a workaround, we queue messages received before initialisation.
+*/
 const queuedMessages = [];
 
 function initMessaging() {


### PR DESCRIPTION
It appears that on Android, in some situations (at least the Pixel 2
emulator running Android 30), it can happen that the RemoteClientPod is
already initialised and starts to send messages through the browser
contexts, but the other side (i.e. in Android) is not ready to receive
messages yet.

Not a particularly beautiful fix, but it's better than having to add
random initialisation sleep calls in features.