### PR TITLE
Fix path to dummy-server package

### DIFF
--- a/android/java-fetch/package-lock.json
+++ b/android/java-fetch/package-lock.json
@@ -17,7 +17,7 @@
       "version": "0.0.1",
       "dev": true,
       "devDependencies": {
-        "@polypoly-eu/dummy-server": "file:../dummy-server",
+        "@polypoly-eu/dummy-server": "file:../../core/utils/dummy-server",
         "@polypoly-eu/eslint-config": "file:../../eslint-config",
         "@rollup/plugin-sucrase": "^3.1.0",
         "@types/chai": "^4.2.14",


### PR DESCRIPTION
Dependabot throws errors due to relative path of a dependency not resolving.