### PR TITLE
Eliminates unused dep

### DIFF
--- a/features/facebookImport/package-lock.json
+++ b/features/facebookImport/package-lock.json
@@ -16,7 +16,6 @@
         "@babel/preset-env": "^7.14.8",
         "@polypoly-eu/pod-api": "file:../../core/api/pod-api",
         "@polypoly-eu/podjs": "file:../../podjs",
-        "@rdfjs/dataset": "^1.1.1",
         "@rollup/plugin-commonjs": "^20.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "11.2.0",
@@ -89,10 +88,10 @@
       },
       "devDependencies": {
         "@open-wc/testing": "^2.5.33",
-        "@web/dev-server": "^0.1.17",
+        "@web/dev-server": "^0.1.22",
         "@web/dev-server-rollup": "^0.3.5",
         "@web/dev-server-storybook": "^0.0.2",
-        "@web/test-runner": "^0.12.20",
+        "@web/test-runner": "^0.13.16",
         "eslint": "^7.26.0",
         "eslint-config-prettier": "^7.2.0",
         "prettier": "^2.2.1",
@@ -2200,39 +2199,6 @@
       "resolved": "../../core/utils/silly-i18n",
       "link": true
     },
-    "node_modules/@rdfjs/data-model": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.3.tgz",
-      "integrity": "sha512-oo9U3nEowTxxML7CZybujL3e/bty4aXHDSWanWXQxfnJQYKU6p5SCgkjeRbuVfQ9lAVfdvz68Qq5D4LtGWuKug==",
-      "dev": true,
-      "dependencies": {
-        "@types/rdf-js": "*"
-      },
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "node_modules/@rdfjs/dataset": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
-      "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/data-model": "^1.2.0"
-      },
-      "bin": {
-        "rdfjs-dataset-test": "bin/test.js"
-      }
-    },
-    "node_modules/@rdfjs/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-YxVkH0XrCNG3MWeZxfg596GFe+oorTVusmNxRP6ZHTsGczZ8AGvG3UchRNkg3Fy4MyysI7vBAA5YZbESL+VmHQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz",
@@ -2481,16 +2447,6 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
       "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
       "dev": true
-    },
-    "node_modules/@types/rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-soR/+RMogGiDU1lrpuQl5ZL55/L1eq/JlR2dWx052Uh/RYs9okh3XZHFlIJXHZqjqyjEn4WdbOMfBj7vvc2WVQ==",
-      "deprecated": "This is a stub types definition. rdf-js provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "rdf-js": "*"
-      }
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -6794,15 +6750,6 @@
         }
       ]
     },
-    "node_modules/rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
-      "dev": true,
-      "dependencies": {
-        "@rdfjs/types": "*"
-      }
-    },
     "node_modules/react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -9626,33 +9573,6 @@
         "jsdoc": "^3.6.7"
       }
     },
-    "@rdfjs/data-model": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.3.tgz",
-      "integrity": "sha512-oo9U3nEowTxxML7CZybujL3e/bty4aXHDSWanWXQxfnJQYKU6p5SCgkjeRbuVfQ9lAVfdvz68Qq5D4LtGWuKug==",
-      "dev": true,
-      "requires": {
-        "@types/rdf-js": "*"
-      }
-    },
-    "@rdfjs/dataset": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
-      "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
-      "dev": true,
-      "requires": {
-        "@rdfjs/data-model": "^1.2.0"
-      }
-    },
-    "@rdfjs/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-YxVkH0XrCNG3MWeZxfg596GFe+oorTVusmNxRP6ZHTsGczZ8AGvG3UchRNkg3Fy4MyysI7vBAA5YZbESL+VmHQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@rollup/plugin-commonjs": {
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz",
@@ -9870,15 +9790,6 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
       "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
       "dev": true
-    },
-    "@types/rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-soR/+RMogGiDU1lrpuQl5ZL55/L1eq/JlR2dWx052Uh/RYs9okh3XZHFlIJXHZqjqyjEn4WdbOMfBj7vvc2WVQ==",
-      "dev": true,
-      "requires": {
-        "rdf-js": "*"
-      }
     },
     "@types/resolve": {
       "version": "1.17.1",
@@ -13044,10 +12955,10 @@
       "version": "file:../../core/utils/poly-look",
       "requires": {
         "@open-wc/testing": "^2.5.33",
-        "@web/dev-server": "^0.1.17",
+        "@web/dev-server": "^0.1.22",
         "@web/dev-server-rollup": "^0.3.5",
         "@web/dev-server-storybook": "^0.0.2",
-        "@web/test-runner": "^0.12.20",
+        "@web/test-runner": "^0.13.16",
         "eslint": "^7.26.0",
         "eslint-config-prettier": "^7.2.0",
         "lit-element": "^2.5.1",
@@ -13158,15 +13069,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
-    },
-    "rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*"
-      }
     },
     "react": {
       "version": "17.0.2",

--- a/features/facebookImport/package.json
+++ b/features/facebookImport/package.json
@@ -13,7 +13,6 @@
     "@babel/preset-env": "^7.14.8",
     "@polypoly-eu/pod-api": "file:../../core/api/pod-api",
     "@polypoly-eu/podjs": "file:../../podjs",
-    "@rdfjs/dataset": "^1.1.1",
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "11.2.0",


### PR DESCRIPTION
Which, besides, was issuing a warning:

```
deprecated
 @types/rdf-js@4.0.2: This is a stub types definition. rdf-js provides its own
 type definitions, so you do not need this installed.
```