### PR TITLE
PROD4POD-787 - Add error handling for importing/reading

### DIFF
--- a/features/facebookImport/src/components/errorPopup/errorPopup.css
+++ b/features/facebookImport/src/components/errorPopup/errorPopup.css
@@ -1,0 +1,20 @@
+.error-popup {
+    display: block;
+    position: absolute;
+    top: 16px;
+    left: 0;
+    right: 0;
+    padding: 8px;
+    background: red;
+}
+
+.error-popup pre {
+    border: 1px solid white;
+    padding: 8px;
+    overflow: scroll;
+    font-family: monospace;
+}
+
+.error-popup button {
+    background: black;
+}

--- a/features/facebookImport/src/components/errorPopup/errorPopup.jsx
+++ b/features/facebookImport/src/components/errorPopup/errorPopup.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+import "./errorPopup.css";
+
+export default function ErrorPopup({ error, onClose }) {
+    return (
+        <div className="error-popup">
+            <h1>An error occurred!</h1>
+            <p>
+                If you want to help us, please report it to
+                feedback@polypoly.coop. While it is helpful for us if you
+                include the concrete error message below, please ensure that it
+                does not contain any of your personal data before sharing it
+                with anyone. When in doubt, just save it, e.g. in a screenshot,
+                and reach out to us without including it first.
+            </p>
+            <pre>{`${error.name}: ${error.message}\n\nCause:\n${error.cause}`}</pre>
+            <button onClick={onClose}>Close</button>
+        </div>
+    );
+}

--- a/features/facebookImport/src/context/importer-context.jsx
+++ b/features/facebookImport/src/context/importer-context.jsx
@@ -28,6 +28,22 @@ const fakeStorage = {
     removeFile: async () => {},
 };
 
+class FileImportError extends Error {
+    constructor(cause) {
+        super("Failed to import file");
+        this.name = "FileImportError";
+        this.cause = cause;
+    }
+}
+
+class RefreshFilesError extends Error {
+    constructor(cause) {
+        super("Failed to refresh files");
+        this.name = "RefreshFilesError";
+        this.cause = cause;
+    }
+}
+
 function updatePodNavigation(pod, history, handleBack, location) {
     pod.polyNav.actions = {
         back: () => handleBack(),
@@ -78,6 +94,7 @@ export const ImporterProvider = ({ children }) => {
     const [facebookAccount, setFacebookAccount] = useState(null);
     const [fileAnalysis, setFileAnalysis] = useState(null);
     const [activeDetails, setActiveDetails] = useState(null);
+    const [globalError, setGlobalError] = useState(null);
 
     const [navigationState, setNavigationState] = useState({
         importStatus: importSteps.loading,
@@ -103,7 +120,11 @@ export const ImporterProvider = ({ children }) => {
 
     const handleImportFile = async () => {
         const { polyNav } = pod;
-        await polyNav.importFile();
+        try {
+            await polyNav.importFile();
+        } catch (error) {
+            setGlobalError(new FileImportError(error));
+        }
         refreshFiles();
     };
 
@@ -130,13 +151,16 @@ export const ImporterProvider = ({ children }) => {
     }
 
     function refreshFiles() {
-        storage.refreshFiles().then(async () => {
-            const resolvedFiles = [];
-            for (const file of storage.files) {
-                resolvedFiles.push(await file);
-            }
-            setFiles(resolvedFiles);
-        });
+        storage
+            .refreshFiles()
+            .then(async () => {
+                const resolvedFiles = [];
+                for (const file of storage.files) {
+                    resolvedFiles.push(await file);
+                }
+                setFiles(resolvedFiles);
+            })
+            .catch((error) => setGlobalError(new RefreshFilesError(error)));
     }
 
     function updateImportStatus(newStatus) {
@@ -208,6 +232,8 @@ export const ImporterProvider = ({ children }) => {
                 refreshFiles,
                 activeDetails,
                 setActiveDetails,
+                globalError,
+                setGlobalError,
             }}
         >
             {children}

--- a/features/facebookImport/src/facebookImporter.jsx
+++ b/features/facebookImport/src/facebookImporter.jsx
@@ -19,6 +19,7 @@ import "./components/import-view.js";
 import "./components/report-view.js";
 import "./components/overview-view.js";
 
+import ErrorPopup from "./components/errorPopup/errorPopup.jsx";
 import Overview from "./views/overview/overview.jsx";
 import ImportView from "./views/import/import.jsx";
 import ExploreView from "./views/explore/explore.jsx";
@@ -28,7 +29,8 @@ import ExploreDetails from "./views/explore/details.jsx";
 import "./styles.css";
 
 const FacebookImporter = () => {
-    const { pod, navigationState, importSteps } = useContext(ImporterContext);
+    const { pod, navigationState, importSteps, globalError, setGlobalError } =
+        useContext(ImporterContext);
     const importStatus = navigationState.importStatus;
 
     const renderSplash = () => {
@@ -67,6 +69,12 @@ const FacebookImporter = () => {
                 </Switch>
             ) : (
                 renderSplash()
+            )}
+            {globalError && (
+                <ErrorPopup
+                    error={globalError}
+                    onClose={() => setGlobalError(null)}
+                />
             )}
         </div>
     );

--- a/features/facebookImport/src/model/storage.js
+++ b/features/facebookImport/src/model/storage.js
@@ -58,17 +58,12 @@ export class ZipFile {
         return polyOut.readdir(this._file.id);
     }
 
-    data() {
-        return new Promise((resolve) => {
-            const { polyOut } = this._pod;
-            polyOut.readFile(this._file.id).then((entries) => resolve(entries));
-        });
+    async data() {
+        return this.getContent(this._file.id);
     }
 
-    getContent(entry) {
-        return new Promise((resolve) => {
-            const { polyOut } = this._pod;
-            polyOut.readFile(entry).then((content) => resolve(content));
-        });
+    async getContent(entry) {
+        const { polyOut } = this._pod;
+        return polyOut.readFile(entry);
     }
 }

--- a/features/facebookImport/src/model/storage.js
+++ b/features/facebookImport/src/model/storage.js
@@ -10,20 +10,13 @@ export default class Storage {
     }
 
     async refreshFiles() {
-        return new Promise((resolve) => {
-            const { polyOut } = this._pod;
-            this._files = [];
-            polyOut.readdir("").then((files) => {
-                for (const file of files) {
-                    try {
-                        this._files[file] = polyOut.stat(file);
-                    } catch (e) {
-                        console.log(e);
-                    }
-                }
-                resolve(files);
-            });
-        });
+        const { polyOut } = this._pod;
+        this._files = [];
+        const files = await polyOut.readdir("");
+        for (let file of files) {
+            this._files[file] = await polyOut.stat(file);
+        }
+        return files;
     }
 
     async readFile(path) {
@@ -60,11 +53,9 @@ export class ZipFile {
         this._file = file;
     }
 
-    getEntries() {
-        return new Promise((resolve) => {
-            const { polyOut } = this._pod;
-            polyOut.readdir(this._file.id).then((entries) => resolve(entries));
-        });
+    async getEntries() {
+        const { polyOut } = this._pod;
+        return polyOut.readdir(this._file.id);
     }
 
     data() {


### PR DESCRIPTION
I left the actual importers and analyses alone, since their error
handling feeds directly into the report. Since we don't have named error
types coming from the backend, we'd still have to include the message in
those to really be able to debug problems, however.

The global error popup is a bit ugly at this point, but I guess it's a
start.