### PR TITLE
PROD4POD-779 - Adjust report flow

### DIFF
--- a/features/facebookImport/src/facebookImporter.jsx
+++ b/features/facebookImport/src/facebookImporter.jsx
@@ -25,6 +25,7 @@ import ImportView from "./views/import/import.jsx";
 import ExploreView from "./views/explore/explore.jsx";
 import ReportView from "./views/report/report.jsx";
 import ExploreDetails from "./views/explore/details.jsx";
+import ReportDetails from "./views/report/details.jsx";
 
 import "./styles.css";
 
@@ -65,6 +66,9 @@ const FacebookImporter = () => {
                     </Route>
                     <Route exact path="/report">
                         <ReportView />
+                    </Route>
+                    <Route exact path="/report/details">
+                        <ReportDetails />
                     </Route>
                 </Switch>
             ) : (

--- a/features/facebookImport/src/i18n.js
+++ b/features/facebookImport/src/i18n.js
@@ -5,12 +5,14 @@ import importEn from "./locales/en/import.json";
 import overviewEn from "./locales/en/overview.json";
 import messagesMinistoryEn from "./locales/en/ministories/messages.json";
 import exploreEn from "./locales/en/explore.json";
+import reportEn from "./locales/en/report.json";
 
 import commonDe from "./locales/de/common.json";
 import importDe from "./locales/de/import.json";
 import overviewDe from "./locales/de/overview.json";
 import messagesMinistoryDe from "./locales/de/ministories/messages.json";
 import exploreDe from "./locales/de/explore.json";
+import reportDe from "./locales/de/report.json";
 
 export default new I18n(determineLanguage(), {
     en: {
@@ -19,6 +21,7 @@ export default new I18n(determineLanguage(), {
         overview: overviewEn,
         messagesMinistory: messagesMinistoryEn,
         explore: exploreEn,
+        report: reportEn,
     },
     de: {
         common: commonDe,
@@ -26,5 +29,6 @@ export default new I18n(determineLanguage(), {
         overview: overviewDe,
         messagesMinistory: messagesMinistoryDe,
         explore: exploreDe,
+        report: reportDe,
     },
 });

--- a/features/facebookImport/src/locales/de/report.json
+++ b/features/facebookImport/src/locales/de/report.json
@@ -1,0 +1,20 @@
+{
+    "intro.headline":
+        "We found something unusual in your data!",
+    "intro.text":
+        "Your data scheme contains data types that even us do not know yet existed. To shed more and more light on what Facebook knows about all of us, it would be awesome if you could share this discovery with us. Of course, you only send the data schema, not the data itself.",
+    "explanation.headline":
+        "What does unrecognized and missing data mean?",
+    "explanation.text":
+        "Whenever Facebook captures a new type of data or restructures data, a new data schema is created. There exist a lot of them and yours is one we haven't explored yet. It would be awesome if you share your data schema with us. By doing so, you help to make transparent what Facebook knows about all of us. Of course, you only send the data schema, not the data itself.",
+    "explanation.viewDetails":
+        "View data report details",
+    "explanation.sendLater":
+        "Send later",
+    "explanation.send":
+        "Send",
+    "success":
+        "Report sent successfully",
+    "error":
+        "Error while sending report."
+}

--- a/features/facebookImport/src/locales/en/report.json
+++ b/features/facebookImport/src/locales/en/report.json
@@ -1,0 +1,20 @@
+{
+    "intro.headline":
+        "We found something unusual in your data!",
+    "intro.text":
+        "Your data scheme contains data types that even us do not know yet existed. To shed more and more light on what Facebook knows about all of us, it would be awesome if you could share this discovery with us. Of course, you only send the data schema, not the data itself.",
+    "explanation.headline":
+        "What does unrecognized and missing data mean?",
+    "explanation.text":
+        "Whenever Facebook captures a new type of data or restructures data, a new data schema is created. There exist a lot of them and yours is one we haven't explored yet. It would be awesome if you share your data schema with us. By doing so, you help to make transparent what Facebook knows about all of us. Of course, you only send the data schema, not the data itself.",
+    "explanation.viewDetails":
+        "View data report details",
+    "explanation.sendLater":
+        "Send later",
+    "explanation.send":
+        "Send",
+    "success":
+        "Report sent successfully",
+    "error":
+        "Error while sending report."
+}

--- a/features/facebookImport/src/views/report/details.jsx
+++ b/features/facebookImport/src/views/report/details.jsx
@@ -1,0 +1,38 @@
+import React, { useContext } from "react";
+import { ImporterContext } from "../../context/importer-context.jsx";
+
+import "./report.css";
+
+export const ReportCard = ({ analysis }) => {
+    return (
+        <>
+            <div className="report-card">
+                <h1>{analysis.title}</h1>
+                <div className="list">{analysis.render()}</div>
+            </div>
+            <div className="report-card-scrolling"></div>
+        </>
+    );
+};
+
+const ReportDetails = () => {
+    const { fileAnalysis } = useContext(ImporterContext);
+    const unrecognizedData = fileAnalysis.unrecognizedData;
+
+    function renderReportAnalyses() {
+        if (!unrecognizedData) {
+            return "";
+        }
+        return (
+            <div>
+                {unrecognizedData.reportAnalyses.map((analysis, index) => (
+                    <ReportCard analysis={analysis} key={index} />
+                ))}
+            </div>
+        );
+    }
+
+    return <div className="report-details">{renderReportAnalyses()}</div>;
+};
+
+export default ReportDetails;

--- a/features/facebookImport/src/views/report/report.css
+++ b/features/facebookImport/src/views/report/report.css
@@ -1,4 +1,4 @@
-.report-view {
+.report-view, .report-details {
     color: var(--color-gray-50);
     line-height: var(--line-height);
     letter-spacing: -0.01em;
@@ -11,11 +11,12 @@
     overflow: hidden scroll;
 }
 
-.report-view .report-view-title {
+.report-view .report-view-title, .report-details h1 {
     text-align: center;
     font-weight: 500;
     margin: 8px 0 20px 0;
     font-size: 24px;
+    line-height: 120%;
 }
 
 .report-view .button-area::before {
@@ -67,15 +68,36 @@
       color: var(--color-red-300);
 }
 
+.report-view .view-details,
+.report-view .send-later,
 .report-view .send {
-    width: 100%;
-    height: 51px;
-    background-color: var(--color-red-300);
-    color: var(--text-dark);
-    box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.06), 0px 1px 3px rgba(0, 0, 0, 0.1);
-    border-radius: 4px;
     font-size: 16px;
     margin-top: 12px;
+}
+
+.report-view .view-details {
+    color: var(--color-red-300);
+    text-decoration: underline;
+}
+
+.report-view .send-later, .report-view .send {
+    width: 100%;
+    height: 51px;
+    box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.06), 0px 1px 3px rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+}
+
+.report-view .send-later {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--color-red-300) !important;
+    color: var(--color-red-300) !important;
+}
+
+.report-view .send {
+    background-color: var(--color-red-300);
+    color: var(--text-dark);
 }
 
 .report-view .report-card:first-child {

--- a/features/facebookImport/src/views/report/report.jsx
+++ b/features/facebookImport/src/views/report/report.jsx
@@ -1,19 +1,10 @@
 import React, { useContext, useEffect, useState } from "react";
+import RouteButton from "../../components/buttons/routeButton.jsx";
 import { ImporterContext } from "../../context/importer-context.jsx";
 
-import "./report.css";
+import i18n from "../../i18n.js";
 
-const ReportCard = ({ analysis }) => {
-    return (
-        <>
-            <div className="report-card">
-                <h1>{analysis.title}</h1>
-                <div className="list">{analysis.render()}</div>
-            </div>
-            <div className="report-card-scrolling"></div>
-        </>
-    );
-};
+import "./report.css";
 
 const PopUpMessage = ({ children, handleClosePopUp }) => {
     return (
@@ -55,36 +46,35 @@ const ReportView = () => {
         setReportSent(true);
     };
 
-    function renderReportAnalyses() {
-        if (!unrecognizedData) {
-            return "";
-        }
-        return (
-            <div>
-                {unrecognizedData.reportAnalyses.map((analysis, index) => (
-                    <ReportCard analysis={analysis} key={index} />
-                ))}
-            </div>
-        );
-    }
-
     useEffect(() => {
         if (reportSent || error) setLoading(false);
     }, [reportSent, error]);
 
     return (
         <div className="report-view">
-            <h1 className="report-view-title">Unrecognized data report</h1>
-            {renderReportAnalyses()}
+            <h1 className="report-view-title">
+                {i18n.t("report:intro.headline")}
+            </h1>
+            <p>{i18n.t("report:intro.text")}</p>
+            <h1 className="report-view-title">
+                {i18n.t("report:explanation.headline")}
+            </h1>
+            <p>{i18n.t("report:explanation.text")}</p>
             <div className="button-area">
+                <RouteButton className="view-details" route="/report/details">
+                    {i18n.t("report:explanation.viewDetails")}
+                </RouteButton>
+                <RouteButton className="send-later" route="/explore">
+                    {i18n.t("report:explanation.sendLater")}
+                </RouteButton>
                 {isOpen && (
                     <PopUpMessage handleClosePopUp={handleClosePopUp}>
                         {reportSent ? (
-                            "Report sent successfully"
+                            i18n.t("report:success")
                         ) : (
                             <div>
                                 <span className="unsuccessfully">
-                                    Error while sending report.
+                                    {i18n.t("report:error")}
                                 </span>
                                 <br />
                                 Message: {error} <br />
@@ -94,10 +84,13 @@ const ReportView = () => {
                     </PopUpMessage>
                 )}
                 {loading ? (
-                    <button className="send disabled">Send report</button>
+                    <button className="send disabled">
+                        {" "}
+                        {i18n.t("report:explanation.send")}
+                    </button>
                 ) : (
                     <button className="send" onClick={handleSendReport}>
-                        Send report
+                        {i18n.t("report:explanation.send")}
                     </button>
                 )}
             </div>


### PR DESCRIPTION
Still a bit different from the designs:

1. I combined the initial dialog and the second screen into one, to save
time for now.

2. I stuck to the old colours and didn't bother _too_ much with making
things look like in the design.

But the new content and flow is there. We will likely still have to
change those strings however, based on the record now not really being
about "unrecognized data" anymore.