### PR TITLE
PROD4POD-809 - Add loading screen to explore view

### DIFF
--- a/features/facebookImport/src/components/loading/loading.css
+++ b/features/facebookImport/src/components/loading/loading.css
@@ -1,0 +1,6 @@
+.loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 60px;
+}

--- a/features/facebookImport/src/components/loading/loading.jsx
+++ b/features/facebookImport/src/components/loading/loading.jsx
@@ -1,0 +1,16 @@
+import React, { useContext, useEffect, useRef, useState } from "react";
+
+import i18n from "../../i18n.js";
+
+import "./loading.css";
+
+const Loading = ({ message }) => (
+    <div className="loading">
+        <div>
+            <p>{message} ...</p>
+            <p>{i18n.t("common:loading.closing")}</p>
+        </div>
+    </div>
+);
+
+export default Loading;

--- a/features/facebookImport/src/components/loading/loading.jsx
+++ b/features/facebookImport/src/components/loading/loading.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React from "react";
 
 import i18n from "../../i18n.js";
 

--- a/features/facebookImport/src/context/importer-context.jsx
+++ b/features/facebookImport/src/context/importer-context.jsx
@@ -90,7 +90,7 @@ async function writeImportStatus(pod, status) {
 export const ImporterProvider = ({ children }) => {
     const [pod, setPod] = useState(null);
     const [storage, setStorage] = useState(fakeStorage);
-    const [files, setFiles] = useState([]);
+    const [files, setFiles] = useState(null);
     const [facebookAccount, setFacebookAccount] = useState(null);
     const [fileAnalysis, setFileAnalysis] = useState(null);
     const [activeDetails, setActiveDetails] = useState(null);
@@ -120,6 +120,7 @@ export const ImporterProvider = ({ children }) => {
 
     const handleImportFile = async () => {
         const { polyNav } = pod;
+        setFiles(null); // To show the loading overlay
         try {
             await polyNav.importFile();
         } catch (error) {
@@ -151,6 +152,7 @@ export const ImporterProvider = ({ children }) => {
     }
 
     function refreshFiles() {
+        setFiles(null);
         storage
             .refreshFiles()
             .then(async () => {
@@ -194,7 +196,7 @@ export const ImporterProvider = ({ children }) => {
     //when files changed run the importer first and create an account model first.
     //after there is an account the analyses are triggered.
     useEffect(() => {
-        if (files[0])
+        if (files?.[0])
             importData(files[0]).then((newFacebookAccount) =>
                 setFacebookAccount(newFacebookAccount)
             );

--- a/features/facebookImport/src/locales/de/common.json
+++ b/features/facebookImport/src/locales/de/common.json
@@ -1,5 +1,6 @@
 {
     "title": "Importer",
     "source.your.facebook.data": "Quelle: Deine Facebook Daten",
-    "months.abbreviation": "Jan Feb Mär Apr Mai Jun Jul Aug Sep Okt Nov Dez"
+    "months.abbreviation": "Jan Feb Mär Apr Mai Jun Jul Aug Sep Okt Nov Dez",
+    "loading.closing": "Danke für deine Geduld!"
 }

--- a/features/facebookImport/src/locales/de/explore.json
+++ b/features/facebookImport/src/locales/de/explore.json
@@ -1,4 +1,5 @@
 {
     "messages.title": "Nachrichten Zusammenfassung",
-    "messages.summary": "In deinem export sind {{messages}} Nachrichten in {{threads}} Threads von {{people}} Personen."
+    "messages.summary": "In deinem export sind {{messages}} Nachrichten in {{threads}} Threads von {{people}} Personen.",
+    "loading": "Deine Daten werden analysiert"
 }

--- a/features/facebookImport/src/locales/de/overview.json
+++ b/features/facebookImport/src/locales/de/overview.json
@@ -7,5 +7,6 @@
     "imported.time": "Importiert am:",
     "size": "Größe",
     "explore": "Erkunden",
-    "new.import": "Neuer Import"
+    "new.import": "Neuer Import",
+    "loading.data": "Deine Daten werden geladen"
 }

--- a/features/facebookImport/src/locales/en/common.json
+++ b/features/facebookImport/src/locales/en/common.json
@@ -1,5 +1,6 @@
 {
     "title": "Importer",
     "source.your.facebook.data": "Source: Your facebook data",
-    "months.abbreviation": "Jan Feb Mar Apr Mai Jun Jul Aug Sep Oct Nov Dec"
+    "months.abbreviation": "Jan Feb Mar Apr Mai Jun Jul Aug Sep Oct Nov Dec",
+    "loading.closing": "Thank you for your patience!"
 }

--- a/features/facebookImport/src/locales/en/explore.json
+++ b/features/facebookImport/src/locales/en/explore.json
@@ -1,4 +1,5 @@
 {
     "messages.title": "Messages Summary",
-    "messages.summary": "In your export there are {{messages}} messages in {{threads}} threads by {{people}} people."
+    "messages.summary": "In your export there are {{messages}} messages in {{threads}} threads by {{people}} people.",
+    "loading": "Your data is being analyzed"
 }

--- a/features/facebookImport/src/locales/en/overview.json
+++ b/features/facebookImport/src/locales/en/overview.json
@@ -7,5 +7,6 @@
     "imported.time": "Imported at:",
     "size": "Size",
     "explore": "Explore",
-    "new.import": "New import"
+    "new.import": "New import",
+    "loading.data": "Loading your data"
 }

--- a/features/facebookImport/src/views/explore/explore.jsx
+++ b/features/facebookImport/src/views/explore/explore.jsx
@@ -1,6 +1,9 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
 import RouteButton from "../../components/buttons/routeButton.jsx";
+import Loading from "../../components/loading/loading.jsx";
 import { ImporterContext } from "../../context/importer-context.jsx";
+
+import i18n from "../../i18n.js";
 
 import "./explore.css";
 
@@ -52,17 +55,8 @@ const ExploreView = () => {
     const exploreRef = useRef();
 
     const renderFileAnalyses = () => {
-        if (!fileAnalysis) {
-            return (
-                <div>
-                    <p>Analyzing your data ...</p>
-                    <p>
-                        If this takes more than a few seconds - or for large
-                        data sets maybe minutes - please report this as an issue
-                        - there was likely an error.
-                    </p>
-                </div>
-            );
+        if (true || !fileAnalysis) {
+            return <Loading message={i18n.t("explore:loading")} />;
         }
         return (
             <div>

--- a/features/facebookImport/src/views/explore/explore.jsx
+++ b/features/facebookImport/src/views/explore/explore.jsx
@@ -55,9 +55,8 @@ const ExploreView = () => {
     const exploreRef = useRef();
 
     const renderFileAnalyses = () => {
-        if (true || !fileAnalysis) {
+        if (!fileAnalysis)
             return <Loading message={i18n.t("explore:loading")} />;
-        }
         return (
             <div>
                 <UnrecognizedCard

--- a/features/facebookImport/src/views/import/import.css
+++ b/features/facebookImport/src/views/import/import.css
@@ -8,3 +8,14 @@
     border-radius: 12px 12px 0px 0px;
     box-sizing: border-box;
 }
+
+.import-view .overlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    pointer-events: none;
+    opacity: 0.5;
+    background: gray;
+}

--- a/features/facebookImport/src/views/import/import.jsx
+++ b/features/facebookImport/src/views/import/import.jsx
@@ -20,7 +20,7 @@ const Import = () => {
         handleImportFile,
     } = useContext(ImporterContext);
     const importStatus = navigationState.importStatus;
-    const file = files[0];
+    const file = files?.[0];
 
     const onRemoveFile = () => {
         handleRemoveFile(file.id);
@@ -42,6 +42,7 @@ const Import = () => {
                 file={file}
                 onRemoveFile={onRemoveFile}
             />
+            {files === null && <div className="overlay"></div>}
         </div>
     );
 };

--- a/features/facebookImport/src/views/overview/overview.jsx
+++ b/features/facebookImport/src/views/overview/overview.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import RouteButton from "../../components/buttons/routeButton.jsx";
+import Loading from "../../components/loading/loading.jsx";
 import { ImporterContext } from "../../context/importer-context.jsx";
 
 import i18n from "../../i18n.js";
@@ -23,6 +24,9 @@ const Overview = () => {
             <div className="separator"></div>
         </div>
     );
+
+    if (files === null)
+        return <Loading message={i18n.t("overview:loading.data")} />;
 
     return (
         <div className="overview">


### PR DESCRIPTION
Still a basic version - I'd use the same on _import_ and _overview_ if this seems like a decent approach.

**Update:** Now I've included a loading screen for the `overview` screen as well, and an overlay for `import`. That should do it for a very first version.