### PR TITLE
Allow purchases  count to be zero

### DIFF
--- a/features/facebookImport/src/model/analyses/off-facebook-events-analysis.js
+++ b/features/facebookImport/src/model/analyses/off-facebook-events-analysis.js
@@ -14,9 +14,10 @@ export default class OffFacebookEventsAnalysis extends RootAnalysis {
     async analyze({ facebookAccount }) {
         this._companiesCount = facebookAccount.offFacebookCompanies.length;
         this.active = this._companiesCount > 0;
-        this._purchasesCount = groupOffFacebookEventsByType(
-            facebookAccount
-        ).find((e) => e.type == "PURCHASE").count;
+        this._purchasesCount =
+            groupOffFacebookEventsByType(facebookAccount).find(
+                (e) => e.type == "PURCHASE"
+            )?.count || 0;
     }
 
     renderSummary() {


### PR DESCRIPTION
There could be exports where there are no "PURCHASE" events.