### PR TITLE
PROD4POD-831/Fix scroll in Report details screen

### DIFF
--- a/features/facebookImport/src/views/overview/overview.css
+++ b/features/facebookImport/src/views/overview/overview.css
@@ -73,7 +73,7 @@ h4 {
 
 .overview .footer {
     width: 100%;
-    position: fixed;
+    position: absolute;
     bottom: 0;
     left: 0;
     box-sizing: border-box;

--- a/features/facebookImport/src/views/overview/overview.css
+++ b/features/facebookImport/src/views/overview/overview.css
@@ -73,7 +73,7 @@ h4 {
 
 .overview .footer {
     width: 100%;
-    position: absolute;
+    position: fixed;
     bottom: 0;
     left: 0;
     box-sizing: border-box;

--- a/features/facebookImport/src/views/report/details.css
+++ b/features/facebookImport/src/views/report/details.css
@@ -14,7 +14,6 @@
 .report-details .report-card table {
     display: block;
     overflow-x: scroll;
-    overflow-y: hidden;
 }
 
 .report-details .report-card > h1 {

--- a/features/facebookImport/src/views/report/details.css
+++ b/features/facebookImport/src/views/report/details.css
@@ -4,31 +4,17 @@
 
 .report-details .report-card {
     max-width: var(--max-width);
-    max-height: 440px;
     margin: 0 auto 12px auto;
     padding: 12px 20px 20px 20px;
     border-radius: 8px;
     background-color: var(--background-light);
     color: var(--text-dark);
-    overflow: scroll;
 }
 
-.report-details .report-card-scrolling {
-    max-width: var(--max-width);
-    position:relative;
-    margin: auto;
-}
-
-.report-details .report-card-scrolling::after {
-    content: "";
-    width: 100%;
-    height: 30px;
-    background: linear-gradient(#ffffff00 0%, #ffffff);
-    position: absolute;
-    bottom: 12px;
-    left: 0;
-    border-radius: 8px;
-
+.report-details .report-card table {
+    display: block;
+    overflow-x: scroll;
+    overflow-y: hidden;
 }
 
 .report-details .report-card > h1 {
@@ -42,6 +28,7 @@
 }
 
 .report-details .report-card .list li {
+    word-break: break-all;
     text-align: justify;
     text-justify: distribute-all-lines;
 }

--- a/features/facebookImport/src/views/report/report.css
+++ b/features/facebookImport/src/views/report/report.css
@@ -6,7 +6,7 @@
     height: 100%;
     width: 100%;
     position: absolute;
-    padding: 24px 24px 152px 24px;
+    padding: 24px;
     border-top: 1px inset #a9b6c6;
     box-sizing: border-box;
     overflow: hidden scroll;


### PR DESCRIPTION
Following the instructions in the Jira ticket, I have removed the scroll in all the sub-sections (or "report-cards"). However, I kept the horizontal scroll only for the tables. 

Some of these sub-sections include a table. I have tried the CSS property `word-break: break-all` (as it is done in the lists of files), but the tables didn't look good in this way. In order to show all the content, I added a horizontal scroll in these tables (only the table, not the whole "report-card"). 

Please let me know if you prefer to remove all the scrolling or if it's ok in this way.