### PR TITLE
Fix Android black screen when importing

### DIFF
--- a/android/app/src/main/kotlin/coop/polypoly/polypod/polyNav/PolyNav.kt
+++ b/android/app/src/main/kotlin/coop/polypoly/polypod/polyNav/PolyNav.kt
@@ -72,7 +72,7 @@ open class PolyNav(
         coroutineScope.launch {
             contentResolver?.openInputStream(importedUrl).use { inputStream ->
                 if (inputStream == null) {
-                    throw Error("File copy error")
+                    throw Error("File import error")
                 }
                 val newId = UUID.randomUUID().toString()
                 val fs = Preferences.getFileSystem(context).toMutableMap()

--- a/android/app/src/main/kotlin/coop/polypoly/polypod/polyNav/PolyNav.kt
+++ b/android/app/src/main/kotlin/coop/polypoly/polypod/polyNav/PolyNav.kt
@@ -8,7 +8,7 @@ import android.webkit.WebMessage
 import android.webkit.WebView
 import coop.polypoly.polypod.Preferences
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.async
 import java.io.File
 import java.util.UUID
 import kotlin.collections.HashSet
@@ -69,7 +69,7 @@ open class PolyNav(
                     )
             }
         }
-        coroutineScope.launch {
+        coroutineScope.async {
             contentResolver?.openInputStream(importedUrl).use { inputStream ->
                 if (inputStream == null) {
                     throw Error("File import error")
@@ -80,7 +80,7 @@ open class PolyNav(
                 Preferences.setFileSystem(context, fs)
                 ZipTools.unzipAndEncrypt(inputStream, context, newId)
             }
-        }
+        }.await()
         return importedUrl
     }
 

--- a/features/facebookImport/src/components/importExplanationExpandable/importExplanationExpandable.jsx
+++ b/features/facebookImport/src/components/importExplanationExpandable/importExplanationExpandable.jsx
@@ -116,7 +116,6 @@ const ImportExplanationExpandable = ({
                         <div className="file-info">
                             <h5>{i18n.t("import:import.chosen")}</h5>
                             <p>ID {file.id}</p>
-                            <p>Size {file.size} Bytes</p>
                         </div>
                     ) : (
                         <h5>{i18n.t("import:import.none.chosen")}</h5>

--- a/features/facebookImport/src/components/importExplanationExpandable/importExplanationExpandable.jsx
+++ b/features/facebookImport/src/components/importExplanationExpandable/importExplanationExpandable.jsx
@@ -116,6 +116,7 @@ const ImportExplanationExpandable = ({
                         <div className="file-info">
                             <h5>{i18n.t("import:import.chosen")}</h5>
                             <p>ID {file.id}</p>
+                            <p>Size {file.size} Bytes</p>
                         </div>
                     ) : (
                         <h5>{i18n.t("import:import.none.chosen")}</h5>


### PR DESCRIPTION
This runs the import in a coroutine. But because the import function finishes before the import is actually done we do not yet know the final size of the import. So this also removes the size from the UI.