### PR TITLE
[Fix] Shell command built from env

### DIFF
--- a/features/bundle/index.js
+++ b/features/bundle/index.js
@@ -24,7 +24,7 @@ function writeOrder(features, targetDir) {
 const features = require("./package.json").polyPodFeatures;
 
 const targetDir = path.join(__dirname, "dist");
-if (fs.existsSync(targetDir)) fs.rmdirSync(targetDir, { recursive: true });
+if (fs.existsSync(targetDir)) fs.rmSync(targetDir, { recursive: true });
 fs.mkdirSync(targetDir);
 
 for (let feature of features) packageFeature(feature, targetDir);

--- a/features/bundle/index.js
+++ b/features/bundle/index.js
@@ -13,7 +13,8 @@ function packageFeature({ archiveName, moduleName, artifactPath }, targetDir) {
         moduleName,
         artifactPath
     );
-    child_process.execSync(`zip -r ${targetArchive} *`, { cwd: sourceDir });
+    const args = ["-r", targetArchive, "*"];
+    child_process.execFileSync("zip", args, { cwd: sourceDir, shell: true });
 }
 
 function writeOrder(features, targetDir) {

--- a/features/bundle/index.js
+++ b/features/bundle/index.js
@@ -13,8 +13,8 @@ function packageFeature({ archiveName, moduleName, artifactPath }, targetDir) {
         moduleName,
         artifactPath
     );
-    const args = ["-r", targetArchive, "*"];
-    child_process.execFileSync("zip", args, { cwd: sourceDir, shell: true });
+    const args = ["-r", targetArchive, "."];
+    child_process.execFileSync("zip", args, { cwd: sourceDir });
 }
 
 function writeOrder(features, targetDir) {


### PR DESCRIPTION
Mainly trying to address [this](https://github.com/polypoly-eu/polyPod/security/code-scanning/1?query=ref%3Arefs%2Fheads%2Fmain)

This mainly follows advice from [the advisory itself](https://codeql.github.com/codeql-query-help/javascript/js-shell-command-injection-from-environment/), however it does not really work, since it does not "find" any file. I'm not really sure if it's a bug, or a USB (user-side bug). So if you've got some advice here, I'd really appreciate it.

[Asked in StackOverflow](https://stackoverflow.com/questions/69358497/problems-with-using-globbing-together-with-execfilesync)