### PR TITLE
Automate App Store upload

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -15,3 +15,4 @@ xcuserdata/
 *.ipa
 *.dSYM.zip
 *.dSYM
+*.xcarchive

--- a/ios/Makefile
+++ b/ios/Makefile
@@ -1,6 +1,7 @@
 archive_path = PolyPod.xcarchive
 project_path = PolyPodApp/PolyPod.xcodeproj
 scheme_name = PolyPod
+export_options_plist = exportOptions.plist
 
 build:
 	xcodebuild clean build \
@@ -19,3 +20,10 @@ archive:
 		-project $(project_path) \
 		-scheme $(scheme_name) \
 		-archivePath $(archive_path)
+
+upload:
+	xcodebuild \
+		-exportArchive \
+		-archivePath $(archive_path) \
+		-exportOptionsPlist exportOptions.plist \
+		-allowProvisioningUpdates

--- a/ios/exportOptions.plist
+++ b/ios/exportOptions.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>method</key>
+        <string>app-store</string>
+        <key>destination</key>
+        <string>upload</string>
+    </dict>
+</plist>


### PR DESCRIPTION
One step closer to the sun! This command allows me to publish a release to the App Store from my local machine without too much hassle:

`./build.js clean && ./build.js && cd ios && make archive && make upload`

OK, there's a bit of hassle in the command itself :D But still, it's way better than all the clicking around in Xcode I currently have to do.

_Why can't we just do that via GitHub actions_ I hear you ask? Well, the problem is that we would need to get the **credentials** there. That looks like a lot of hassle to me, but also "just work". It's the final missing piece now.