### PR TITLE
Add basic analysis triggered when there are pictures present in the export

### DIFF
--- a/features/facebookImport/src/model/analyses/about-pictures-data-analysis.js
+++ b/features/facebookImport/src/model/analyses/about-pictures-data-analysis.js
@@ -39,12 +39,11 @@ export default class AboutPicturesDataAnalysis extends RootAnalysis {
      */
     async _userPicturesFromExport(zipFile) {
         const relevantEntries = await relevantZipEntries(zipFile);
-        return relevantEntries.filter((zipEntry) => {
-            const noPrefixEntry = removeEntryPrefix(zipEntry);
-            return /^photos_and_videos\/(.+)\.(png|jpg|jpeg|gif)$/.test(
-                noPrefixEntry
-            );
-        });
+        return relevantEntries.filter((zipEntry) =>
+            /^photos_and_videos\/(.+)\.(png|jpg|jpeg|gif)$/.test(
+                removeEntryPrefix(zipEntry)
+            )
+        );
     }
 
     async analyze({ zipFile }) {

--- a/features/facebookImport/src/model/analyses/about-pictures-data-analysis.js
+++ b/features/facebookImport/src/model/analyses/about-pictures-data-analysis.js
@@ -40,7 +40,7 @@ export default class AboutPicturesDataAnalysis extends RootAnalysis {
     async _userPicturesFromExport(zipFile) {
         const relevantEntries = await relevantZipEntries(zipFile);
         return relevantEntries.filter((zipEntry) =>
-            /^photos_and_videos\/(.+)\.(png|jpg|jpeg|gif)$/.test(
+            /^photos_and_videos\/(.+)\.(jpg|jpeg)$/.test(
                 removeEntryPrefix(zipEntry)
             )
         );

--- a/features/facebookImport/src/model/analyses/about-pictures-data-analysis.js
+++ b/features/facebookImport/src/model/analyses/about-pictures-data-analysis.js
@@ -1,0 +1,63 @@
+import {
+    relevantZipEntries,
+    removeEntryPrefix,
+} from "../../importer/importer-util";
+import RootAnalysis from "./root-analysis";
+
+/**
+ * Minimum number of picutures that should be present in
+ * the export in order for this analysis to be active.
+ */
+const PICTURES_THRESHOLD = 3;
+
+export default class AboutPicturesDataAnalysis extends RootAnalysis {
+    get label() {
+        return RootAnalysis.Labels.TECH_DEMO;
+    }
+
+    get title() {
+        return "About Pictures Story";
+    }
+
+    /**
+     * Determine the pictures posted by the user.
+     *
+     * At the moment, since we do not import posts and albums,
+     * we count only the number of picture files in the folder
+     * "photos_and_videos" where posted pictures are exported.
+     *
+     * Depending on the export that folder might contain also
+     * other picture files like "emptyalbum.png" which was not
+     * uploaded by a user, but most likely added by Facebook.
+     *
+     * Also some folders like "thumbnails" indicate that pictures
+     * there are created from other pictures.
+     *
+     * For now we do not try to distinguish them from pictures
+     * uploaded by a user, or do any other classification. We
+     * simply include all pictures in that folder.
+     */
+    async _userPicturesFromExport(zipFile) {
+        const relevantEntries = await relevantZipEntries(zipFile);
+        return relevantEntries.filter((zipEntry) => {
+            const noPrefixEntry = removeEntryPrefix(zipEntry);
+            return /^photos_and_videos\/(.+)\.(png|jpg|jpeg|gif)$/.test(
+                noPrefixEntry
+            );
+        });
+    }
+
+    async analyze({ zipFile }) {
+        const pictureEntries = await this._userPicturesFromExport(zipFile);
+        this._picturesCount = pictureEntries.length;
+        this.active = this._picturesCount >= PICTURES_THRESHOLD;
+    }
+
+    renderSummary() {
+        return `There  ${
+            this._picturesCount === 1
+                ? `are ${this._picturesCount} pictures`
+                : `is ${this._picturesCount} picture`
+        } in your export.`;
+    }
+}

--- a/features/facebookImport/src/model/analyses/about-pictures-data-analysis.js
+++ b/features/facebookImport/src/model/analyses/about-pictures-data-analysis.js
@@ -56,8 +56,8 @@ export default class AboutPicturesDataAnalysis extends RootAnalysis {
     renderSummary() {
         return `There  ${
             this._picturesCount === 1
-                ? `are ${this._picturesCount} pictures`
-                : `is one picture`
+                ? `is one picture`
+                : `are ${this._picturesCount} pictures`
         } in your export.`;
     }
 }

--- a/features/facebookImport/src/model/analyses/about-pictures-data-analysis.js
+++ b/features/facebookImport/src/model/analyses/about-pictures-data-analysis.js
@@ -8,7 +8,7 @@ import RootAnalysis from "./root-analysis";
  * Minimum number of picutures that should be present in
  * the export in order for this analysis to be active.
  */
-const PICTURES_THRESHOLD = 3;
+const PICTURES_THRESHOLD = 1;
 
 export default class AboutPicturesDataAnalysis extends RootAnalysis {
     get label() {

--- a/features/facebookImport/src/model/analyses/about-pictures-data-analysis.js
+++ b/features/facebookImport/src/model/analyses/about-pictures-data-analysis.js
@@ -57,7 +57,7 @@ export default class AboutPicturesDataAnalysis extends RootAnalysis {
         return `There  ${
             this._picturesCount === 1
                 ? `are ${this._picturesCount} pictures`
-                : `is ${this._picturesCount} picture`
+                : `is one picture`
         } in your export.`;
     }
 }

--- a/features/facebookImport/src/model/analysis.js
+++ b/features/facebookImport/src/model/analysis.js
@@ -37,6 +37,7 @@ import UknownTopLevelFoldersAnalysis from "./analyses-report/unknown-top-level-f
 import InactiveCardsSummary from "./analyses-report/inactive-cards-summary.js";
 import ActivitiesAnalysis from "./analyses/activities-analysis.js";
 import AdvertisingValueAnalysis from "./analyses/advertising-value-analysis.js";
+import AboutPicturesDataAnalysis from "./analyses/about-pictures-data-analysis.js";
 
 const subAnalyses = [
     DataStructureBubblesAnalysis,
@@ -65,6 +66,7 @@ const subAnalyses = [
     PagesOverviewAnalysis,
     SesssionActivityLocationsAnalysis,
     ImportedJsonFilesAnalysis,
+    AboutPicturesDataAnalysis,
 
     ReportMetadataAnalysis,
     DataImportingStatusAnalysis,


### PR DESCRIPTION
This adds analysis that is triggered when the number of pictures is greater or equal to a threshold. The current threshold is 3. For now we count all pictures in the folder `photos_and_videos` with the extension png, jpg, jpeg or gif.