### PR TITLE
Fix race condition for new imports

### DIFF
--- a/features/facebookImport/src/model/storage.js
+++ b/features/facebookImport/src/model/storage.js
@@ -36,15 +36,10 @@ export default class Storage {
     }
 
     async removeFile(file) {
-        return new Promise((resolve) => {
-            const { polyNav } = this._pod;
-            polyNav
-                .removeFile(file)
-                .then(() => {
-                    this.refreshFiles().then(() => resolve());
-                })
-                .then(() => this.changeListener());
-        });
+        const { polyNav } = this._pod;
+        await polyNav.removeFile(file);
+        await this.refreshFiles();
+        this.changeListener();
     }
 }
 

--- a/features/facebookImport/src/views/overview/overview.jsx
+++ b/features/facebookImport/src/views/overview/overview.jsx
@@ -102,7 +102,6 @@ const Overview = () => {
                     proceedButton={{
                         text: i18n.t("overview:new.import.dialog.continue"),
                         onClick: async () => {
-                            console.log(JSON.stringify(files));
                             await handleRemoveFile(files[0].id);
                             updateImportStatus(importSteps.import);
                         },

--- a/features/facebookImport/src/views/overview/overview.jsx
+++ b/features/facebookImport/src/views/overview/overview.jsx
@@ -101,9 +101,10 @@ const Overview = () => {
                     }}
                     proceedButton={{
                         text: i18n.t("overview:new.import.dialog.continue"),
-                        onClick: () => {
+                        onClick: async () => {
+                            console.log(JSON.stringify(files));
+                            await handleRemoveFile(files[0].id);
                             updateImportStatus(importSteps.import);
-                            handleRemoveFile(files[0].id);
                         },
                         route: "/import",
                         stateChange: { importStatus: importSteps.import },


### PR DESCRIPTION
Two big async issues that caused this:

1. handleRemoveFile was not awaited before leaving the overview (view)

2. Storage.removeFile resolved before triggering the change listener (I
   suspect, didn't go to any lengths to find the _exact_ problem in that
   function, but that's the main semantic difference I can see with my
   changes.)