### PR TITLE
PROD4POD-859 - Experimental changes

### DIFF
--- a/ios/PolyPodApp/FeatureContainer/FeatureContainerView.swift
+++ b/ios/PolyPodApp/FeatureContainer/FeatureContainerView.swift
@@ -46,7 +46,7 @@ class FeatureWebView: WKWebView {
     private let activeActions: Binding<[String]>
     private let openUrlHandler: (String) -> Void
     private var lastActionDispatch: DispatchTime = DispatchTime.now()
-    private let filePicker = FilePicker()
+    @State private var filePicker = State(initialValue: FilePicker())
 
     init(
         feature: Feature,
@@ -249,7 +249,7 @@ extension FeatureWebView: PolyNavDelegate {
     }
     
     func doHandleImportFile(completion: @escaping (URL?) -> Void) {
-        filePicker.pick(completion: completion)
+        filePicker.wrappedValue.pick(completion: completion)
     }
 }
 

--- a/ios/PolyPodApp/FeatureContainer/FilePicker.swift
+++ b/ios/PolyPodApp/FeatureContainer/FilePicker.swift
@@ -3,6 +3,15 @@ import UIKit
 class FilePicker: NSObject, UIDocumentPickerDelegate {
     private var currentCompletion: ((URL?) -> Void)?
     
+    private lazy var documentPickerController: UIDocumentPickerViewController = {
+        let controller = UIDocumentPickerViewController(
+            documentTypes: ["public.item"],
+            in: .open
+        )
+        controller.delegate = self
+        return controller
+    }()
+    
     func pick(completion: @escaping (URL?) -> Void) {
         if currentCompletion != nil {
             completion(nil)
@@ -10,19 +19,9 @@ class FilePicker: NSObject, UIDocumentPickerDelegate {
         }
         currentCompletion = completion
         
-        let documentPickerController = UIDocumentPickerViewController(
-            documentTypes: ["public.item"],
-            in: .import
-        )
-        documentPickerController.delegate = self
-        
         let viewController =
             UIApplication.shared.windows.first!.rootViewController!
-        viewController.present(
-            documentPickerController,
-            animated: true,
-            completion: nil
-        )
+        viewController.present(documentPickerController, animated: true)
     }
     
     func documentPicker(
@@ -41,5 +40,8 @@ class FilePicker: NSObject, UIDocumentPickerDelegate {
     private func complete(url: URL?) {
         currentCompletion?(url)
         currentCompletion = nil
+        // It shouldn't _quite_ be necessary to dismiss the controller
+        // manually, but it's an attempted workaround for PROD4POD-859
+        documentPickerController.dismiss(animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
(Please note that *none of this actually solves the issue*)

Trying three changes to solve the issue:

1. Keep the FilePicker instance in a state variable (not particularly
   necessary since the previous code constructed all objects it needed
   ad hoc)

2. Explicitly dismiss the document picker controller (shouldn't really
   be necessary)

3. Keep the document picker controller as state in FilePicker -
   shouldn't really be necessary, but otherwise (1) doesn't make a lot
   of sense, and (2) is not possible.

4. Change the open mode from .import to .open - now that we don't
   actually keep the ZIP file anymore, that's probably what we want
   anyway, as it avoids making the unnecessary copy we currently don't
   even remove.