### PR TITLE
[Fix] Updates to some plugins that had became obsolete in PolyLook as well as downstream dependencies

### DIFF
--- a/core/utils/poly-look/package-lock.json
+++ b/core/utils/poly-look/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@open-wc/testing": "^2.5.33",
+        "@rollup/plugin-sucrase": "^4.0.1",
         "@web/dev-server": "^0.1.22",
         "@web/dev-server-rollup": "^0.3.5",
         "@web/dev-server-storybook": "^0.0.2",
@@ -26,7 +27,6 @@
         "rollup": "^2.48.0",
         "rollup-plugin-filesize": "^9.1.1",
         "rollup-plugin-node-resolve": "^5.2.0",
-        "rollup-plugin-sucrase": "^2.1.0",
         "rollup-plugin-svg": "^2.0.0",
         "rollup-plugin-terser": "^7.0.2"
       }
@@ -406,6 +406,41 @@
       "peerDependencies": {
         "rollup": "^1.20.0||^2.0.0"
       }
+    },
+    "node_modules/@rollup/plugin-sucrase": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-sucrase/-/plugin-sucrase-4.0.1.tgz",
+      "integrity": "sha512-VDVLl+civWOw8eLBa6jOh1SeOBWCUKTyubmi4T+Ab1eFgxUG0OqdNPXVYJbsKAOqfS+Scj5oMHXvzyJmwoJAPQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^4.1.1",
+        "sucrase": "^3.20.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.53.1"
+      }
+    },
+    "node_modules/@rollup/plugin-sucrase/node_modules/@rollup/pluginutils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+      "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-sucrase/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "node_modules/@rollup/pluginutils": {
       "version": "3.1.0",
@@ -6581,17 +6616,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/rollup-plugin-sucrase": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-sucrase/-/rollup-plugin-sucrase-2.1.0.tgz",
-      "integrity": "sha512-chdA3OruR1FH/IIKrzZCpGKLXAx3DOHoK24RIPtlVccK0wbTpHE0HpGEQYCxte1XaB17NgRe/frFyKR7g45qxQ==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-sucrase.",
-      "dev": true,
-      "dependencies": {
-        "rollup-pluginutils": "^2.3.0",
-        "sucrase": "3.x"
-      }
-    },
     "node_modules/rollup-plugin-svg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-svg/-/rollup-plugin-svg-2.0.0.tgz",
@@ -8187,6 +8211,34 @@
         "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
         "resolve": "^1.19.0"
+      }
+    },
+    "@rollup/plugin-sucrase": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-sucrase/-/plugin-sucrase-4.0.1.tgz",
+      "integrity": "sha512-VDVLl+civWOw8eLBa6jOh1SeOBWCUKTyubmi4T+Ab1eFgxUG0OqdNPXVYJbsKAOqfS+Scj5oMHXvzyJmwoJAPQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^4.1.1",
+        "sucrase": "^3.20.0"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+          "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
+          "dev": true,
+          "requires": {
+            "estree-walker": "^2.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
+        }
       }
     },
     "@rollup/pluginutils": {
@@ -13017,16 +13069,6 @@
             "@types/node": "*"
           }
         }
-      }
-    },
-    "rollup-plugin-sucrase": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-sucrase/-/rollup-plugin-sucrase-2.1.0.tgz",
-      "integrity": "sha512-chdA3OruR1FH/IIKrzZCpGKLXAx3DOHoK24RIPtlVccK0wbTpHE0HpGEQYCxte1XaB17NgRe/frFyKR7g45qxQ==",
-      "dev": true,
-      "requires": {
-        "rollup-pluginutils": "^2.3.0",
-        "sucrase": "3.x"
       }
     },
     "rollup-plugin-svg": {

--- a/core/utils/poly-look/package.json
+++ b/core/utils/poly-look/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@open-wc/testing": "^2.5.33",
+    "@rollup/plugin-sucrase": "^4.0.1",
     "@web/dev-server": "^0.1.22",
     "@web/dev-server-rollup": "^0.3.5",
     "@web/dev-server-storybook": "^0.0.2",
@@ -33,7 +34,6 @@
     "rollup-plugin-filesize": "^9.1.1",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-svg": "^2.0.0",
-    "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-sucrase": "^2.1.0"
+    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/core/utils/poly-look/rollup.config.js
+++ b/core/utils/poly-look/rollup.config.js
@@ -2,7 +2,7 @@ import filesize from "rollup-plugin-filesize";
 import { terser } from "rollup-plugin-terser";
 import resolve from "rollup-plugin-node-resolve";
 import svg from "rollup-plugin-svg";
-import sucrase from "rollup-plugin-sucrase";
+import sucrase from "@rollup/plugin-sucrase";
 
 export default {
   input: "src/poly-look.js",


### PR DESCRIPTION
Initially, `@rollup/plugin-sucrase`. There might be others.