### PR TITLE
Move importer tests to dedicated folder

### DIFF
--- a/features/facebookImport/test/importers/ad-view-language-importer.test.js
+++ b/features/facebookImport/test/importers/ad-view-language-importer.test.js
@@ -4,9 +4,9 @@ import {
     createDanishAdViewsData,
     createEnglishAdViewsData,
     createGermanAdViewsData,
-} from "./datasets/ad-views-data";
-import { runAdsImportForDataset } from "./utils/data-importing";
-import { expectImportSuccess } from "./utils/importer-assertions";
+} from "../datasets/ad-views-data";
+import { runAdsImportForDataset } from "../utils/data-importing";
+import { expectImportSuccess } from "../utils/importer-assertions";
 
 const datasets = [
     ["English", createEnglishAdViewsData()],

--- a/features/facebookImport/test/importers/ad-views-importer.test.js
+++ b/features/facebookImport/test/importers/ad-views-importer.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { RECENTLY_VIEWED_FILE_PATH } from "../src/model/importers/recently-viewed-ads-importer";
+import { RECENTLY_VIEWED_FILE_PATH } from "../../src/model/importers/recently-viewed-ads-importer";
 import {
     creatAdViewsWithCompanyWithUnicodeCharactersData,
     createDanishAdViewsData,
@@ -8,17 +8,17 @@ import {
     createEnglishDatasetWithMissingAdsCategory,
     createGermanAdViewsData,
     createIncompleteEnglishAdViewsData,
-} from "./datasets/ad-views-data";
-import { ZipFileMock } from "./mocks/zipfile-mock";
+} from "../datasets/ad-views-data";
+import { ZipFileMock } from "../mocks/zipfile-mock";
 import {
     runAdsImportForDataset,
     runRecentlyViewedAdsImporter,
-} from "./utils/data-importing";
+} from "../utils/data-importing";
 import {
     expectImportSuccess,
     expectInvalidContentError,
     expectMissingFileError,
-} from "./utils/importer-assertions";
+} from "../utils/importer-assertions";
 
 describe("Import ad views from empty export", () => {
     let zipFile = null;

--- a/features/facebookImport/test/importers/language-and-locale-importer.test.js
+++ b/features/facebookImport/test/importers/language-and-locale-importer.test.js
@@ -1,16 +1,16 @@
-import { LANGUAGE_AND_LOCALE_FILE_PATH } from "../src/model/importers/language-and-locale-importer";
+import { LANGUAGE_AND_LOCALE_FILE_PATH } from "../../src/model/importers/language-and-locale-importer";
 import {
     createLanguageSettingsData,
     createLocaleData,
-} from "./datasets/language-and-locale-data";
-import { ZipFileMock } from "./mocks/zipfile-mock";
-import { runLanguageAndLocaleImporter } from "./utils/data-importing";
+} from "../datasets/language-and-locale-data";
+import { ZipFileMock } from "../mocks/zipfile-mock";
+import { runLanguageAndLocaleImporter } from "../utils/data-importing";
 import {
     expectImportSuccess,
     expectImportWarning,
     expectInvalidContentError,
     expectMissingFileError,
-} from "./utils/importer-assertions";
+} from "../utils/importer-assertions";
 
 describe("Import language from", () => {
     let zipFile = null;

--- a/features/facebookImport/test/importers/messages-importer.test.js
+++ b/features/facebookImport/test/importers/messages-importer.test.js
@@ -1,12 +1,12 @@
 "use strict";
 
-import { MissingMessagesFilesException } from "../src/model/importers/utils/failed-import-exception.js";
-import { ZipFileMock } from "./mocks/zipfile-mock.js";
-import { runMessagesImporter } from "./utils/data-importing.js";
+import { MissingMessagesFilesException } from "../../src/model/importers/utils/failed-import-exception.js";
+import { ZipFileMock } from "../mocks/zipfile-mock.js";
+import { runMessagesImporter } from "../utils/data-importing.js";
 import {
     expectError,
     expectImportSuccess,
-} from "./utils/importer-assertions.js";
+} from "../utils/importer-assertions.js";
 
 function createMessageThreadOneData() {
     return {

--- a/features/facebookImport/test/importers/name-importer.test.js
+++ b/features/facebookImport/test/importers/name-importer.test.js
@@ -1,13 +1,13 @@
 "use strict";
 
-import { ZipFileMock } from "./mocks/zipfile-mock";
-import { runNameImporter } from "./utils/data-importing";
+import { ZipFileMock } from "../mocks/zipfile-mock";
+import { runNameImporter } from "../utils/data-importing";
 import {
     expectError,
     expectImportSuccess,
     expectInvalidContentError,
     expectMissingFileError,
-} from "./utils/importer-assertions.js";
+} from "../utils/importer-assertions.js";
 
 const profileInformationFileName =
     "profile_information/profile_information.json";

--- a/features/facebookImport/test/importers/off-facebook-events-importer.test.js
+++ b/features/facebookImport/test/importers/off-facebook-events-importer.test.js
@@ -1,14 +1,14 @@
 "use strict";
 
-import { OFF_FACEBOOK_EVENTS_FILE_PATH } from "../src/model/importers/off-facebook-events-importer";
-import { createOffFacebookEventsSimpleData } from "./datasets/off-facebook-events-data";
-import { ZipFileMock } from "./mocks/zipfile-mock";
-import { runOffFacebookEventsImporter } from "./utils/data-importing";
+import { OFF_FACEBOOK_EVENTS_FILE_PATH } from "../../src/model/importers/off-facebook-events-importer";
+import { createOffFacebookEventsSimpleData } from "../datasets/off-facebook-events-data";
+import { ZipFileMock } from "../mocks/zipfile-mock";
+import { runOffFacebookEventsImporter } from "../utils/data-importing";
 import {
     expectImportSuccess,
     expectInvalidContentError,
     expectMissingFileError,
-} from "./utils/importer-assertions";
+} from "../utils/importer-assertions";
 
 describe("Import off-facebook events from empty export", () => {
     let zipFile = null;


### PR DESCRIPTION
Now we will have tests for importers and mini-stories. This separates the importer tests into a dedicated folder.