### PR TITLE
Handle ad view having a photo url

### DIFF
--- a/features/facebookImport/src/model/importers/utils/url-processing.js
+++ b/features/facebookImport/src/model/importers/utils/url-processing.js
@@ -2,6 +2,7 @@
  * Extract data from an url of the form:
  * "https://www.facebook.com/<id>/posts/<somethig-else>"
  * "https://www.facebook.com/<id>/photos/<somethig-else>".
+ * "https://www.facebook.com/<id>/videos/<somethig-else>".
  *
  * Return this account data:
  *  {
@@ -11,7 +12,7 @@
  */
 export function extractAccountDataFromStandardUrl(urlString) {
     const postUrlMatch = urlString.match(
-        /^(https:\/\/www\.facebook\.com\/([^/]+))\/(?:posts|photos)\/.*$/
+        /^(https:\/\/www\.facebook\.com\/([^/]+))\/(?:posts|photos|videos)\/.*$/
     );
     if (postUrlMatch && postUrlMatch.length === 3) {
         return { url: postUrlMatch[1], urlId: postUrlMatch[2] };

--- a/features/facebookImport/test/url-processing.test.js
+++ b/features/facebookImport/test/url-processing.test.js
@@ -31,13 +31,22 @@ test("Extract account data from photo url", () => {
     expect(extractAccountDataFromUrl(url)).toStrictEqual(extractedData);
 });
 
+test("Extract account data from video url", () => {
+    const url = "https://www.facebook.com/companyx/videos/11111222333444/";
+    const extractedData = {
+        url: "https://www.facebook.com/companyx",
+        urlId: "companyx",
+    };
+    expect(extractAccountDataFromUrl(url)).toStrictEqual(extractedData);
+});
+
 test("Group urls are not supported", () => {
     const url =
         "https://www.facebook.com/groups/999888777655/permalink/11111222333444/";
     expect(extractAccountDataFromUrl(url)).toBe(null);
 });
 
-test("Video urls are not supported", () => {
-    const url = "https://www.facebook.com/companyx/videos/11111222333444//";
+test("Urls for unknown data types not supported", () => {
+    const url = "https://www.facebook.com/companyx/something/11111222333444/";
     expect(extractAccountDataFromUrl(url)).toBe(null);
 });


### PR DESCRIPTION
Some ads viewed on Facebook have URLs that point to a photo, not to a post. Take also them into account when importing ad views.