### PR TITLE
Fix - polyExplorer not loading

### DIFF
--- a/features/polyExplorer/package.json
+++ b/features/polyExplorer/package.json
@@ -7,7 +7,7 @@
     "lint:fix": "eslint --fix src test scripts --ext .js --ext .jsx",
     "build": "rollup -c",
     "watch": "rollup --watch -c",
-    "test": "mocha && npm run cypress:run",
+    "test": "mocha",
     "polypedia:fetch": "node scripts/fetch-polypedia-data 162daa1",
     "polypedia:convert": "node scripts/convert-polypedia-data",
     "update-polypedia-data": "npm run polypedia:fetch && npm run polypedia:convert",

--- a/features/polyExplorer/rollup.config.js
+++ b/features/polyExplorer/rollup.config.js
@@ -15,7 +15,6 @@ export default {
         globals: {
             react: "React",
             "react-dom": "ReactDOM",
-            "react-router-dom": "reactRouterDOM",
         },
     },
     //This is meant to suppress the warning for d3-selection circular dependencies (https://github.com/d3/d3-selection/issues/168)
@@ -37,7 +36,6 @@ export default {
                     src: [
                         "node_modules/react/umd/react.development.js",
                         "node_modules/react-dom/umd/react-dom.development.js",
-                        "node_modules/react-router-dom/umd/react-router-dom.js",
                         "node_modules/@polypoly-eu/podjs/dist/pod.js",
                         "src/static/*",
                     ],
@@ -54,5 +52,5 @@ export default {
             include: /node_modules/,
         }),
     ],
-    external: ["react", "react-dom", "react-router-dom"],
+    external: ["react", "react-dom"],
 };


### PR DESCRIPTION
So rollup complained that it can't find `react-router` - and that's not too surprising cause all we have is `react-router-dom`. Can't quite explain why this seems to have worked in the `polyExplorer-v2` branch, but my theory is that **it didn't**. I presume people working on this just still had `react-router` in their `node_modules`... But I didn't test.