### PR TITLE
PROD4POD-857 - Determine active feature dynamically

### DIFF
--- a/ios/PolyPodApp/FeatureContainer/FeatureContainerView.swift
+++ b/ios/PolyPodApp/FeatureContainer/FeatureContainerView.swift
@@ -141,6 +141,8 @@ class FeatureWebView: WKWebView {
         openUrlHandler: @escaping (String) -> Void,
         pickFileHandler: @escaping (String?, @escaping (URL?) -> Void) -> Void
     ) {
+        FeatureStorage.shared.activeFeature = feature
+        
         self.featureTitle = title
         self.activeActions = activeActions
         self.errorHandler = errorHandler

--- a/ios/PolyPodApp/Features/FeatureStorage.swift
+++ b/ios/PolyPodApp/Features/FeatureStorage.swift
@@ -4,6 +4,8 @@ import Zip
 class FeatureStorage {
     static let shared = FeatureStorage()
     
+    var activeFeature: Feature? = nil
+    
     lazy var featuresFileUrl: URL = {
         do {
             let documentsUrl = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)

--- a/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
+++ b/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
@@ -40,9 +40,7 @@ extension PolyOut {
     
     static func featureFilesPath() -> URL {
         let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.resolvingSymlinksInPath()
-        // TODO: Hard coded for the sake of speed, but we need to determine the active feature's ID here
-        let featureId = "facebookImport"
-        return documentDirectory.appendingPathComponent(PolyOut.fsFilesRoot).appendingPathComponent(featureId)
+        return documentDirectory.appendingPathComponent(PolyOut.fsFilesRoot).appendingPathComponent(FeatureStorage.shared.activeFeature!.id)
     }
     
     private static func pathFromUrl(url: String) -> URL? {


### PR DESCRIPTION
I was wondering where to best store the _active_ feature - ended up with `FeatureStorage`, whereas it's in `Preferences` on Android. I'd have half a mind to implement it similarly on Android if this one gets approved.