### PR TITLE
[PROD4POD-984] Add path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,7 @@ jobs:
             - 'core/api/**'
             - 'core/communication/**'
             - 'core/utils/silly-i18n/**'
-            - 'features/lexicon/**'
-            - 'features/polyExplorer/**'
-            - 'features/polyPreview/**'
-            - 'features/facebookImport/**'
+            - 'features/**'
             - 'podjs/**'
             js:
             - '**/*.js'


### PR DESCRIPTION
Which was causing the Android tests for facebookImport not being tested.