### PR TITLE
Import reactions

### DIFF
--- a/features/facebookImport/src/model/analyses/ministories/post-reactions-types-analysis.js
+++ b/features/facebookImport/src/model/analyses/ministories/post-reactions-types-analysis.js
@@ -1,0 +1,20 @@
+import React from "react";
+import BarChart from "../../../components/dataViz/barChart.jsx";
+import { groupPostReactionsByType } from "../utils/post-reactions-utils";
+import RootAnalysis from "./root-analysis";
+
+export default class PostReactionsTypesAnalysis extends RootAnalysis {
+    get title() {
+        return "Post Reactions by Type";
+    }
+
+    async analyze({ facebookAccount }) {
+        this._reactionsTypeCountPairs =
+            groupPostReactionsByType(facebookAccount);
+        this.active = this._reactionsTypeCountPairs.length > 0;
+    }
+
+    renderSummary() {
+        return <BarChart data={this._reactionsTypeCountPairs} names="type" />;
+    }
+}

--- a/features/facebookImport/src/model/analyses/utils/post-reactions-utils.js
+++ b/features/facebookImport/src/model/analyses/utils/post-reactions-utils.js
@@ -1,0 +1,24 @@
+export function groupDataByType(dataEntries) {
+    const dataCountByType = {};
+    dataEntries.forEach((dataEntry) => {
+        if (!dataCountByType[dataEntry.type]) {
+            dataCountByType[dataEntry.type] = 0;
+        }
+        dataCountByType[dataEntry.type]++;
+    });
+
+    const dataTypeCountPairs = [];
+    for (const type in dataCountByType) {
+        dataTypeCountPairs.push({
+            type,
+            count: dataCountByType[type],
+        });
+    }
+    return dataTypeCountPairs.sort(function (pairA, pairB) {
+        return pairB.count - pairA.count;
+    });
+}
+
+export function groupPostReactionsByType(facebookAccount) {
+    return groupDataByType(facebookAccount.postReactions);
+}

--- a/features/facebookImport/src/model/analysis.js
+++ b/features/facebookImport/src/model/analysis.js
@@ -43,6 +43,7 @@ import AdvertisingValueAnalysis from "./analyses/ministories/advertising-value-a
 import AboutPicturesDataAnalysis from "./analyses/ministories/about-pictures-data-analysis.js";
 import AdViewsAnalysis from "./analyses/ministories/ad-views-analysis.js";
 import OnOffFacebookAdvertisersAnalysis from "./analyses/ministories/on-off-facebook-advertisers-analysis.js";
+import PostReactionsTypesAnalysis from "./analyses/ministories/post-reactions-types-analysis.js";
 
 const subAnalyses = [
     DataStructureBubblesAnalysis,
@@ -52,6 +53,7 @@ const subAnalyses = [
     AboutPicturesDataAnalysis,
     AdvertisingValueAnalysis,
 
+    PostReactionsTypesAnalysis,
     ExportTitleAnalysis,
     ExportSizeAnalysis,
     DataChartsAnalysis,

--- a/features/facebookImport/src/model/entities/facebook-account.js
+++ b/features/facebookImport/src/model/entities/facebook-account.js
@@ -22,6 +22,7 @@ class FacebookAccount {
         this._searches = [];
         this._adminRecords = [];
         this._accountSessionActivities = [];
+        this._postReactions = [];
 
         this._messageThreadsGroup = new MessageThreadsGroup();
         this._relatedAccounts = new RelatedAccountsGroup();
@@ -232,6 +233,14 @@ class FacebookAccount {
 
     get relatedAccountsCount() {
         return this._relatedAccounts.count;
+    }
+
+    get postReactions() {
+        return this._postReactions;
+    }
+
+    set postReactions(postReactions) {
+        this._postReactions = postReactions;
     }
 
     get dataGroups() {

--- a/features/facebookImport/src/model/importer.js
+++ b/features/facebookImport/src/model/importer.js
@@ -23,6 +23,7 @@ import {
 } from "./importers/utils/importer-status.js";
 import LanguageAndLocaleImporter from "./importers/language-and-locale-importer.js";
 import RecentlyViewedAdsImporter from "./importers/recently-viewed-ads-importer.js";
+import PostReactionsImporter from "./importers/post-reactions-importer.js";
 
 const dataImporters = [
     AdInterestsImporter,
@@ -42,6 +43,7 @@ const dataImporters = [
     NameImporter,
     LanguageAndLocaleImporter,
     RecentlyViewedAdsImporter,
+    PostReactionsImporter,
 ];
 
 export async function runImporter(

--- a/features/facebookImport/src/model/importers/direct-key-data-importer.js
+++ b/features/facebookImport/src/model/importers/direct-key-data-importer.js
@@ -8,11 +8,17 @@ export default class DirectKeyDataImporter {
     }
 
     async import({ zipFile, facebookAccount }) {
-        facebookAccount[this._dataStorageKey] = await readJSONDataArray(
-            this._dataFileName,
-            this._dataKey,
-            zipFile
+        facebookAccount[this._dataStorageKey] = this.extractData(
+            await readJSONDataArray(this._dataFileName, this._dataKey, zipFile)
         );
         facebookAccount.addImportedFileName(this._dataFileName);
+    }
+
+    /**
+     * Hook method to allow importers to change the data
+     * that gets places into the Facebook Account
+     */
+    extractData(rawData) {
+        return rawData;
     }
 }

--- a/features/facebookImport/src/model/importers/post-reactions-importer.js
+++ b/features/facebookImport/src/model/importers/post-reactions-importer.js
@@ -1,0 +1,29 @@
+import DirectKeyDataImporter from "./direct-key-data-importer.js";
+
+export const POST_REACTIONS_FILE_PATH =
+    "comments_and_reactions/posts_and_comments.json";
+export const POST_REACTIONS_DATA_KEY = "reactions_v2";
+export const POST_REACTIONS_STORAGE_KEY = "postReactions";
+
+export default class PostReactionsImporter extends DirectKeyDataImporter {
+    constructor() {
+        super(
+            POST_REACTIONS_FILE_PATH,
+            POST_REACTIONS_DATA_KEY,
+            POST_REACTIONS_STORAGE_KEY
+        );
+    }
+
+    _extractDataFromReaction(reactionData) {
+        return {
+            timestamp: reactionData.timestamp,
+            type: reactionData?.data[0]?.reaction?.reaction,
+        };
+    }
+
+    extractData(rawData) {
+        return rawData.map((reactionData) =>
+            this._extractDataFromReaction(reactionData)
+        );
+    }
+}

--- a/features/facebookImport/src/model/importers/post-reactions-importer.js
+++ b/features/facebookImport/src/model/importers/post-reactions-importer.js
@@ -17,7 +17,7 @@ export default class PostReactionsImporter extends DirectKeyDataImporter {
     _extractDataFromReaction(reactionData) {
         return {
             timestamp: reactionData.timestamp,
-            type: reactionData?.data[0]?.reaction?.reaction,
+            type: reactionData?.data[0]?.reaction?.reaction.toUpperCase(),
         };
     }
 

--- a/features/facebookImport/test/datasets/post-reactions-data.js
+++ b/features/facebookImport/test/datasets/post-reactions-data.js
@@ -1,0 +1,45 @@
+import {
+    POST_REACTIONS_DATA_KEY,
+    POST_REACTIONS_FILE_PATH,
+} from "../../src/model/importers/post-reactions-importer";
+import { createMockedZip } from "../utils/data-creation";
+
+export const DATASET_EXPECTED_VALUES = {
+    numberOfPostsReactions: 6,
+};
+
+export function wrapPostReactionsData(data) {
+    return { [POST_REACTIONS_DATA_KEY]: data };
+}
+
+function createPostReaction(timestamp, type, accountName) {
+    return {
+        timestamp: timestamp,
+        data: [
+            {
+                reaction: {
+                    reaction: type,
+                    actor: "John Doe",
+                },
+            },
+        ],
+        title: `John Doe likes ${accountName}'s post.`,
+    };
+}
+
+export function createPostReactionsDataset() {
+    return wrapPostReactionsData([
+        createPostReaction(1589138279, "LIKE", "Jane Doe"),
+        createPostReaction(1512409643, "LIKE", "Test Name"),
+        createPostReaction(1494999874, "WOW", "Jane Doe"),
+        createPostReaction(1398893265, "SAD", "Donald Duck"),
+        createPostReaction(1416949925, "LIKE", "Alice Joe"),
+        createPostReaction(1498845994, "WOW", "Jane Doe"),
+    ]);
+}
+
+export function zipFileWithPostReactions() {
+    return createMockedZip([
+        [POST_REACTIONS_FILE_PATH, createPostReactionsDataset()],
+    ]);
+}

--- a/features/facebookImport/test/importers/post-reactions-importer.test.js
+++ b/features/facebookImport/test/importers/post-reactions-importer.test.js
@@ -1,0 +1,56 @@
+import { POST_REACTIONS_FILE_PATH } from "../../src/model/importers/post-reactions-importer";
+import {
+    DATASET_EXPECTED_VALUES,
+    zipFileWithPostReactions,
+} from "../datasets/post-reactions-data";
+import { ZipFileMock } from "../mocks/zipfile-mock";
+import { zipWithWrongDatasetKey } from "../utils/data-creation";
+import { runPostReactionsImporter } from "../utils/data-importing";
+import {
+    expectImportSuccess,
+    expectInvalidContentError,
+    expectMissingFileError,
+} from "../utils/importer-assertions";
+
+describe("Import post reactions from empty export", () => {
+    let zipFile = null;
+    beforeAll(() => {
+        zipFile = new ZipFileMock();
+    });
+
+    it("triggers missing files error", async () => {
+        const { result } = await runPostReactionsImporter(zipFile);
+
+        expectMissingFileError(result);
+    });
+});
+
+describe("Import post reactions from export with wrong data key", () => {
+    let zipFile = null;
+
+    beforeAll(async () => {
+        zipFile = zipWithWrongDatasetKey(POST_REACTIONS_FILE_PATH);
+    });
+
+    it("triggers missing data key error", async () => {
+        const { result } = await runPostReactionsImporter(zipFile);
+        expectInvalidContentError(result);
+    });
+});
+
+describe("Import post reactions", () => {
+    let result = null;
+    let facebookAccount = null;
+
+    beforeAll(async () => {
+        const zipFile = zipFileWithPostReactions();
+        ({ facebookAccount, result } = await runPostReactionsImporter(zipFile));
+    });
+
+    it("returns success status", () => expectImportSuccess(result));
+
+    it("has corrent number of entities", () =>
+        expect(facebookAccount.postReactions.length).toBe(
+            DATASET_EXPECTED_VALUES.numberOfPostsReactions
+        ));
+});

--- a/features/facebookImport/test/ministory/post-reactions-types-analysis.test.js
+++ b/features/facebookImport/test/ministory/post-reactions-types-analysis.test.js
@@ -1,0 +1,59 @@
+import PostReactionsTypesAnalysis from "../../src/model/analyses/ministories/post-reactions-types-analysis";
+import { zipFileWithPostReactions } from "../datasets/post-reactions-data";
+import { ZipFileMock } from "../mocks/zipfile-mock";
+import { runAnalysisForExport } from "../utils/analyses-execution";
+import {
+    expectActiveAnalysis,
+    expectAnalysisSuccessStatus,
+    expectInactiveAnalysis,
+} from "../utils/analysis-assertions";
+
+describe("Post reactions analysis for empty zip", () => {
+    let analysis = null;
+    let status = null;
+
+    beforeAll(async () => {
+        let zipFile = new ZipFileMock();
+        ({ analysis, status } = await runAnalysisForExport(
+            PostReactionsTypesAnalysis,
+            zipFile
+        ));
+    });
+
+    it("has success status", async () => {
+        expectAnalysisSuccessStatus(status);
+    });
+
+    it("is not active", async () => {
+        expectInactiveAnalysis(analysis);
+    });
+});
+
+describe("Post reactions analysis from export data", () => {
+    let analysis = null;
+    let status = null;
+
+    beforeAll(async () => {
+        const zipFile = zipFileWithPostReactions();
+        ({ analysis, status } = await runAnalysisForExport(
+            PostReactionsTypesAnalysis,
+            zipFile
+        ));
+    });
+
+    it("has success status", async () => {
+        expectAnalysisSuccessStatus(status);
+    });
+
+    it("is active", async () => {
+        expectActiveAnalysis(analysis);
+    });
+
+    it("has correct reactions per type", async () => {
+        expect(analysis._reactionsTypeCountPairs).toStrictEqual([
+            { type: "LIKE", count: 3 },
+            { type: "WOW", count: 2 },
+            { type: "SAD", count: 1 },
+        ]);
+    });
+});

--- a/features/facebookImport/test/utils/data-importing.js
+++ b/features/facebookImport/test/utils/data-importing.js
@@ -10,6 +10,7 @@ import { ZipFileMock } from "../mocks/zipfile-mock.js";
 import LanguageAndLocaleImporter from "../../src/model/importers/language-and-locale-importer.js";
 import FriendsImporter from "../../src/model/importers/friends-importer.js";
 import LikedPagesImporter from "../../src/model/importers/pages-liked-importer.js";
+import PostReactionsImporter from "../../src/model/importers/post-reactions-importer.js";
 
 export async function runMultipleImporters(importerClasses, zipFile) {
     const facebookAccount = new FacebookAccount();
@@ -53,6 +54,10 @@ export async function runFriendsImporter(zipFile) {
 
 export async function runLikedPagesImporter(zipFile) {
     return runSingleImporter(LikedPagesImporter, zipFile);
+}
+
+export async function runPostReactionsImporter(zipFile) {
+    return runSingleImporter(PostReactionsImporter, zipFile);
 }
 
 export async function runImportForDataset(importerClass, filePath, dataset) {


### PR DESCRIPTION
This imports reaction data to posts:
- only imports the type and the timestamp
- extends DirectKeyDataImporter with a hook for transforming data
- adds tests for the importer
- groups reactions by types
- adds a simple ministory that can be expanded

<img width="467" alt="Screenshot 2021-10-29 at 15 54 24" src="https://user-images.githubusercontent.com/3534711/139449470-069cb698-b738-4599-b435-ec71bb1364c2.png">


