### PR TITLE
Update Android repositories

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,8 @@ buildscript {
     ext.kotlin_version = '1.4.0'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
@@ -16,7 +17,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        gradlePluginPortal()
     }
 }
 

--- a/android/java-fetch/build.gradle
+++ b/android/java-fetch/build.gradle
@@ -6,7 +6,8 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
+    gradlePluginPortal()
 }
 
 import groovy.json.JsonSlurper

--- a/android/polyOut/build.gradle
+++ b/android/polyOut/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    gradlePluginPortal()
 }
 
 compileKotlin {

--- a/core/communication/bubblewrap/build.gradle
+++ b/core/communication/bubblewrap/build.gradle
@@ -5,7 +5,8 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
+    gradlePluginPortal()
 }
 
 import groovy.json.JsonSlurper


### PR DESCRIPTION
This updates android repositories, mainly due to deprecation on jcenter (which is [not really deprecated](https://stackoverflow.com/questions/66651640/jcenter-deprecation-impact-on-gradle-and-android)).