### PR TITLE
PROD4POD-951/Fix polyExplorer bugs

### DIFF
--- a/features/polyExplorer/src/infographics/featuredEntity.svg
+++ b/features/polyExplorer/src/infographics/featuredEntity.svg
@@ -1,5 +1,5 @@
 <svg width="308" height="219" viewBox="0 0 308 219" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="featuredCompany">
+<g id="featuredEntity">
 <g id="Bar">
 <text id="115" fill="#3749A9" xml:space="preserve" style="white-space: pre" font-family="Jost*" font-size="12" letter-spacing="-0.01em"><tspan x="262.343" y="114.17">115</tspan></text>
 <text id="30" opacity="0.7" fill="#3749A9" xml:space="preserve" style="white-space: pre" font-family="Jost*" font-size="12" letter-spacing="-0.01em"><tspan x="89.567" y="114.17">30</tspan></text>

--- a/features/polyExplorer/src/infographics/infographics.js
+++ b/features/polyExplorer/src/infographics/infographics.js
@@ -3,7 +3,7 @@ import category from "./category.svg";
 import correlation from "./correlation.svg";
 import companies from "./companies.svg";
 import purpose from "./purpose.svg";
-import featuredCompany from "./featuredCompany.svg";
+import featuredEntity from "./featuredEntity.svg";
 import jurisdiction from "./jurisdiction.svg";
 import jurisdiction2 from "./jurisdiction2.svg";
 
@@ -13,7 +13,7 @@ export default {
     correlation: correlation,
     companies: companies,
     purpose: purpose,
-    featuredCompany: featuredCompany,
+    featuredEntity: featuredEntity,
     jurisdiction: jurisdiction,
     jurisdiction2: jurisdiction2,
 };

--- a/features/polyExplorer/src/locales/de/infographic.json
+++ b/features/polyExplorer/src/locales/de/infographic.json
@@ -1,8 +1,8 @@
 {
-    "featuredCompany.text1": "Maximale Anzahl für diese Firma.",
-    "featuredCompany.highlighted1": "25 Dateneinträge",
-    "featuredCompany.text2": "Durchschnittlicher Wert aller derzeit verfügbaren Firmeninformationen in dieser Kategorie.",
-    "featuredCompany.text3": "Wert der Firma, die in dieser Kategorie von allen derzeit verfügbaren Firmeninformationen, den höchsten Wert aufweist.",
+    "featuredEntity.text1": "Maximale Anzahl für diese Firma.",
+    "featuredEntity.highlighted1": "25 Dateneinträge",
+    "featuredEntity.text2": "Durchschnittlicher Wert aller derzeit verfügbaren Firmeninformationen in dieser Kategorie.",
+    "featuredEntity.text3": "Wert der Firma, die in dieser Kategorie von allen derzeit verfügbaren Firmeninformationen, den höchsten Wert aufweist.",
     "dataTypes.text1": "Menge aller Datentypen, die ein Unternehmen teilt.",
     "dataTypes.text2": "Anzahl, wie oft dieser Datentyp mit anderen Firmen geteilt wird.",
     "dataTypes.text3": "Datentyp",

--- a/features/polyExplorer/src/locales/en/infographic.json
+++ b/features/polyExplorer/src/locales/en/infographic.json
@@ -1,8 +1,8 @@
 {
-    "featuredCompany.text1": "Max value for this company.",
-    "featuredCompany.highlighted1": "25 Data Entries",
-    "featuredCompany.text2": "Average value from all company information currently available in this category.",
-    "featuredCompany.text3": "Highest value for a single company, based on currently available company information.",
+    "featuredEntity.text1": "Max value for this company.",
+    "featuredEntity.highlighted1": "25 Data Entries",
+    "featuredEntity.text2": "Average value from all company information currently available in this category.",
+    "featuredEntity.text3": "Highest value for a single company, based on currently available company information.",
     "dataTypes.text1": "Amount of all data types a company shares.",
     "dataTypes.text2": "Amount of times this data type is shared with other companies.",
     "dataTypes.text3": "Data type",

--- a/features/polyExplorer/src/screens/dataExploration/dataExploration.css
+++ b/features/polyExplorer/src/screens/dataExploration/dataExploration.css
@@ -157,7 +157,7 @@
 }
 
 .static-content-jurisdictions .info-button {
-    bottom: 200px;
+    bottom: 140px;
 }
 
 .data-exploration .static-content .data-sharing-legend-fill {

--- a/features/polyExplorer/src/screens/dataExploration/dataExploration.css
+++ b/features/polyExplorer/src/screens/dataExploration/dataExploration.css
@@ -157,7 +157,7 @@
 }
 
 .static-content-jurisdictions .info-button {
-    bottom: 140px;
+    bottom: 130px;
 }
 
 .data-exploration .static-content .data-sharing-legend-fill {

--- a/features/polyExplorer/src/screens/dataExploration/dataExploration.jsx
+++ b/features/polyExplorer/src/screens/dataExploration/dataExploration.jsx
@@ -276,7 +276,7 @@ const DataExplorationScreen = () => {
                     </p>
 
                     <InfoButton
-                        route="data-types-info"
+                        route="/data-types-info"
                         saveActiveIndex={saveActiveIndex}
                     />
                     {filler}
@@ -307,7 +307,7 @@ const DataExplorationScreen = () => {
                         {i18n.t("common:source")}: polyPedia
                     </p>
                     <InfoButton
-                        route="data-types-info"
+                        route="/data-types-info"
                         saveActiveIndex={saveActiveIndex}
                     />
                 </div>
@@ -334,7 +334,7 @@ const DataExplorationScreen = () => {
                     </p>
 
                     <InfoButton
-                        route="data-category-info"
+                        route="/data-category-info"
                         saveActiveIndex={saveActiveIndex}
                         stateChange={{
                             explorationState: {
@@ -368,7 +368,7 @@ const DataExplorationScreen = () => {
                         {i18n.t("common:source")}: polyPedia
                     </p>
                     <InfoButton
-                        route="data-correlation-info"
+                        route="/data-correlation-info"
                         saveActiveIndex={saveActiveIndex}
                     />
                 </div>
@@ -396,7 +396,7 @@ const DataExplorationScreen = () => {
                     </p>
 
                     <InfoButton
-                        route="data-correlation-info"
+                        route="/data-correlation-info"
                         saveActiveIndex={saveActiveIndex}
                     />
                 </div>
@@ -435,7 +435,7 @@ const DataExplorationScreen = () => {
                     </p>
 
                     <InfoButton
-                        route="companies-info"
+                        route="/companies-info"
                         saveActiveIndex={saveActiveIndex}
                     />
                 </div>
@@ -464,7 +464,7 @@ const DataExplorationScreen = () => {
                         {i18n.t("common:source")}: polyPedia
                     </p>
                     <InfoButton
-                        route="companies-info"
+                        route="/companies-info"
                         saveActiveIndex={saveActiveIndex}
                     />
                 </div>
@@ -507,7 +507,7 @@ const DataExplorationScreen = () => {
                     </p>
 
                     <InfoButton
-                        route="companies-info"
+                        route="/companies-info"
                         saveActiveIndex={saveActiveIndex}
                     />
                 </div>

--- a/features/polyExplorer/src/screens/dataExploration/dataExploration.jsx
+++ b/features/polyExplorer/src/screens/dataExploration/dataExploration.jsx
@@ -306,10 +306,6 @@ const DataExplorationScreen = () => {
                     <p className="bubble-source">
                         {i18n.t("common:source")}: polyPedia
                     </p>
-                    <InfoButton
-                        route="/data-types-info"
-                        saveActiveIndex={saveActiveIndex}
-                    />
                 </div>
             );
         else if (activeScreen.startsWith("dataTypesCategory"))
@@ -367,10 +363,6 @@ const DataExplorationScreen = () => {
                     <p className="bubble-source">
                         {i18n.t("common:source")}: polyPedia
                     </p>
-                    <InfoButton
-                        route="/data-correlation-info"
-                        saveActiveIndex={saveActiveIndex}
-                    />
                 </div>
             );
         else if (activeScreen === "dataTypesCorrelation")
@@ -463,10 +455,6 @@ const DataExplorationScreen = () => {
                     <p className="bubble-source">
                         {i18n.t("common:source")}: polyPedia
                     </p>
-                    <InfoButton
-                        route="/companies-info"
-                        saveActiveIndex={saveActiveIndex}
-                    />
                 </div>
             );
         else if (

--- a/features/polyExplorer/src/screens/dataRegionInfo/dataRegionInfo.jsx
+++ b/features/polyExplorer/src/screens/dataRegionInfo/dataRegionInfo.jsx
@@ -19,7 +19,7 @@ const DataRegionInfo = ({ onClose }) => {
             <div className="base-info-padding">
                 <div className="legend-container">
                     <div className="jurisdictions-label">
-                        <p>{i18n.t("companyDetailsScreen:jurisdictions")}:</p>
+                        <p>{i18n.t("entityDetailsScreen:jurisdictions")}:</p>
                     </div>
                     <div className="legend">
                         <div>
@@ -56,7 +56,7 @@ const DataRegionInfo = ({ onClose }) => {
             <div className="base-info-padding">
                 <div className="legend-container">
                     <div className="jurisdictions-label">
-                        <p>{i18n.t("companyDetailsScreen:jurisdictions")}:</p>
+                        <p>{i18n.t("entityDetailsScreen:jurisdictions")}:</p>
                     </div>
                     <div className="legend">
                         <div>
@@ -81,7 +81,7 @@ const DataRegionInfo = ({ onClose }) => {
             <div className="base-info-padding">
                 <div className="legend-container">
                     <div className="jurisdictions-label">
-                        <p>{i18n.t("companyDetailsScreen:jurisdictions")}:</p>
+                        <p>{i18n.t("entityDetailsScreen:jurisdictions")}:</p>
                     </div>
                     <div className="legend">
                         <div>
@@ -112,7 +112,7 @@ const DataRegionInfo = ({ onClose }) => {
             <div className="base-info-padding">
                 <div className="legend-container">
                     <div className="jurisdictions-label">
-                        <p>{i18n.t("companyDetailsScreen:jurisdictions")}:</p>
+                        <p>{i18n.t("entityDetailsScreen:jurisdictions")}:</p>
                     </div>
                     <div className="legend">
                         <div>
@@ -134,7 +134,7 @@ const DataRegionInfo = ({ onClose }) => {
             <div className="base-info-padding">
                 <div className="legend-container">
                     <div className="jurisdictions-label">
-                        <p>{i18n.t("companyDetailsScreen:jurisdictions")}:</p>
+                        <p>{i18n.t("entityDetailsScreen:jurisdictions")}:</p>
                     </div>
                     <div className="legend">
                         <div>
@@ -156,7 +156,7 @@ const DataRegionInfo = ({ onClose }) => {
             <div className="base-info-padding">
                 <div className="legend-container">
                     <div className="jurisdictions-label">
-                        <p>{i18n.t("companyDetailsScreen:jurisdictions")}:</p>
+                        <p>{i18n.t("entityDetailsScreen:jurisdictions")}:</p>
                     </div>
                     <div className="legend">
                         <div>

--- a/features/polyExplorer/src/screens/explorationInfo/categoryInfo/categoryInfo.jsx
+++ b/features/polyExplorer/src/screens/explorationInfo/categoryInfo/categoryInfo.jsx
@@ -12,6 +12,8 @@ const CategoryInfo = () => {
         useContext(ExplorerContext);
     const entity = selectedEntityObject;
     const activeCategory = navigationState.explorationState.category;
+    const capitalizeCountryCode = i18n.t("common:country.code").toUpperCase();
+    const description = "Description_" + capitalizeCountryCode;
 
     return (
         <BaseInfoScreen
@@ -19,15 +21,13 @@ const CategoryInfo = () => {
             headline={i18n.t("explorationCategoryInfoScreen:headline")}
         >
             <div className="base-info-padding">
-                {/* <p>
+                <p>
                     {
                         globals.polypoly_parent_categories[activeCategory][
-                            i18n.t(
-                                "dataExplorationScreen:from.polyPedia.description"
-                            )
+                            description
                         ]
                     }
-                </p> */}
+                </p>
                 <Infographic
                     type="category"
                     texts={{

--- a/features/polyExplorer/src/screens/explorationInfo/categoryInfo/categoryInfo.jsx
+++ b/features/polyExplorer/src/screens/explorationInfo/categoryInfo/categoryInfo.jsx
@@ -8,9 +8,9 @@ import Infographic from "../../../components/infographic/infographic.jsx";
 import { ExplorerContext } from "../../../context/explorer-context.jsx";
 
 const CategoryInfo = () => {
-    const { selectedCompanyObject, navigationState } =
+    const { selectedEntityObject, navigationState } =
         useContext(ExplorerContext);
-    const company = selectedCompanyObject;
+    const entity = selectedEntityObject;
     const activeCategory = navigationState.explorationState.category;
 
     return (
@@ -19,7 +19,7 @@ const CategoryInfo = () => {
             headline={i18n.t("explorationCategoryInfoScreen:headline")}
         >
             <div className="base-info-padding">
-                <p>
+                {/* <p>
                     {
                         globals.polypoly_parent_categories[activeCategory][
                             i18n.t(
@@ -27,7 +27,7 @@ const CategoryInfo = () => {
                             )
                         ]
                     }
-                </p>
+                </p> */}
                 <Infographic
                     type="category"
                     texts={{
@@ -36,7 +36,7 @@ const CategoryInfo = () => {
                         text3: i18n.t("infographic:category.text3"),
                     }}
                 />
-                {highlights[company.ppid].dataTypeCategories[activeCategory]
+                {highlights[entity.ppid].dataTypeCategories[activeCategory]
                     .explanation ? (
                     <div>
                         <h2>
@@ -44,7 +44,7 @@ const CategoryInfo = () => {
                         </h2>
                         <p>
                             {
-                                highlights[company.ppid].dataTypeCategories[
+                                highlights[entity.ppid].dataTypeCategories[
                                     activeCategory
                                 ].explanation[i18n.t("common:country.code")]
                             }

--- a/features/polyExplorer/src/screens/explorationInfo/correlationInfo/correlationInfo.jsx
+++ b/features/polyExplorer/src/screens/explorationInfo/correlationInfo/correlationInfo.jsx
@@ -7,8 +7,8 @@ import Infographic from "../../../components/infographic/infographic.jsx";
 import { ExplorerContext } from "../../../context/explorer-context.jsx";
 
 const CorrelationInfo = () => {
-    const { selectedCompanyObject } = useContext(ExplorerContext);
-    const company = selectedCompanyObject;
+    const { selectedEntityObject } = useContext(ExplorerContext);
+    const entity = selectedEntityObject;
     return (
         <BaseInfoScreen
             className="correlation-info"
@@ -26,8 +26,9 @@ const CorrelationInfo = () => {
                 />
                 <p>
                     {
-                        highlights[company.ppid].dataTypeCorrelation
-                            .explanation[i18n.t("common:country.code")]
+                        highlights[entity.ppid].dataTypeCorrelation.explanation[
+                            i18n.t("common:country.code")
+                        ]
                     }
                 </p>
             </div>

--- a/features/polyExplorer/src/screens/explorationInfo/jurisdictionInfo/jurisdictionInfo.jsx
+++ b/features/polyExplorer/src/screens/explorationInfo/jurisdictionInfo/jurisdictionInfo.jsx
@@ -60,7 +60,7 @@ const JurisdictionInfo = ({ onClose }) => {
             <div className="base-info-padding">
                 <div className="legend-container">
                     <div className="jurisdictions-label">
-                        <p>{i18n.t("companyDetailsScreen:jurisdictions")}:</p>
+                        <p>{i18n.t("entityDetailsScreen:jurisdictions")}:</p>
                     </div>
                     <div className="legend fixed-graphic">
                         <div>
@@ -103,7 +103,7 @@ const JurisdictionInfo = ({ onClose }) => {
             <div className="base-info-padding">
                 <div className="legend-container">
                     <div className="jurisdictions-label">
-                        <p>{i18n.t("companyDetailsScreen:jurisdictions")}:</p>
+                        <p>{i18n.t("entityDetailsScreen:jurisdictions")}:</p>
                     </div>
                     <div className="legend">
                         <div>
@@ -129,7 +129,7 @@ const JurisdictionInfo = ({ onClose }) => {
             <div className="base-info-padding">
                 <div className="legend-container">
                     <div className="jurisdictions-label">
-                        <p>{i18n.t("companyDetailsScreen:jurisdictions")}:</p>
+                        <p>{i18n.t("entityDetailsScreen:jurisdictions")}:</p>
                     </div>
                     <div className="legend">
                         <div>
@@ -160,7 +160,7 @@ const JurisdictionInfo = ({ onClose }) => {
             <div className="base-info-padding">
                 <div className="legend-container">
                     <div className="jurisdictions-label">
-                        <p>{i18n.t("companyDetailsScreen:jurisdictions")}:</p>
+                        <p>{i18n.t("entityDetailsScreen:jurisdictions")}:</p>
                     </div>
                     <div className="legend">
                         <div>
@@ -182,7 +182,7 @@ const JurisdictionInfo = ({ onClose }) => {
             <div className="base-info-padding">
                 <div className="legend-container">
                     <div className="jurisdictions-label">
-                        <p>{i18n.t("companyDetailsScreen:jurisdictions")}:</p>
+                        <p>{i18n.t("entityDetailsScreen:jurisdictions")}:</p>
                     </div>
                     <div className="legend">
                         <div>
@@ -204,7 +204,7 @@ const JurisdictionInfo = ({ onClose }) => {
             <div className="base-info-padding">
                 <div className="legend-container">
                     <div className="jurisdictions-label">
-                        <p>{i18n.t("companyDetailsScreen:jurisdictions")}:</p>
+                        <p>{i18n.t("entityDetailsScreen:jurisdictions")}:</p>
                     </div>
                     <div className="legend">
                         <div>


### PR DESCRIPTION
I have taken a look at all the bugs in the **PROD4POD-951** ticket and I have fixed some of the sub-tickets (bugs) in it:

- **PROD4POD-655/Uncontrolled on "how to read" button** (and **PROD4POD-619/Info Button (?) not working in Data Story tab**, both tickets were pointing at the same issue).

- **PROD4POD-618/Info Button (?) not working in Exploration screens**

- **PROD4POD-550/CategoryInfo intro screen -> where does info button lead?** - HTRT button removed from transition screens (screens with only text) in the Exploration screens