### PR TITLE
Partially import posts

### DIFF
--- a/features/facebookImport/src/model/analyses/ministories/activities-analysis.js
+++ b/features/facebookImport/src/model/analyses/ministories/activities-analysis.js
@@ -25,6 +25,7 @@ export default class ActivitiesAnalysis extends RootAnalysis {
             ...facebookAccount.searches,
             ...facebookAccount.unfollowedPages,
             ...facebookAccount.postReactions,
+            ...facebookAccount.posts,
         ].map((each) => new Date(each.timestamp * 1000));
 
         //for nested structures

--- a/features/facebookImport/src/model/entities/facebook-account.js
+++ b/features/facebookImport/src/model/entities/facebook-account.js
@@ -248,6 +248,10 @@ class FacebookAccount {
         return this._posts;
     }
 
+    addPosts(newPosts) {
+        this.posts.push(...newPosts);
+    }
+
     get dataGroups() {
         return [
             {

--- a/features/facebookImport/src/model/entities/facebook-account.js
+++ b/features/facebookImport/src/model/entities/facebook-account.js
@@ -248,10 +248,6 @@ class FacebookAccount {
         return this._posts;
     }
 
-    set posts(posts) {
-        this._posts = posts;
-    }
-
     get dataGroups() {
         return [
             {

--- a/features/facebookImport/src/model/entities/facebook-account.js
+++ b/features/facebookImport/src/model/entities/facebook-account.js
@@ -23,6 +23,7 @@ class FacebookAccount {
         this._adminRecords = [];
         this._accountSessionActivities = [];
         this._postReactions = [];
+        this._posts = [];
 
         this._messageThreadsGroup = new MessageThreadsGroup();
         this._relatedAccounts = new RelatedAccountsGroup();
@@ -243,6 +244,14 @@ class FacebookAccount {
         this._postReactions = postReactions;
     }
 
+    get posts() {
+        return this._posts;
+    }
+
+    set posts(posts) {
+        this._posts = posts;
+    }
+
     get dataGroups() {
         return [
             {
@@ -317,6 +326,11 @@ class FacebookAccount {
             {
                 title: "Reactions",
                 count: this.postReactions.length,
+            },
+
+            {
+                title: "Posts",
+                count: this.posts.length,
             },
         ];
     }

--- a/features/facebookImport/src/model/importer.js
+++ b/features/facebookImport/src/model/importer.js
@@ -24,6 +24,7 @@ import {
 import LanguageAndLocaleImporter from "./importers/language-and-locale-importer.js";
 import RecentlyViewedAdsImporter from "./importers/recently-viewed-ads-importer.js";
 import PostReactionsImporter from "./importers/post-reactions-importer.js";
+import PostsImporter from "./importers/posts-importer.js";
 
 const dataImporters = [
     AdInterestsImporter,
@@ -44,6 +45,7 @@ const dataImporters = [
     LanguageAndLocaleImporter,
     RecentlyViewedAdsImporter,
     PostReactionsImporter,
+    PostsImporter,
 ];
 
 export async function runImporter(

--- a/features/facebookImport/src/model/importers/messages-importer.js
+++ b/features/facebookImport/src/model/importers/messages-importer.js
@@ -1,84 +1,22 @@
+import MultipleFilesImporter from "./multiple-files-importer.js";
 import { MissingMessagesFilesException } from "./utils/failed-import-exception.js";
-import { createErrorResult, IMPORT_SUCCESS } from "./utils/importer-status.js";
-import {
-    readFullPathJSONFile,
-    relevantZipEntries,
-    removeEntryPrefix,
-    sliceIntoChunks,
-} from "./utils/importer-util.js";
+import { removeEntryPrefix } from "./utils/importer-util.js";
 
-export default class MessagesImporter {
-    _isJsonMessageFile(entryName) {
+export default class MessagesImporter extends MultipleFilesImporter {
+    _isTargetPostFile(entryName) {
         const formattedEntryName = removeEntryPrefix(entryName);
         return /messages\/(inbox|legacy_threads|message_requests|filtered_threads|archived_threads)\/[0-9_a-z]+\/message_[1-9][0-9]?.json$/.test(
             formattedEntryName
         );
     }
 
-    async _extractJsonEntries(zipFile) {
-        const entries = await relevantZipEntries(zipFile);
-        return entries.filter((fileName) => this._isJsonMessageFile(fileName));
-    }
-
-    async _readJSONFileWithStatus(messageFile, zipFile) {
-        return readFullPathJSONFile(messageFile, zipFile)
-            .then((data) => {
-                return { status: IMPORT_SUCCESS, messageFile, data };
-            })
-            .catch((error) => {
-                return createErrorResult(MessagesImporter, error);
-            });
-    }
-
-    _importMessageThread(facebookAccount, messageThreadResults) {
-        const successfullResults = messageThreadResults.filter(
-            (result) => result.status === IMPORT_SUCCESS
-        );
-
-        for (const each of successfullResults) {
-            const fileName = removeEntryPrefix(each.messageFile);
-            facebookAccount.addImportedFileName(fileName);
-        }
+    _importRawDataResults(facebookAccount, dataResults) {
         facebookAccount.messageThreadsGroup.addMessageThreadsFromData(
-            successfullResults.map((result) => result.data)
+            dataResults
         );
     }
 
-    async _importMessageThreadsFromFiles(
-        messageThreadFiles,
-        zipFile,
-        facebookAccount
-    ) {
-        const messageThreadResults = await Promise.all(
-            messageThreadFiles.map((messageFile) =>
-                this._readJSONFileWithStatus(messageFile, zipFile)
-            )
-        );
-        this._importMessageThread(facebookAccount, messageThreadResults);
-        return messageThreadResults.filter(
-            (result) => !(result.status === IMPORT_SUCCESS)
-        );
-    }
-
-    async import({ zipFile, facebookAccount }) {
-        const messageThreadFiles = await this._extractJsonEntries(zipFile);
-        if (messageThreadFiles.length === 0) {
-            throw new MissingMessagesFilesException();
-        }
-        // TODO: The same message thread can be in multiple files
-        const fileChunks = sliceIntoChunks(messageThreadFiles, 5);
-        const resultChunks = [];
-        for (let currentChunk of fileChunks) {
-            const resultChunk = await this._importMessageThreadsFromFiles(
-                currentChunk,
-                zipFile,
-                facebookAccount
-            );
-
-            resultChunks.push(resultChunk);
-        }
-        const failedResults = resultChunks.flat();
-
-        return failedResults.length > 0 ? failedResults : null;
+    _createMissingFilesError() {
+        return new MissingMessagesFilesException();
     }
 }

--- a/features/facebookImport/src/model/importers/messages-importer.js
+++ b/features/facebookImport/src/model/importers/messages-importer.js
@@ -1,5 +1,4 @@
 import MultipleFilesImporter from "./multiple-files-importer.js";
-import { MissingMessagesFilesException } from "./utils/failed-import-exception.js";
 import { removeEntryPrefix } from "./utils/importer-util.js";
 
 export default class MessagesImporter extends MultipleFilesImporter {
@@ -14,9 +13,5 @@ export default class MessagesImporter extends MultipleFilesImporter {
         facebookAccount.messageThreadsGroup.addMessageThreadsFromData(
             dataResults
         );
-    }
-
-    _createMissingFilesError() {
-        return new MissingMessagesFilesException();
     }
 }

--- a/features/facebookImport/src/model/importers/multiple-files-importer.js
+++ b/features/facebookImport/src/model/importers/multiple-files-importer.js
@@ -1,3 +1,4 @@
+import { MissingFilesException } from "./utils/failed-import-exception";
 import { createErrorResult, IMPORT_SUCCESS } from "./utils/importer-status";
 import {
     readFullPathJSONFile,
@@ -54,7 +55,7 @@ export default class MultipleFilesImporter {
     }
 
     _createMissingFilesError() {
-        return new Error("Missing import files");
+        return new MissingFilesException();
     }
 
     async import({ zipFile, facebookAccount }) {

--- a/features/facebookImport/src/model/importers/multiple-files-importer.js
+++ b/features/facebookImport/src/model/importers/multiple-files-importer.js
@@ -1,0 +1,81 @@
+import { createErrorResult, IMPORT_SUCCESS } from "./utils/importer-status";
+import {
+    readFullPathJSONFile,
+    relevantZipEntries,
+    removeEntryPrefix,
+    sliceIntoChunks,
+} from "./utils/importer-util";
+
+export default class MultipleFilesImporter {
+    // eslint-disable-next-line no-unused-vars
+    _isTargetPostFile(entryName) {
+        return false;
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    _importRawDataResults(facebookAccount, dataResults) {}
+
+    async _extractTargetEntries(zipFile) {
+        const entries = await relevantZipEntries(zipFile);
+        return entries.filter((fileName) => this._isTargetPostFile(fileName));
+    }
+
+    async _readJSONFileWithStatus(targetFile, zipFile) {
+        return readFullPathJSONFile(targetFile, zipFile)
+            .then((data) => {
+                return { status: IMPORT_SUCCESS, targetFile, data };
+            })
+            .catch((error) => {
+                return createErrorResult(this.constructor, error);
+            });
+    }
+
+    async _importDataFromFiles(targetFiles, zipFile, facebookAccount) {
+        const fileDataWithResults = await Promise.all(
+            targetFiles.map((targetFile) =>
+                this._readJSONFileWithStatus(targetFile, zipFile)
+            )
+        );
+
+        const successfullResults = fileDataWithResults.filter(
+            (result) => result.status === IMPORT_SUCCESS
+        );
+
+        for (const each of successfullResults) {
+            const fileName = removeEntryPrefix(each.targetFile);
+            facebookAccount.addImportedFileName(fileName);
+        }
+        const dataResults = successfullResults.map((result) => result.data);
+        this._importRawDataResults(facebookAccount, dataResults);
+
+        return fileDataWithResults.filter(
+            (result) => !(result.status === IMPORT_SUCCESS)
+        );
+    }
+
+    _createMissingFilesError() {
+        return new Error("Missing import files");
+    }
+
+    async import({ zipFile, facebookAccount }) {
+        const targetFiles = await this._extractTargetEntries(zipFile);
+        if (targetFiles.length === 0) {
+            throw this._createMissingFilesError();
+        }
+
+        const fileChunks = sliceIntoChunks(targetFiles, 5);
+        const failedResultChunks = [];
+        for (let currentChunk of fileChunks) {
+            const resultChunk = await this._importDataFromFiles(
+                currentChunk,
+                zipFile,
+                facebookAccount
+            );
+
+            failedResultChunks.push(resultChunk);
+        }
+        const failedResults = failedResultChunks.flat();
+
+        return failedResults.length > 0 ? failedResults : null;
+    }
+}

--- a/features/facebookImport/src/model/importers/posts-importer.js
+++ b/features/facebookImport/src/model/importers/posts-importer.js
@@ -1,0 +1,23 @@
+import MultipleFilesImporter from "./multiple-files-importer";
+import { MissingPostFilesException } from "./utils/failed-import-exception";
+import { removeEntryPrefix } from "./utils/importer-util";
+
+export default class PostsImporter extends MultipleFilesImporter {
+    _isTargetPostFile(entryName) {
+        const formattedEntryName = removeEntryPrefix(entryName);
+        return /posts\/your_posts_[1-9][0-9]?.json$/.test(formattedEntryName);
+    }
+
+    _importRawDataResults(facebookAccount, dataResults) {
+        dataResults.forEach((rawPosts) => {
+            const postsWithTimestamp = rawPosts.map((postData) => {
+                return { timestamp: postData.timestamp };
+            });
+            facebookAccount.posts.push(...postsWithTimestamp);
+        });
+    }
+
+    _createMissingFilesError() {
+        return new MissingPostFilesException();
+    }
+}

--- a/features/facebookImport/src/model/importers/posts-importer.js
+++ b/features/facebookImport/src/model/importers/posts-importer.js
@@ -1,5 +1,4 @@
 import MultipleFilesImporter from "./multiple-files-importer";
-import { MissingPostFilesException } from "./utils/failed-import-exception";
 import { removeEntryPrefix } from "./utils/importer-util";
 
 export default class PostsImporter extends MultipleFilesImporter {
@@ -15,9 +14,5 @@ export default class PostsImporter extends MultipleFilesImporter {
             });
             facebookAccount.addPosts(postsWithTimestamp);
         });
-    }
-
-    _createMissingFilesError() {
-        return new MissingPostFilesException();
     }
 }

--- a/features/facebookImport/src/model/importers/posts-importer.js
+++ b/features/facebookImport/src/model/importers/posts-importer.js
@@ -13,7 +13,7 @@ export default class PostsImporter extends MultipleFilesImporter {
             const postsWithTimestamp = rawPosts.map((postData) => {
                 return { timestamp: postData.timestamp };
             });
-            facebookAccount.posts.push(...postsWithTimestamp);
+            facebookAccount.addPosts(postsWithTimestamp);
         });
     }
 

--- a/features/facebookImport/src/model/importers/utils/failed-import-exception.js
+++ b/features/facebookImport/src/model/importers/utils/failed-import-exception.js
@@ -34,16 +34,9 @@ export class FileTooLargeException extends FailedFileImportException {
     }
 }
 
-export class MissingMessagesFilesException extends Error {
+export class MissingFilesException extends Error {
     constructor(message) {
         super(message);
-        this.name = "MissingMessagesFilesException";
-    }
-}
-
-export class MissingPostFilesException extends Error {
-    constructor(message) {
-        super(message);
-        this.name = "MissingPostFilesException";
+        this.name = "MissingFilesException";
     }
 }

--- a/features/facebookImport/src/model/importers/utils/failed-import-exception.js
+++ b/features/facebookImport/src/model/importers/utils/failed-import-exception.js
@@ -40,3 +40,10 @@ export class MissingMessagesFilesException extends Error {
         this.name = "MissingMessagesFilesException";
     }
 }
+
+export class MissingPostFilesException extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "MissingPostFilesException";
+    }
+}

--- a/features/facebookImport/test/datasets/posts-data.js
+++ b/features/facebookImport/test/datasets/posts-data.js
@@ -22,22 +22,15 @@ function createPostEntry(timestamp, postText = "Lorem Ipsum") {
 }
 
 export function createPostsOneDataset() {
-    return [
-        createPostEntry(1624458721),
-        createPostEntry(1624481575),
-        createPostEntry(1624595792),
-        createPostEntry(1626976792),
-        createPostEntry(1627001733),
-    ];
+    return [1624458721, 1624481575, 1624595792, 1626976792, 1627001733].map(
+        (timestamp) => createPostEntry(timestamp)
+    );
 }
 
 export function createPostsTwoDataset() {
-    return [
-        createPostEntry(1621560294),
-        createPostEntry(1621585743),
-        createPostEntry(1621604231),
-        createPostEntry(1621632401),
-    ];
+    return [1621560294, 1621585743, 1621604231, 1621632401].map((timestamp) =>
+        createPostEntry(timestamp)
+    );
 }
 
 export function zipFileWithTwoPostsFiles() {

--- a/features/facebookImport/test/datasets/posts-data.js
+++ b/features/facebookImport/test/datasets/posts-data.js
@@ -1,0 +1,62 @@
+import { createMockedZip } from "../utils/data-creation";
+
+const POSTS_FILE_PATH = "posts/your_posts_X.json";
+
+export const DATASET_ONE_EXPECTED_VALUES = {
+    numberOfPosts: 5,
+};
+
+export const DATASET_TWO_EXPECTED_VALUES = {
+    numberOfPosts: 4,
+};
+
+function createPostEntry(timestamp, postText = "Lorem Ipsum") {
+    return {
+        timestamp,
+        data: [
+            {
+                post: postText,
+            },
+        ],
+    };
+}
+
+export function createPostsOneDataset() {
+    return [
+        createPostEntry(1624458721),
+        createPostEntry(1624481575),
+        createPostEntry(1624595792),
+        createPostEntry(1626976792),
+        createPostEntry(1627001733),
+    ];
+}
+
+export function createPostsTwoDataset() {
+    return [
+        createPostEntry(1621560294),
+        createPostEntry(1621585743),
+        createPostEntry(1621604231),
+        createPostEntry(1621632401),
+    ];
+}
+
+export function zipFileWithTwoPostsFiles() {
+    return createMockedZip([
+        [POSTS_FILE_PATH.replace("X", "1"), createPostsOneDataset()],
+        [POSTS_FILE_PATH.replace("X", "2"), createPostsTwoDataset()],
+    ]);
+}
+
+export function zipFileWithOnePostsFiles() {
+    return createMockedZip([
+        [POSTS_FILE_PATH.replace("X", "1"), createPostsOneDataset()],
+    ]);
+}
+
+export function zipFileWithFileError() {
+    let zipFile = createMockedZip([
+        [POSTS_FILE_PATH.replace("X", "1"), createPostsOneDataset()],
+    ]);
+    zipFile.addTextEntry(POSTS_FILE_PATH.replace("X", "2"), "[");
+    return zipFile;
+}

--- a/features/facebookImport/test/importers/messages-importer.test.js
+++ b/features/facebookImport/test/importers/messages-importer.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { MissingMessagesFilesException } from "../../src/model/importers/utils/failed-import-exception.js";
+import { MissingFilesException } from "../../src/model/importers/utils/failed-import-exception.js";
 import {
     DATASET_EXPECTED_VALUES,
     zipFileWithMessageThreads,
@@ -21,7 +21,7 @@ describe("Import messages from empty export", () => {
     it("triggers missing files error", async () => {
         const { result } = await runMessagesImporter(zipFile);
 
-        expectError(result, MissingMessagesFilesException);
+        expectError(result, MissingFilesException);
     });
 });
 

--- a/features/facebookImport/test/importers/posts-importer.test.js
+++ b/features/facebookImport/test/importers/posts-importer.test.js
@@ -1,0 +1,90 @@
+import PostsImporter from "../../src/model/importers/posts-importer";
+import { MissingPostFilesException } from "../../src/model/importers/utils/failed-import-exception";
+import {
+    DATASET_ONE_EXPECTED_VALUES,
+    DATASET_TWO_EXPECTED_VALUES,
+    zipFileWithFileError,
+    zipFileWithOnePostsFiles,
+    zipFileWithTwoPostsFiles,
+} from "../datasets/posts-data";
+import { ZipFileMock } from "../mocks/zipfile-mock";
+import { runPostsImporter } from "../utils/data-importing";
+import {
+    expectError,
+    expectImportSuccess,
+    expectSyntaxError,
+} from "../utils/importer-assertions";
+
+describe("Import posts from empty export", () => {
+    let zipFile = null;
+    beforeAll(() => {
+        zipFile = new ZipFileMock();
+    });
+
+    it("triggers missing files error", async () => {
+        const { result } = await runPostsImporter(zipFile);
+        expectError(result, MissingPostFilesException);
+    });
+});
+
+describe("Import searches from export with file error", () => {
+    let result = null;
+    let facebookAccount = null;
+
+    beforeAll(async () => {
+        const zipFile = zipFileWithFileError();
+        ({ result, facebookAccount } = await runPostsImporter(zipFile));
+    });
+
+    it("has one error status", async () => {
+        expect(result.length).toBe(1);
+    });
+
+    it("triggers syntax error", async () => {
+        expectSyntaxError(result[0]);
+    });
+
+    it("has correct importer class", async () => {
+        expect(result[0].importerClass).toBe(PostsImporter);
+    });
+
+    it("has correct number of entities from file one", () =>
+        expect(facebookAccount.posts.length).toBe(
+            DATASET_ONE_EXPECTED_VALUES.numberOfPosts
+        ));
+});
+
+describe("Import posts from export with one file", () => {
+    let result = null;
+    let facebookAccount = null;
+
+    beforeAll(async () => {
+        const zipFile = zipFileWithOnePostsFiles();
+        ({ result, facebookAccount } = await runPostsImporter(zipFile));
+    });
+
+    it("returns success status", () => expectImportSuccess(result));
+
+    it("has correct number of entities", () =>
+        expect(facebookAccount.posts.length).toBe(
+            DATASET_ONE_EXPECTED_VALUES.numberOfPosts
+        ));
+});
+
+describe("Import posts from export with two files", () => {
+    let result = null;
+    let facebookAccount = null;
+
+    beforeAll(async () => {
+        const zipFile = zipFileWithTwoPostsFiles();
+        ({ result, facebookAccount } = await runPostsImporter(zipFile));
+    });
+
+    it("returns success status", () => expectImportSuccess(result));
+
+    it("has correct number of entities", () =>
+        expect(facebookAccount.posts.length).toBe(
+            DATASET_ONE_EXPECTED_VALUES.numberOfPosts +
+                DATASET_TWO_EXPECTED_VALUES.numberOfPosts
+        ));
+});

--- a/features/facebookImport/test/importers/posts-importer.test.js
+++ b/features/facebookImport/test/importers/posts-importer.test.js
@@ -1,5 +1,5 @@
 import PostsImporter from "../../src/model/importers/posts-importer";
-import { MissingPostFilesException } from "../../src/model/importers/utils/failed-import-exception";
+import { MissingFilesException } from "../../src/model/importers/utils/failed-import-exception";
 import {
     DATASET_ONE_EXPECTED_VALUES,
     DATASET_TWO_EXPECTED_VALUES,
@@ -23,7 +23,7 @@ describe("Import posts from empty export", () => {
 
     it("triggers missing files error", async () => {
         const { result } = await runPostsImporter(zipFile);
-        expectError(result, MissingPostFilesException);
+        expectError(result, MissingFilesException);
     });
 });
 

--- a/features/facebookImport/test/mocks/zipfile-mock.js
+++ b/features/facebookImport/test/mocks/zipfile-mock.js
@@ -46,9 +46,18 @@ export class ZipFileMock {
         this._entries[this.id + "/" + fileName] = stringContent;
     }
 
-    addJsonEntry(fileName, jsonData) {
-        const escapedString = jsonStringifyWithUtfEscape(jsonData);
+    addEncodingEntry(fileName, escapedString) {
         const encoded = new TextEncoder("utf-8").encode(escapedString);
         this.addNamedEntry(fileName, encoded);
+    }
+
+    addTextEntry(fileName, stringContent) {
+        const escapedString = unescape(encodeURIComponent(stringContent));
+        this.addEncodingEntry(fileName, escapedString);
+    }
+
+    addJsonEntry(fileName, jsonData) {
+        const escapedString = jsonStringifyWithUtfEscape(jsonData);
+        this.addEncodingEntry(fileName, escapedString);
     }
 }

--- a/features/facebookImport/test/utils/data-importing.js
+++ b/features/facebookImport/test/utils/data-importing.js
@@ -15,6 +15,7 @@ import ConnectedAdvertisersImporter from "../../src/model/importers/connected-ad
 import SearchesImporter from "../../src/model/importers/searches-importer.js";
 import InteractedWithAdvertisersImporter from "../../src/model/importers/interacted-with-advertisers-importer.js";
 import PostReactionsImporter from "../../src/model/importers/post-reactions-importer.js";
+import PostsImporter from "../../src/model/importers/posts-importer.js";
 
 export async function runMultipleImporters(importerClasses, zipFile) {
     const facebookAccount = new FacebookAccount();
@@ -78,6 +79,10 @@ export async function runInteractedWithAdvertisersImporter(zipFile) {
 
 export async function runPostReactionsImporter(zipFile) {
     return runSingleImporter(PostReactionsImporter, zipFile);
+}
+
+export async function runPostsImporter(zipFile) {
+    return runSingleImporter(PostsImporter, zipFile);
 }
 
 export async function runImportForDataset(importerClass, filePath, dataset) {

--- a/features/facebookImport/test/utils/importer-assertions.js
+++ b/features/facebookImport/test/utils/importer-assertions.js
@@ -22,6 +22,10 @@ export function expectInvalidContentError(result) {
     expectError(result, InvalidContentImportException);
 }
 
+export function expectSyntaxError(result) {
+    expectError(result, SyntaxError);
+}
+
 export function expectImportSuccess(result) {
     expect(result.status).toBe(IMPORT_SUCCESS);
 }


### PR DESCRIPTION
This imports timestamp for posts and adds them to the mini-stories "Structure of your data" and "Your activities".

Also refactors the messages importer to have a common logic with the posts importers for importing data from multiple files.

<img width="467" alt="Screenshot 2021-11-03 at 15 12 39" src="https://user-images.githubusercontent.com/3534711/140080941-35af7af7-acf5-40c3-bf68-dbe7eb360f5c.png">

