### PR TITLE
Basic tests for the report

### DIFF
--- a/features/facebookImport/src/model/analyses/report/report-metadata.js
+++ b/features/facebookImport/src/model/analyses/report/report-metadata.js
@@ -16,10 +16,10 @@ export default class ReportMetadataAnalysis extends ReportAnalysis {
         };
     }
 
-    async analyze({ size, zipFile, facebookAccount }) {
+    async analyze({ size, zipFile, facebookAccount, pod }) {
         this.active = true;
 
-        const info = await window.pod.info;
+        const info = await pod.info;
         this._polyPodRuntime = await info.getRuntime();
         this._polyPodVersion = await info.getVersion();
 

--- a/features/facebookImport/src/model/analysis.js
+++ b/features/facebookImport/src/model/analysis.js
@@ -112,6 +112,8 @@ const subAnalyses = [
     ].includes(analysis);
 });
 
+export const NUMBER_OF_ANALYSES = subAnalyses.length;
+
 class UnrecognizedData {
     constructor(analysesResults) {
         this._activeReportAnalyses = analysesResults

--- a/features/facebookImport/src/model/analysis.js
+++ b/features/facebookImport/src/model/analysis.js
@@ -217,9 +217,8 @@ export async function runAnalysis(analysisClass, enrichedData) {
     }
 }
 
-export async function analyzeFile(file, facebookAccount) {
-    const zipFile = new ZipFile(file, window.pod);
-    const enrichedData = { ...file, zipFile, facebookAccount };
+export async function analyzeZip(zipData, zipFile, facebookAccount) {
+    const enrichedData = { ...zipData, zipFile, facebookAccount };
     const analysesResults = await Promise.all(
         subAnalyses.map(async (subAnalysisClass) => {
             return runAnalysis(subAnalysisClass, enrichedData);
@@ -237,4 +236,9 @@ export async function analyzeFile(file, facebookAccount) {
         analyses: activeGlobalAnalyses,
         unrecognizedData: new UnrecognizedData(analysesResults),
     };
+}
+
+export async function analyzeFile(zipData, facebookAccount) {
+    const zipFile = new ZipFile(zipData, window.pod);
+    return await analyzeZip(zipData, zipFile, facebookAccount);
 }

--- a/features/facebookImport/src/model/analysis.js
+++ b/features/facebookImport/src/model/analysis.js
@@ -217,8 +217,8 @@ export async function runAnalysis(analysisClass, enrichedData) {
     }
 }
 
-export async function analyzeZip(zipData, zipFile, facebookAccount) {
-    const enrichedData = { ...zipData, zipFile, facebookAccount };
+export async function analyzeZip(zipData, zipFile, facebookAccount, pod) {
+    const enrichedData = { ...zipData, zipFile, facebookAccount, pod };
     const analysesResults = await Promise.all(
         subAnalyses.map(async (subAnalysisClass) => {
             return runAnalysis(subAnalysisClass, enrichedData);
@@ -240,5 +240,5 @@ export async function analyzeZip(zipData, zipFile, facebookAccount) {
 
 export async function analyzeFile(zipData, facebookAccount) {
     const zipFile = new ZipFile(zipData, window.pod);
-    return await analyzeZip(zipData, zipFile, facebookAccount);
+    return await analyzeZip(zipData, zipFile, facebookAccount, window.pod);
 }

--- a/features/facebookImport/src/model/importer.js
+++ b/features/facebookImport/src/model/importer.js
@@ -50,6 +50,8 @@ const dataImporters = [
     PostsImporter,
 ];
 
+export const NUMBER_OF_IMPORTERS = dataImporters.length;
+
 class ImporterExecutionResult {
     constructor(importer, status, executionTime) {
         this._importer = importer;

--- a/features/facebookImport/src/model/importer.js
+++ b/features/facebookImport/src/model/importer.js
@@ -146,5 +146,5 @@ export async function importZip(zipFile, pod) {
 
 export async function importData(zipData) {
     const zipFile = new ZipFile(zipData, window.pod);
-    return importZip(zipFile, zipData, window.pod);
+    return importZip(zipFile, window.pod);
 }

--- a/features/facebookImport/test/ministory/importing-status-analysys.test.js
+++ b/features/facebookImport/test/ministory/importing-status-analysys.test.js
@@ -1,0 +1,40 @@
+import DataImportingStatusAnalysis from "../../src/model/analyses/report/importing-status-analysys";
+import { NUMBER_OF_IMPORTERS } from "../../src/model/importer";
+import { runAnalysisForExport } from "../utils/analyses-execution";
+import {
+    expectActiveAnalysis,
+    expectAnalysisSuccessStatus,
+} from "../utils/analysis-assertions";
+import { createMockedZip } from "../utils/data-creation";
+
+describe("Importing status analysis for empty zip", () => {
+    let analysis = null;
+    let status = null;
+    let jsonReport = null;
+
+    beforeAll(async () => {
+        const zipFile = createMockedZip([]);
+        const { analysisResult } = await runAnalysisForExport(
+            DataImportingStatusAnalysis,
+            zipFile
+        );
+        ({ analysis, status } = analysisResult);
+        jsonReport = analysis.jsonReport;
+    });
+
+    it("has success status", async () => {
+        expectAnalysisSuccessStatus(status);
+    });
+
+    it("is active", async () => {
+        expectActiveAnalysis(analysis);
+    });
+
+    it("has id in JSON report", async () => {
+        expect(jsonReport.id).toBe(DataImportingStatusAnalysis.name);
+    });
+
+    it("has correct number of importers", async () => {
+        expect(jsonReport.data.length).toBe(NUMBER_OF_IMPORTERS);
+    });
+});

--- a/features/facebookImport/test/ministory/ministories-status-analysis.test.js
+++ b/features/facebookImport/test/ministory/ministories-status-analysis.test.js
@@ -4,7 +4,7 @@ import { zipFileWithOffFacebookEvents } from "../datasets/off-facebook-events-da
 import { runAnalysesForZip } from "../utils/analyses-execution";
 import { expectActiveAnalysis } from "../utils/analysis-assertions";
 
-describe("Ministories status analysis for empty zip", () => {
+describe("Ministories status analysis", () => {
     let unrecognizedData = null;
     let ministoriesAnalysis = null;
     let jsonReport = null;

--- a/features/facebookImport/test/ministory/ministories-status-analysis.test.js
+++ b/features/facebookImport/test/ministory/ministories-status-analysis.test.js
@@ -1,0 +1,29 @@
+import MinistoriesStatusAnalysis from "../../src/model/analyses/report/ministories-status-analysis";
+import { NUMBER_OF_ANALYSES } from "../../src/model/analysis";
+import { zipFileWithOffFacebookEvents } from "../datasets/off-facebook-events-data";
+import { runAnalysesForZip } from "../utils/analyses-execution";
+import { expectActiveAnalysis } from "../utils/analysis-assertions";
+
+describe("Ministories status analysis for empty zip", () => {
+    let unrecognizedData = null;
+    let ministoriesAnalysis = null;
+    let jsonReport = null;
+
+    beforeAll(async () => {
+        const zipFile = zipFileWithOffFacebookEvents();
+        ({ unrecognizedData } = await runAnalysesForZip(zipFile));
+
+        ministoriesAnalysis = unrecognizedData.reportAnalyses.find(
+            (each) => each.constructor === MinistoriesStatusAnalysis
+        );
+        jsonReport = ministoriesAnalysis.jsonReport;
+    });
+
+    it("is active", async () => {
+        expectActiveAnalysis(ministoriesAnalysis);
+    });
+
+    it("has correct number of importers", async () => {
+        expect(jsonReport.data.length).toBe(NUMBER_OF_ANALYSES);
+    });
+});

--- a/features/facebookImport/test/ministory/missing-common-json-files.test.js
+++ b/features/facebookImport/test/ministory/missing-common-json-files.test.js
@@ -28,6 +28,19 @@ describe("Missing common JSON files analysis for empty zip", () => {
     it("is active", async () => {
         expectActiveAnalysis(analysis);
     });
+
+    it("has id in JSON report", async () => {
+        expect(analysis.jsonReport.id).toBe(
+            MissingCommonJSONFilesAnalysis.name
+        );
+    });
+
+    it("has all common files in JSON report", async () => {
+        const missingJsonFileNames = commonStructure.filter((each) =>
+            each.endsWith(".json")
+        );
+        expect(analysis.jsonReport.data).toStrictEqual(missingJsonFileNames);
+    });
 });
 
 describe("Missing common JSON files analysis for zip with no missing common files", () => {

--- a/features/facebookImport/test/ministory/report-metadata.test.js
+++ b/features/facebookImport/test/ministory/report-metadata.test.js
@@ -1,0 +1,110 @@
+import ReportMetadataAnalysis from "../../src/model/analyses/report/report-metadata";
+import { INTERACTED_WITH_ADVERTISERS_FILE_PATH } from "../../src/model/importers/interacted-with-advertisers-importer";
+import { LANGUAGE_AND_LOCALE_FILE_PATH } from "../../src/model/importers/language-and-locale-importer";
+import { OFF_FACEBOOK_EVENTS_FILE_PATH } from "../../src/model/importers/off-facebook-events-importer";
+import { createInteractedWithAdvertisersDataset } from "../datasets/interacted-with-advertisers-data";
+import { createLanguageSettingsData } from "../datasets/language-and-locale-data";
+import { createOffFacebookEventsSimpleData } from "../datasets/off-facebook-events-data";
+import {
+    MOCKED_POD_RUNTIME,
+    MOCKED_POD_RUNTIME_VERSION,
+} from "../mocks/pod-mock";
+import { MINIMUM_FILE_SIZE } from "../mocks/zipfile-mock";
+import { runAnalysisForExport } from "../utils/analyses-execution";
+import {
+    expectActiveAnalysis,
+    expectAnalysisSuccessStatus,
+} from "../utils/analysis-assertions";
+import { createMockedZip } from "../utils/data-creation";
+
+describe("Report metadata analysis", () => {
+    const preferedLanguage = {
+        code: "en_US",
+        name: "Selected Language",
+    };
+    let analysis = null;
+    let status = null;
+    let jsonReport = null;
+
+    beforeAll(async () => {
+        // Create a zip with two json files.
+        const zipFile = createMockedZip([
+            [
+                OFF_FACEBOOK_EVENTS_FILE_PATH,
+                createOffFacebookEventsSimpleData(),
+            ],
+            [
+                INTERACTED_WITH_ADVERTISERS_FILE_PATH,
+                createInteractedWithAdvertisersDataset(),
+            ],
+            [
+                LANGUAGE_AND_LOCALE_FILE_PATH,
+                createLanguageSettingsData(
+                    preferedLanguage.code,
+                    "de_DE",
+                    "en"
+                ),
+            ],
+        ]);
+        const { analysisResult } = await runAnalysisForExport(
+            ReportMetadataAnalysis,
+            zipFile
+        );
+        ({ analysis, status } = analysisResult);
+        jsonReport = analysis.jsonReport;
+    });
+
+    it("has success status", async () => {
+        expectAnalysisSuccessStatus(status);
+    });
+
+    it("is active", async () => {
+        expectActiveAnalysis(analysis);
+    });
+
+    it("has id in JSON report", async () => {
+        expect(jsonReport.id).toBe(ReportMetadataAnalysis.name);
+    });
+
+    it("has correct file size in analysis", async () => {
+        expect(analysis._size).toBe(MINIMUM_FILE_SIZE);
+    });
+
+    it("has correct file size in JSON report", async () => {
+        expect(jsonReport.data.fileSize).toBe(MINIMUM_FILE_SIZE);
+    });
+
+    it("has correct files count in analysis", async () => {
+        expect(analysis._filesCount).toBe(3);
+    });
+
+    it("has correct files count in JSON report", async () => {
+        expect(jsonReport.data.filesCount).toBe(3);
+    });
+
+    it("has correct prefered language in analysis", async () => {
+        expect(analysis._preferedLanguage).toStrictEqual(preferedLanguage);
+    });
+
+    it("has correct prefered ,anguage in JSON report", async () => {
+        expect(jsonReport.data.preferedLanguage).toStrictEqual(
+            preferedLanguage
+        );
+    });
+
+    it("has correct polyPod version in analysis", async () => {
+        expect(analysis._polyPodVersion).toBe(MOCKED_POD_RUNTIME_VERSION);
+    });
+
+    it("has correct polyPod version in JSON report", async () => {
+        expect(jsonReport.data.polyPodVersion).toBe(MOCKED_POD_RUNTIME_VERSION);
+    });
+
+    it("has correct polyPod runtime in analysis", async () => {
+        expect(analysis._polyPodRuntime).toBe(MOCKED_POD_RUNTIME);
+    });
+
+    it("has correct polyPod runtime in JSON report", async () => {
+        expect(jsonReport.data.polyPodRuntime).toBe(MOCKED_POD_RUNTIME);
+    });
+});

--- a/features/facebookImport/test/ministory/report-metadata.test.js
+++ b/features/facebookImport/test/ministory/report-metadata.test.js
@@ -27,7 +27,6 @@ describe("Report metadata analysis", () => {
     let jsonReport = null;
 
     beforeAll(async () => {
-        // Create a zip with two json files.
         const zipFile = createMockedZip([
             [
                 OFF_FACEBOOK_EVENTS_FILE_PATH,

--- a/features/facebookImport/test/ministory/unknown-top-level-folders-analysis.test.js
+++ b/features/facebookImport/test/ministory/unknown-top-level-folders-analysis.test.js
@@ -10,7 +10,7 @@ import {
 } from "../utils/analysis-assertions";
 import { createMockedZip } from "../utils/data-creation";
 
-describe("Post reactions analysis for empty zip", () => {
+describe("Unknown top level folders analysis", () => {
     let analysis = null;
     let status = null;
     let jsonReport = null;

--- a/features/facebookImport/test/ministory/unknown-top-level-folders-analysis.test.js
+++ b/features/facebookImport/test/ministory/unknown-top-level-folders-analysis.test.js
@@ -16,7 +16,7 @@ describe("Unknown top level folders analysis", () => {
     let jsonReport = null;
 
     beforeAll(async () => {
-        const zipFile = createMockedZip([
+        let zipFile = createMockedZip([
             [
                 OFF_FACEBOOK_EVENTS_FILE_PATH,
                 createOffFacebookEventsSimpleData(),

--- a/features/facebookImport/test/ministory/unknown-top-level-folders-analysis.test.js
+++ b/features/facebookImport/test/ministory/unknown-top-level-folders-analysis.test.js
@@ -1,0 +1,59 @@
+import UknownTopLevelFoldersAnalysis from "../../src/model/analyses/report/unknown-top-level-folders-analysis";
+import { INTERACTED_WITH_ADVERTISERS_FILE_PATH } from "../../src/model/importers/interacted-with-advertisers-importer";
+import { OFF_FACEBOOK_EVENTS_FILE_PATH } from "../../src/model/importers/off-facebook-events-importer";
+import { createInteractedWithAdvertisersDataset } from "../datasets/interacted-with-advertisers-data";
+import { createOffFacebookEventsSimpleData } from "../datasets/off-facebook-events-data";
+import { runAnalysisForExport } from "../utils/analyses-execution";
+import {
+    expectActiveAnalysis,
+    expectAnalysisSuccessStatus,
+} from "../utils/analysis-assertions";
+import { createMockedZip } from "../utils/data-creation";
+
+describe("Post reactions analysis for empty zip", () => {
+    let analysis = null;
+    let status = null;
+    let jsonReport = null;
+
+    beforeAll(async () => {
+        const zipFile = createMockedZip([
+            [
+                OFF_FACEBOOK_EVENTS_FILE_PATH,
+                createOffFacebookEventsSimpleData(),
+            ],
+            [
+                INTERACTED_WITH_ADVERTISERS_FILE_PATH,
+                createInteractedWithAdvertisersDataset(),
+            ],
+        ]);
+        zipFile.addJsonEntry("unknow_folder/unknown_file.json", '""');
+        zipFile.addJsonEntry("another_unknow_folder/file.json", '""');
+        zipFile.addTextEntry("unknow_folder_with_text/some_file.txt", '""');
+        const { analysisResult } = await runAnalysisForExport(
+            UknownTopLevelFoldersAnalysis,
+            zipFile
+        );
+        ({ analysis, status } = analysisResult);
+        jsonReport = analysis.jsonReport;
+    });
+
+    it("has success status", async () => {
+        expectAnalysisSuccessStatus(status);
+    });
+
+    it("is active", async () => {
+        expectActiveAnalysis(analysis);
+    });
+
+    it("has id in JSON report", async () => {
+        expect(jsonReport.id).toBe(UknownTopLevelFoldersAnalysis.name);
+    });
+
+    it("has correct unknow folders in JSON report", async () => {
+        expect(jsonReport.data).toStrictEqual([
+            "unknow_folder",
+            "another_unknow_folder",
+            "unknow_folder_with_text",
+        ]);
+    });
+});

--- a/features/facebookImport/test/mocks/pod-mock.js
+++ b/features/facebookImport/test/mocks/pod-mock.js
@@ -1,0 +1,15 @@
+class MockerPodInfo {
+    async getRuntime() {
+        return "podjs-mock";
+    }
+
+    async getVersion() {
+        return "podjs-mock-version";
+    }
+}
+
+export class MockerPod {
+    get info() {
+        return new MockerPodInfo();
+    }
+}

--- a/features/facebookImport/test/mocks/pod-mock.js
+++ b/features/facebookImport/test/mocks/pod-mock.js
@@ -1,10 +1,13 @@
+export const MOCKED_POD_RUNTIME = "podjs-mock";
+export const MOCKED_POD_RUNTIME_VERSION = "podjs-mock-version";
+
 class MockerPodInfo {
     async getRuntime() {
-        return "podjs-mock";
+        return MOCKED_POD_RUNTIME;
     }
 
     async getVersion() {
-        return "podjs-mock-version";
+        return MOCKED_POD_RUNTIME_VERSION;
     }
 }
 

--- a/features/facebookImport/test/mocks/zipfile-mock.js
+++ b/features/facebookImport/test/mocks/zipfile-mock.js
@@ -1,11 +1,14 @@
 import { jsonStringifyWithUtfEscape } from "../../src/model/importers/utils/json-encoding";
 
+//The minimum size of a .ZIP file is 22 bytes
+export const MINIMUM_FILE_SIZE = 22;
+
 export class ZipFileMock {
     constructor() {
         this.id = "polypod://de71f571-d90a-45e0-b007-d8f059e0541b";
         this.time = new Date("2021-09-20T16:37:36.243Z");
         this.name = "facebook-facebookuser.zip";
-        this.size = 22; //The minimum size of a .ZIP file is 22 bytes
+        this.size = MINIMUM_FILE_SIZE;
         this._entries = {};
     }
 

--- a/features/facebookImport/test/report-creation.test.js
+++ b/features/facebookImport/test/report-creation.test.js
@@ -1,7 +1,5 @@
-import { analyzeZip } from "../src/model/analysis";
-import { importZip } from "../src/model/importer";
 import { zipFileWithOffFacebookEvents } from "./datasets/off-facebook-events-data";
-import { MockerPod } from "./mocks/pod-mock";
+import { runAnalysesForZip } from "./utils/analyses-execution";
 import { expectActiveAnalysis } from "./utils/analysis-assertions";
 
 export const NUMBER_OF_REPORT_ANALYSES = 8;
@@ -13,13 +11,7 @@ describe("Report creation for empty zip", () => {
     beforeAll(async () => {
         let zipFile = zipFileWithOffFacebookEvents();
         zipFile.addJsonEntry("unknow_folder/unknown_file.json", '""');
-        const facebookAccount = await importZip(zipFile);
-        ({ unrecognizedData } = await analyzeZip(
-            zipFile.enrichedFileData(),
-            zipFile,
-            facebookAccount,
-            new MockerPod()
-        ));
+        ({ unrecognizedData } = await runAnalysesForZip(zipFile));
 
         jsonReport = unrecognizedData.jsonReport;
     });

--- a/features/facebookImport/test/report-creation.test.js
+++ b/features/facebookImport/test/report-creation.test.js
@@ -1,0 +1,42 @@
+import { analyzeZip } from "../src/model/analysis";
+import { importZip } from "../src/model/importer";
+import { zipFileWithOffFacebookEvents } from "./datasets/off-facebook-events-data";
+import { MockerPod } from "./mocks/pod-mock";
+import { expectActiveAnalysis } from "./utils/analysis-assertions";
+
+export const NUMBER_OF_REPORT_ANALYSES = 8;
+
+describe("Report creation for empty zip", () => {
+    let unrecognizedData = null;
+    let jsonReport = null;
+
+    beforeAll(async () => {
+        let zipFile = zipFileWithOffFacebookEvents();
+        zipFile.addJsonEntry("unknow_folder/unknown_file.json", '""');
+        const facebookAccount = await importZip(zipFile);
+        ({ unrecognizedData } = await analyzeZip(
+            zipFile.enrichedFileData(),
+            zipFile,
+            facebookAccount,
+            new MockerPod()
+        ));
+
+        jsonReport = unrecognizedData.jsonReport;
+    });
+
+    it("is report", async () => {
+        expectActiveAnalysis(unrecognizedData);
+    });
+
+    it("has correct number of report analysis", async () => {
+        expect(unrecognizedData.reportAnalyses.length).toBe(
+            NUMBER_OF_REPORT_ANALYSES
+        );
+    });
+
+    it("has correct number of analysis in JSON report", async () => {
+        expect(jsonReport.reportAnalyses_v1.length).toBe(
+            NUMBER_OF_REPORT_ANALYSES
+        );
+    });
+});

--- a/features/facebookImport/test/report-creation.test.js
+++ b/features/facebookImport/test/report-creation.test.js
@@ -4,7 +4,7 @@ import { expectActiveAnalysis } from "./utils/analysis-assertions";
 
 export const NUMBER_OF_REPORT_ANALYSES = 8;
 
-describe("Report creation for empty zip", () => {
+describe("Report creation for export", () => {
     let unrecognizedData = null;
     let jsonReport = null;
 

--- a/features/facebookImport/test/utils/analyses-execution.js
+++ b/features/facebookImport/test/utils/analyses-execution.js
@@ -1,4 +1,4 @@
-import { runAnalysis } from "../../src/model/analysis";
+import { analyzeZip, runAnalysis } from "../../src/model/analysis";
 import { importZip } from "../../src/model/importer";
 import { MockerPod } from "../mocks/pod-mock";
 
@@ -20,4 +20,14 @@ export async function runAnalysisForAccount(
 ) {
     const enrichedData = { facebookAccount, pod };
     return runAnalysis(analysisClass, enrichedData);
+}
+
+export async function runAnalysesForZip(zipFile) {
+    const facebookAccount = await importZip(zipFile);
+    return await analyzeZip(
+        zipFile.enrichedFileData(),
+        zipFile,
+        facebookAccount,
+        new MockerPod()
+    );
 }

--- a/features/facebookImport/test/utils/analyses-execution.js
+++ b/features/facebookImport/test/utils/analyses-execution.js
@@ -1,14 +1,23 @@
 import { runAnalysis } from "../../src/model/analysis";
 import { importZip } from "../../src/model/importer";
+import { MockerPod } from "../mocks/pod-mock";
 
-export async function runAnalysisForExport(analysisClass, zipFile) {
+export async function runAnalysisForExport(
+    analysisClass,
+    zipFile,
+    pod = new MockerPod()
+) {
     const facebookAccount = await importZip(zipFile);
-    const enrichedData = { ...zipFile.enrichedData(), facebookAccount };
+    const enrichedData = { ...zipFile.enrichedData(), facebookAccount, pod };
     const analysisResult = await runAnalysis(analysisClass, enrichedData);
     return { analysisResult, facebookAccount };
 }
 
-export async function runAnalysisForAccount(analysisClass, facebookAccount) {
-    const enrichedData = { facebookAccount };
+export async function runAnalysisForAccount(
+    analysisClass,
+    facebookAccount,
+    pod = new MockerPod()
+) {
+    const enrichedData = { facebookAccount, pod };
     return runAnalysis(analysisClass, enrichedData);
 }


### PR DESCRIPTION
This ads some tests for the report generation:
- injects the pod into the analyze so features do not have to use window.pod (same API as importers)
- adds a MockedPod for testing
- ads an overall test for the report generation
- tests some individual mini-stories from the report