### PR TITLE
Take into account only known reaction types.

### DIFF
--- a/features/facebookImport/src/model/analyses/ministories/post-reactions-types-analysis.js
+++ b/features/facebookImport/src/model/analyses/ministories/post-reactions-types-analysis.js
@@ -5,6 +5,7 @@ import RootAnalysis from "./root-analysis";
 
 import PostReactionTypesMiniStory from "../../../components/postReactionTypesMiniStory/postReactionTypesMiniStory.jsx";
 import i18n from "../../../i18n";
+import { KNOWN_REACTION_TYPES } from "../../importers/post-reactions-importer";
 
 export default class PostReactionsTypesAnalysis extends RootAnalysis {
     get title() {
@@ -16,8 +17,10 @@ export default class PostReactionsTypesAnalysis extends RootAnalysis {
     }
 
     async analyze({ facebookAccount }) {
-        this._reactionsTypeCountPairs =
-            groupPostReactionsByType(facebookAccount);
+        const allReactionsByType = groupPostReactionsByType(facebookAccount);
+        this._reactionsTypeCountPairs = allReactionsByType.filter((each) =>
+            KNOWN_REACTION_TYPES.includes(each.type)
+        );
         this.active = this._reactionsTypeCountPairs.length > 0;
     }
 

--- a/features/facebookImport/src/model/importers/post-reactions-importer.js
+++ b/features/facebookImport/src/model/importers/post-reactions-importer.js
@@ -5,6 +5,16 @@ export const POST_REACTIONS_FILE_PATH =
 export const POST_REACTIONS_DATA_KEY = "reactions_v2";
 export const POST_REACTIONS_STORAGE_KEY = "postReactions";
 
+export const KNOWN_REACTION_TYPES = [
+    "LIKE",
+    "LOVE",
+    "HAHA",
+    "CARE",
+    "WOW",
+    "SAD",
+    "ANGER",
+];
+
 export default class PostReactionsImporter extends DirectKeyDataImporter {
     constructor() {
         super(

--- a/features/facebookImport/test/datasets/post-reactions-data.js
+++ b/features/facebookImport/test/datasets/post-reactions-data.js
@@ -5,7 +5,8 @@ import {
 import { createMockedZip } from "../utils/data-creation";
 
 export const DATASET_EXPECTED_VALUES = {
-    numberOfPostsReactions: 7,
+    numberOfPostsReactions:
+        createPostReactionsDataset()[POST_REACTIONS_DATA_KEY].length,
 };
 
 export function wrapPostReactionsData(data) {

--- a/features/facebookImport/test/datasets/post-reactions-data.js
+++ b/features/facebookImport/test/datasets/post-reactions-data.js
@@ -5,7 +5,7 @@ import {
 import { createMockedZip } from "../utils/data-creation";
 
 export const DATASET_EXPECTED_VALUES = {
-    numberOfPostsReactions: 6,
+    numberOfPostsReactions: 7,
 };
 
 export function wrapPostReactionsData(data) {

--- a/features/facebookImport/test/datasets/post-reactions-data.js
+++ b/features/facebookImport/test/datasets/post-reactions-data.js
@@ -35,6 +35,7 @@ export function createPostReactionsDataset() {
         createPostReaction(1398893265, "SAD", "Donald Duck"),
         createPostReaction(1416949925, "LIKE", "Alice Joe"),
         createPostReaction(1498845994, "WOW", "Jane Doe"),
+        createPostReaction(1598845994, "SORRY", "Jane Doe"),
     ]);
 }
 


### PR DESCRIPTION
Only take into account known reaction types. There seem to be also other types of reactions in the data, for which we do not have icons at the moment. This avoid a crash in the reactions mini-story if there are unknown reactions.

Pair programming with @mteresa-jimenez 