### PR TITLE
Use poly-look.js instead of duplicating the code

### DIFF
--- a/core/utils/poly-look/package.json
+++ b/core/utils/poly-look/package.json
@@ -33,7 +33,6 @@
     "prettier": "^2.2.1",
     "rollup": "^2.48.0",
     "rollup-plugin-css-only": "^3.1.0",
-    "rollup-plugin-svg": "^2.0.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup-plugin-svg": "^2.0.0"
   }
 }

--- a/core/utils/poly-look/rollup.config.js
+++ b/core/utils/poly-look/rollup.config.js
@@ -1,4 +1,3 @@
-import { terser } from "rollup-plugin-terser";
 import resolve from "@rollup/plugin-node-resolve";
 import svg from "rollup-plugin-svg";
 import sucrase from "@rollup/plugin-sucrase";
@@ -23,15 +22,6 @@ export default {
       production: true,
     }),
     resolve(),
-    terser({
-      module: true,
-      warnings: true,
-      mangle: {
-        properties: {
-          regex: /^__/,
-        },
-      },
-    }),
   ],
   external: ["react", "react-dom"],
   onwarn: (warning) => {

--- a/features/facebookImport/rollup.config.js
+++ b/features/facebookImport/rollup.config.js
@@ -10,16 +10,20 @@ import svg from "rollup-plugin-svg";
 
 const fallbackURL = "http://localhost:8000";
 const fallbackAuthorization = "username:password";
+
+const externalPackages = {
+    "@polypoly-eu/poly-look": "polyLook",
+    react: "React",
+    "react-dom": "ReactDOM",
+};
+
 export default (commandLineArgs) => {
     return {
         input: "src/facebookImporter.jsx",
         output: {
             file: "dist/facebook-import.js",
             format: "iife",
-            globals: {
-                react: "React",
-                "react-dom": "ReactDOM",
-            },
+            globals: externalPackages,
         },
         plugins: [
             svg(),
@@ -74,7 +78,7 @@ export default (commandLineArgs) => {
             }),
             commandLineArgs.configServe ? serve("dist") : null,
         ],
-        external: ["react", "react-dom"],
+        external: Object.keys(externalPackages),
         onwarn: (warning) => {
             // overwite the default warning function
             if (


### PR DESCRIPTION
I disabled the Rollup plugin we used for minification in polyLook for
now. We'd have to configure it properly so that it ends up exporting all
the necessary global symbols, and currently we win more by having things
easy to debug anyway.