### PR TITLE
PROD4POD-913 - Add thumbnailColor to feature manifests

### DIFF
--- a/android/app/src/main/kotlin/coop/polypoly/polypod/FeatureCardAdapter.kt
+++ b/android/app/src/main/kotlin/coop/polypoly/polypod/FeatureCardAdapter.kt
@@ -36,7 +36,7 @@ class FeatureCardAdapter(
 
     private fun updateThumbnail(view: View, feature: Feature) {
         val thumbnail = view.findViewById<ImageView>(R.id.thumbnail)
-        thumbnail.setBackgroundColor(feature.primaryColor)
+        thumbnail.setBackgroundColor(feature.thumbnailColor)
         feature.thumbnail?.let {
             thumbnail.setImageBitmap(it)
         }

--- a/android/app/src/main/kotlin/coop/polypoly/polypod/features/Feature.kt
+++ b/android/app/src/main/kotlin/coop/polypoly/polypod/features/Feature.kt
@@ -20,6 +20,10 @@ class Feature(
         get() = runCatching { Color.parseColor(manifest.primaryColor) }
             .getOrDefault(0)
 
+    val thumbnailColor: Int
+        get() = runCatching { Color.parseColor(manifest.thumbnailColor) }
+            .getOrDefault(primaryColor)
+
     val thumbnail: Bitmap?
         get() {
             if (manifest.thumbnail == null) return null

--- a/android/app/src/main/kotlin/coop/polypoly/polypod/features/FeatureManifest.kt
+++ b/android/app/src/main/kotlin/coop/polypoly/polypod/features/FeatureManifest.kt
@@ -8,6 +8,7 @@ open class FeatureManifest(
     val version: String?,
     val description: String?,
     val thumbnail: String?,
+    val thumbnailColor: String?,
     val primaryColor: String?,
     val links: Map<String, String>?
 ) {
@@ -25,6 +26,8 @@ open class FeatureManifest(
                 description = translations?.description
                     ?: fullManifest.description,
                 thumbnail = translations?.thumbnail ?: fullManifest.thumbnail,
+                thumbnailColor = translations?.thumbnailColor
+                    ?: fullManifest.thumbnailColor,
                 primaryColor = translations?.primaryColor
                     ?: fullManifest.primaryColor,
                 links = translations?.links ?: fullManifest.links
@@ -39,6 +42,7 @@ private class FullFeatureManifest(
     version: String?,
     description: String?,
     thumbnail: String?,
+    thumbnailColor: String?,
     primaryColor: String?,
     links: Map<String, String>?,
     val translations: Map<String, FeatureManifest>?
@@ -48,6 +52,7 @@ private class FullFeatureManifest(
     version = version,
     description = description,
     thumbnail = thumbnail,
+    thumbnailColor = thumbnailColor,
     primaryColor = primaryColor,
     links = links
 ) {

--- a/android/app/src/main/kotlin/coop/polypoly/polypod/features/FeatureStorage.kt
+++ b/android/app/src/main/kotlin/coop/polypoly/polypod/features/FeatureStorage.kt
@@ -56,7 +56,9 @@ class FeatureStorage {
         val manifestEntry = content.getEntry("manifest.json")
         if (manifestEntry == null) {
             logger.warn("Missing manifest for '${content.name}'")
-            return FeatureManifest(null, null, null, null, null, null, null)
+            return FeatureManifest(
+                null, null, null, null, null, null, null, null
+            )
         }
         val manifestString =
             content.getInputStream(manifestEntry).reader().readText()

--- a/features/facebookImport/src/static/manifest.json
+++ b/features/facebookImport/src/static/manifest.json
@@ -3,6 +3,7 @@
     "author": "polypoly Cooperative",
     "description": "Facebook knows a lot about you. With the Facebook Importer you can load your data in three steps from Facebook into your polyPod and finally get an overview yourself.",
     "thumbnail": "images/thumbnail.png",
+    "thumbnailColor": "#f0f1fe",
     "primaryColor": "#0f1938",
     "links": {
         "data-download": "https://www.facebook.com/dyi",

--- a/features/polyPreview/src/static/manifest.json
+++ b/features/polyPreview/src/static/manifest.json
@@ -3,6 +3,7 @@
     "author": "polypoly Cooperative",
     "description": "Your polyPod is constantly being improved. If you want to know what's planned, here is a preview.",
     "thumbnail": "images/thumbnail.png",
+    "thumbnailColor": "#fb8a89",
     "primaryColor": "#fff5f5",
     "links": {
         "membership": "https://polypoly.coop/en-de/membership"

--- a/ios/PolyPodApp/Features/Feature.swift
+++ b/ios/PolyPodApp/Features/Feature.swift
@@ -29,7 +29,8 @@ class Feature {
         name = translations?.name ?? manifest.name ?? id
         author = translations?.author ?? manifest.author
         description = translations?.description ?? manifest.description
-        primaryColor = parseColor(hexValue: translations?.primaryColor ?? manifest.primaryColor)
+        let primaryColor = parseColor(hexValue: translations?.primaryColor ?? manifest.primaryColor)
+        self.primaryColor = primaryColor
         thumbnailColor = parseColor(hexValue: translations?.thumbnailColor ?? manifest.thumbnailColor) ?? primaryColor
         thumbnail = findThumbnail(
             featurePath: path,

--- a/ios/PolyPodApp/Features/Feature.swift
+++ b/ios/PolyPodApp/Features/Feature.swift
@@ -7,6 +7,7 @@ class Feature {
     let author: String?
     let description: String?
     let primaryColor: Color?
+    let thumbnailColor: Color?
     let thumbnail: URL?
     private let links: [String: String]
     
@@ -29,6 +30,7 @@ class Feature {
         author = translations?.author ?? manifest.author
         description = translations?.description ?? manifest.description
         primaryColor = parseColor(hexValue: translations?.primaryColor ?? manifest.primaryColor)
+        thumbnailColor = parseColor(hexValue: translations?.thumbnailColor ?? manifest.thumbnailColor) ?? primaryColor
         thumbnail = findThumbnail(
             featurePath: path,
             thumbnailPath: translations?.thumbnail ?? manifest.thumbnail
@@ -58,6 +60,7 @@ private func readManifest(_ basePath: URL) -> FeatureManifest {
         author: nil,
         description: nil,
         thumbnail: nil,
+        thumbnailColor: nil,
         primaryColor: nil,
         links: nil,
         translations: nil

--- a/ios/PolyPodApp/Features/FeatureManifest.swift
+++ b/ios/PolyPodApp/Features/FeatureManifest.swift
@@ -5,6 +5,7 @@ struct FeatureManifest: Decodable {
     let author: String?
     let description: String?
     let thumbnail: String?
+    let thumbnailColor: String?
     let primaryColor: String?
     let links: [String: String]?
     let translations: [String: Override]?
@@ -27,6 +28,7 @@ struct FeatureManifest: Decodable {
         let author: String?
         let description: String?
         let thumbnail: String?
+        let thumbnailColor: String?
         let primaryColor: String?
         let links: [String: String]?
     }

--- a/ios/PolyPodApp/PolyPod/FeatureListView.swift
+++ b/ios/PolyPodApp/PolyPod/FeatureListView.swift
@@ -122,7 +122,7 @@ private struct FeatureCard: View {
             .background(Color.white)
         }
         .frame(maxWidth: .infinity)
-        .background(feature.primaryColor)
+        .background(feature.thumbnailColor)
         .cornerRadius(15)
         .overlay(
             RoundedRectangle(cornerRadius: 15)

--- a/ios/PolyPodApp/PolyPod/PreviewUtils.swift
+++ b/ios/PolyPodApp/PolyPod/PreviewUtils.swift
@@ -5,6 +5,7 @@ func createStubFeature(
     author: String? = nil,
     description: String? = nil,
     thumbnail: String? = nil,
+    thumbnailColor: String? = nil,
     primaryColor: String? = nil,
     links: [String: String]? = nil
 ) -> Feature {
@@ -13,6 +14,7 @@ func createStubFeature(
         author: author,
         description: description,
         thumbnail: thumbnail,
+        thumbnailColor: thumbnailColor,
         primaryColor: primaryColor,
         links: links,
         translations: nil


### PR DESCRIPTION
Feature thumbnails are always rendered in the correct aspect ratio -
rather than cut off. As a result, we have some background space to
account for to fill the feature's card.

For this, we used to just use the feature's primaryColor, assuming that
the thumbnail's background colour would always match that one. Turns out
that's not the case, so I gave up and added a dedicated thumbnailColor
field that can be used to overwrite this. If not specified, we fall back
to primaryColor, i.e. the old behaviour.

I specified it for the two features that had a mismatch: facebookImport
and polyPreview.