### PR TITLE
PROD4POD-1094 - Fix first time crash in facebookImport

### DIFF
--- a/android/app/src/main/kotlin/coop/polypoly/polypod/postoffice/PostOfficeMessageCallback.kt
+++ b/android/app/src/main/kotlin/coop/polypoly/polypod/postoffice/PostOfficeMessageCallback.kt
@@ -52,7 +52,8 @@ class PostOfficeMessageCallback(
                         Pair(
                             "error",
                             Codec.string.encode(
-                                "Something went wrong: ${e.message}"
+                                "Error dispatching request: " +
+                                    e.stackTraceToString()
                             )
                         ),
                         Pair("id", id)

--- a/features/facebookImport/src/context/importer-context.jsx
+++ b/features/facebookImport/src/context/importer-context.jsx
@@ -91,13 +91,13 @@ async function writeImportStatus(pod, status) {
             predicate: dataFactory.namedNode(`${namespace}importStatus`),
         })
     )[0];
-    polyIn.delete(existingQuad);
+    if (existingQuad) await polyIn.delete(existingQuad);
     const quad = dataFactory.quad(
         dataFactory.namedNode(`${namespace}facebookImporter`),
         dataFactory.namedNode(`${namespace}importStatus`),
         dataFactory.namedNode(`${namespace}${status}`)
     );
-    polyIn.add(quad);
+    await polyIn.add(quad);
 }
 
 export const ImporterProvider = ({ children }) => {

--- a/ios/PolyPodApp/PodApi/PostOffice.swift
+++ b/ios/PolyPodApp/PodApi/PostOffice.swift
@@ -105,7 +105,12 @@ extension PostOffice {
         
         for arg in args {
             guard let extendedData = arg as? ExtendedData else {
-                completionHandler(nil, MessagePackValue("Bad data"))
+                let message = """
+                    Bad argument data: \(arg)
+                    \(Thread.callStackSymbols.joined(separator: "\n"))
+                """
+                print(message)
+                completionHandler(nil, MessagePackValue(message))
                 return extendedDataSet
             }
             


### PR DESCRIPTION
This one wasn't particularly hard to fix - `polyIn.delete` just can't deal with invalid inputs. Instead of making the APIs more forgiving, I opted to just call it more carefully in the feature - it's the smaller change.

What did take quite a while was reproducing and debugging the problem, due to terrible error messages for invalid arguments. So I took some time to improve those: It's still not pretty, but now we get stack traces based on which we can understand which call caused the issue.