### PR TITLE
PROD4POD-1069 - Fix total for only one type of reaction

### DIFF
--- a/features/facebookImport/src/components/postReactionTypesMiniStory/postReactionTypesMiniStory.jsx
+++ b/features/facebookImport/src/components/postReactionTypesMiniStory/postReactionTypesMiniStory.jsx
@@ -44,7 +44,8 @@ const PostReactionTypesMiniStory = ({ reactionData }) => {
             : "saturate(0)";
 
     const totalAmountOfReactions = reactionData.reduce(
-        (prev, curr) => (prev.count || prev) + curr.count
+        (prev, curr) => (prev.count || prev) + curr.count,
+        0
     );
 
     const extendedReactionData = [


### PR DESCRIPTION
Pretty simple one: Calling `reduce` without `initialValue` on an array that could in theory have less than two elements is not a good idea :D