### PR TITLE
Fix font size calculation and clean up css styling

### DIFF
--- a/features/facebookImport/src/components/activitiesMiniStory/activitiesMiniStory.jsx
+++ b/features/facebookImport/src/components/activitiesMiniStory/activitiesMiniStory.jsx
@@ -43,7 +43,20 @@ const DatePicker = ({ year, yearRange, onYearChange }) => {
     );
 };
 
-const ActivitiesMiniStory = ({ totalEvents }) => {
+export const ActivitiesMiniStorySummary = ({ totalEvents }) => {
+    return (
+        <div className="render-summary">
+            <p className="highlighted-number">
+                {totalEvents.total.toLocaleString("de-DE")}
+            </p>
+            {i18n.t("activitiesMiniStory:summary", {
+                number_activities: totalEvents.total,
+            })}
+        </div>
+    );
+};
+
+export const ActivitiesMiniStoryDetails = ({ totalEvents }) => {
     const yearRange = fillArray(Object.keys(totalEvents.values));
 
     const yearlyTotals = yearRange.map((year) => {
@@ -121,6 +134,11 @@ const ActivitiesMiniStory = ({ totalEvents }) => {
 
     return (
         <div className="activities-ministory">
+            <p>
+                {i18n.t("activitiesMiniStory:summary", {
+                    number_activities: totalEvents.total,
+                })}
+            </p>
             <div className="tab-container">
                 <div className="tab-button-container">
                     {tabs.map((tab, index) => (
@@ -179,5 +197,3 @@ const ActivitiesMiniStory = ({ totalEvents }) => {
         </div>
     );
 };
-
-export default ActivitiesMiniStory;

--- a/features/facebookImport/src/components/messagesMiniStory/messagesMinistory.jsx
+++ b/features/facebookImport/src/components/messagesMiniStory/messagesMinistory.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+import i18n from "../../i18n";
+
+import BarChart from "../dataViz/barChart.jsx";
+import InfoButton from "../buttons/infoButton/infoButton.jsx";
+
+export const MessagesMiniStorySummary = ({
+    messagesCount,
+    messagesThreadsData,
+    totalUsernamesCount,
+}) => {
+    return (
+        <div className="render-summary">
+            <p className="highlighted-number">
+                {messagesCount.toLocaleString("de-DE")}
+            </p>
+            <p>
+                {i18n.t("explore:messages.summary", {
+                    messages: messagesCount,
+                    threads: messagesThreadsData.length,
+                    people: totalUsernamesCount,
+                })}
+            </p>
+        </div>
+    );
+};
+
+export const MessagesMiniStoryDetails = ({
+    totalUsernamesCount,
+    messagesThreadsData,
+}) => {
+    return (
+        <>
+            <p>
+                {i18n.t("messagesMiniStory:number.chats", {
+                    number_chats: totalUsernamesCount,
+                })}
+            </p>
+            <p> {i18n.t("messagesMiniStory:chart.title")}</p>
+            <BarChart
+                data={messagesThreadsData}
+                screenPadding={48}
+                footerContent={({ extraData }) => (
+                    <>
+                        <div className="bar-extra-info">
+                            <p>{i18n.t("messagesMiniStory:first.chat")}</p>
+                            {extraData.firstChatDate
+                                ? extraData.firstChatDate.toDateString()
+                                : "unknown"}
+                        </div>
+                        <div className="bar-extra-info">
+                            <p>
+                                {i18n.t("messagesMiniStory:last.interaction")}
+                            </p>
+                            {extraData.lastChatDate
+                                ? extraData.lastChatDate.toDateString()
+                                : "unknown"}
+                        </div>
+                    </>
+                )}
+            />
+            <InfoButton route="/report/details/messages-info" />
+            <p className="source">
+                {i18n.t("common:source.your.facebook.data")}
+            </p>
+        </>
+    );
+};

--- a/features/facebookImport/src/components/onOffFacebookMiniStory/onOffFacebookMiniStory.jsx
+++ b/features/facebookImport/src/components/onOffFacebookMiniStory/onOffFacebookMiniStory.jsx
@@ -36,7 +36,7 @@ export const OnOffFacebookMiniStorySummary = ({
                     __html: i18n.t("offFacebookEventsMiniStory:general"),
                 }}
             />
-            <h2>{companiesCount}</h2>
+            <p className="highlighted-number">{companiesCount}</p>
             <p
                 dangerouslySetInnerHTML={{
                     __html: i18n.t("offFacebookEventsMiniStory:companies", {
@@ -46,7 +46,9 @@ export const OnOffFacebookMiniStorySummary = ({
             />
             {companiesWithAdsCount === 0 ? null : (
                 <>
-                    <h2>{companiesWithAdsCount}</h2>
+                    <p className="highlighted-number">
+                        {companiesWithAdsCount}
+                    </p>
                     <p
                         dangerouslySetInnerHTML={{
                             __html: i18n.t(

--- a/features/facebookImport/src/model/analyses/ministories/activities-analysis.js
+++ b/features/facebookImport/src/model/analyses/ministories/activities-analysis.js
@@ -1,9 +1,11 @@
-import React, { useRef } from "react";
+import React from "react";
 import i18n from "../../../i18n.js";
 import RootAnalysis from "./root-analysis.js";
 
-import ActivitiesMiniStory from "../../../components/activitiesMiniStory/activitiesMiniStory.jsx";
-import "./ministories.css";
+import {
+    ActivitiesMiniStorySummary,
+    ActivitiesMiniStoryDetails,
+} from "../../../components/activitiesMiniStory/activitiesMiniStory.jsx";
 
 export default class ActivitiesAnalysis extends RootAnalysis {
     get label() {
@@ -74,53 +76,11 @@ export default class ActivitiesAnalysis extends RootAnalysis {
         this.active = groupedActivities.total > 0;
     }
 
-    _calculateFontSize(text, maxWidth) {
-        // TODO: Extract text size affecting styles from target element
-        const minFontSize = 10;
-        const maxFontSize = 60;
-        const canvas = document.createElement("canvas");
-        const context = canvas.getContext("2d");
-        for (let fontSize = maxFontSize; fontSize > minFontSize; fontSize--) {
-            context.font = `${fontSize}px Jost Medium`;
-            if (context.measureText(text).width <= maxWidth) return fontSize;
-        }
-        return minFontSize;
-    }
-
     renderSummary() {
-        const refWidth = useRef(0);
-
-        const fontSize = this._calculateFontSize(
-            this._messagesCount,
-            refWidth.current.clientWidth
-        );
-
-        return (
-            <div className="render-summary">
-                <h2
-                    style={{ fontSize: fontSize, marginBottom: "30px" }}
-                    ref={refWidth}
-                >
-                    {" "}
-                    {this._totalEvents.total.toLocaleString("de-DE")}
-                </h2>
-                {i18n.t("activitiesMiniStory:summary", {
-                    number_activities: this._totalEvents.total,
-                })}
-            </div>
-        );
+        return <ActivitiesMiniStorySummary totalEvents={this._totalEvents} />;
     }
 
     renderDetails() {
-        return (
-            <>
-                <p>
-                    {i18n.t("activitiesMiniStory:summary", {
-                        number_activities: this._totalEvents.total,
-                    })}
-                </p>
-                <ActivitiesMiniStory totalEvents={this._totalEvents} />
-            </>
-        );
+        return <ActivitiesMiniStoryDetails totalEvents={this._totalEvents} />;
     }
 }

--- a/features/facebookImport/src/model/analyses/ministories/messages-analysis.js
+++ b/features/facebookImport/src/model/analyses/ministories/messages-analysis.js
@@ -1,10 +1,11 @@
-import React, { useRef } from "react";
+import React from "react";
 import i18n from "../../../i18n";
 import RootAnalysis from "./root-analysis";
-import InfoButton from "../../../components/buttons/infoButton/infoButton.jsx";
 
-import BarChart from "../../../components/dataViz/barChart.jsx";
-import "./ministories.css";
+import {
+    MessagesMiniStoryDetails,
+    MessagesMiniStorySummary,
+} from "../../../components/messagesMiniStory/messagesMinistory.jsx";
 
 export default class MessagesAnalysis extends RootAnalysis {
     get label() {
@@ -61,88 +62,22 @@ export default class MessagesAnalysis extends RootAnalysis {
         this.active = this._messagesThreadsData.length > 0;
     }
 
-    _calculateFontSize(text, maxWidth) {
-        // TODO: Extract text size affecting styles from target element
-        const minFontSize = 10;
-        const maxFontSize = 80;
-        const canvas = document.createElement("canvas");
-        const context = canvas.getContext("2d");
-        for (let fontSize = maxFontSize; fontSize > minFontSize; fontSize--) {
-            context.font = `${fontSize}px Jost`;
-            if (context.measureText(text).width <= maxWidth) return fontSize;
-        }
-        return minFontSize;
-    }
-
     renderSummary() {
-        const refWidth = useRef(0);
-
-        const fontSize = this._calculateFontSize(
-            this._messagesCount,
-            refWidth.current.clientWidth
-        );
-
         return (
-            <div className="render-summary">
-                <h2
-                    style={{
-                        fontSize: fontSize,
-                        marginBottom: "35px",
-                        marginTop: "25px",
-                    }}
-                    ref={refWidth}
-                >
-                    {this._messagesCount.toLocaleString("de-DE")}
-                </h2>
-                <p>
-                    {i18n.t("explore:messages.summary", {
-                        messages: this._messagesCount,
-                        threads: this._messagesThreadsData.length,
-                        people: this._totalUsernamesCount,
-                    })}
-                </p>
-            </div>
+            <MessagesMiniStorySummary
+                messagesCount={this._messagesCount}
+                messagesThreadsData={this._messagesThreadsData}
+                totalUsernamesCount={this._totalUsernamesCount}
+            />
         );
     }
 
     renderDetails() {
         return (
-            <>
-                <p>
-                    {i18n.t("messagesMiniStory:number.chats", {
-                        number_chats: this._totalUsernamesCount,
-                    })}
-                </p>
-                <p> {i18n.t("messagesMiniStory:chart.title")}</p>
-                <BarChart
-                    data={this._messagesThreadsData}
-                    screenPadding={48}
-                    footerContent={({ extraData }) => (
-                        <>
-                            <div className="bar-extra-info">
-                                <p>{i18n.t("messagesMiniStory:first.chat")}</p>
-                                {extraData.firstChatDate
-                                    ? extraData.firstChatDate.toDateString()
-                                    : "unknown"}
-                            </div>
-                            <div className="bar-extra-info">
-                                <p>
-                                    {i18n.t(
-                                        "messagesMiniStory:last.interaction"
-                                    )}
-                                </p>
-                                {extraData.lastChatDate
-                                    ? extraData.lastChatDate.toDateString()
-                                    : "unknown"}
-                            </div>
-                        </>
-                    )}
-                />
-                <InfoButton route="/report/details/messages-info" />
-                <p className="source">
-                    {i18n.t("common:source.your.facebook.data")}
-                </p>
-            </>
+            <MessagesMiniStoryDetails
+                totalUsernamesCount={this._totalUsernamesCount}
+                messagesThreadsData={this._messagesThreadsData}
+            />
         );
     }
 }

--- a/features/facebookImport/src/model/analyses/ministories/ministories.css
+++ b/features/facebookImport/src/model/analyses/ministories/ministories.css
@@ -1,9 +1,0 @@
-.render-summary h2 {
-    font-weight: 800;
-    color: var(--color-gray-50);
-    /* font-size: 60px; */
-    font-family: "Jost Medium";
-    margin-top: 3px;
-    margin-bottom: 3px;
-    letter-spacing: -0.01em;
-}

--- a/features/facebookImport/src/views/explore/details.css
+++ b/features/facebookImport/src/views/explore/details.css
@@ -9,12 +9,6 @@
     flex-direction: column;
 }
 
-.details-view .details-view-title {
-    font-weight: 500;
-    margin: 0;
-    font-size: 24px;
-}
-
 .details-view ul {
     padding: 0 20px;
 }

--- a/features/facebookImport/src/views/explore/details.jsx
+++ b/features/facebookImport/src/views/explore/details.jsx
@@ -7,7 +7,7 @@ const ExploreDetails = () => {
     const { activeDetails } = useContext(ImporterContext);
     return (
         <div className="details-view">
-            <h1 className="details-view-title">{activeDetails.title}</h1>
+            <h1 className="ministory-title">{activeDetails.title}</h1>
             {activeDetails.renderDetails()}
         </div>
     );

--- a/features/facebookImport/src/views/explore/explore.css
+++ b/features/facebookImport/src/views/explore/explore.css
@@ -92,13 +92,6 @@
     justify-content: space-between;
     margin-bottom: 16px;
 }
-.analysis-card .card-container > h1 {
-    max-width: 320px;
-    font-size: 24px;
-    font-weight: 500;
-    line-height: 28.8px;
-    margin: 0 0 15px 0;
-}
 
 .analysis-card .card-container > label {
     width: 90px;

--- a/features/facebookImport/src/views/explore/explore.jsx
+++ b/features/facebookImport/src/views/explore/explore.jsx
@@ -6,6 +6,7 @@ import { ImporterContext } from "../../context/importer-context.jsx";
 import i18n from "../../i18n.js";
 
 import "./explore.css";
+import "./ministory-styles.css";
 
 const PopUpMessage = ({ children, reportResultAnswer }) => {
     return <div className={"pop-up" + reportResultAnswer}>{children}</div>;
@@ -20,7 +21,7 @@ const AnalysisCard = ({
         <>
             <div className="analysis-card">
                 <div className="card-container">
-                    <h1>{analysis.title}</h1>
+                    <h1 className="ministory-title">{analysis.title}</h1>
                     {analysis.label !== null && (
                         <label>
                             {i18n.t(`explore:analysis.label.${analysis.label}`)}

--- a/features/facebookImport/src/views/explore/ministory-styles.css
+++ b/features/facebookImport/src/views/explore/ministory-styles.css
@@ -1,0 +1,14 @@
+.ministory-title {
+    max-width: 320px;
+    font-size: 24px;
+    font-weight: 500;
+    line-height: 28.8px;
+    margin: 0 0 15px 0;
+}
+
+.analysis-card .highlighted-number {
+    font-size: clamp(1rem, 15vw, 3.75rem);
+    font-weight: 800;
+    font-family: "Jost Medium";
+    margin: 32px 0;
+}

--- a/features/facebookImport/src/views/explore/ministory-styles.css
+++ b/features/facebookImport/src/views/explore/ministory-styles.css
@@ -7,7 +7,7 @@
 }
 
 .analysis-card .highlighted-number {
-    font-size: clamp(1rem, 15vw, 3.75rem);
+    font-size: clamp(1rem, 14vw, 5rem);
     font-weight: 800;
     font-family: "Jost Medium";
     margin: 32px 0;


### PR DESCRIPTION
I went away from the js calculation font-size approach since the numbers were not uniformly sized and it looked odd. Also when coming back from a detail screen you needed to scroll to get the resizing going. This feels better to me but let me know if you have objections.

Also I cleaned up the css so all common analysis css is now in `ministory-styles.css`