### PR TITLE
[fix] {PROD4POD-1026} Upgrade gson to non-vulnerable version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.0'
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.synnapps:carouselview:0.1.5'
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation group: 'org.apache.jena', name: 'jena-core', version: '3.17.0'
     implementation 'androidx.work:work-runtime:2.3.4'
     implementation 'androidx.biometric:biometric:1.1.0'


### PR DESCRIPTION
This is a simple upgrade to the first non-vulnerable version mentioned.