### PR TITLE
Cache list of files from the zip

### DIFF
--- a/features/facebookImport/src/model/analysis.js
+++ b/features/facebookImport/src/model/analysis.js
@@ -254,7 +254,6 @@ export async function analyzeZip(zipData, zipFile, facebookAccount, pod) {
 }
 
 export async function analyzeFile(zipData, facebookAccount) {
-    const zipFile = new ZipFile(zipData, window.pod);
-    await zipFile.refreshCachedEntries();
+    const zipFile = await ZipFile.createFor(zipData, window.pod);
     return await analyzeZip(zipData, zipFile, facebookAccount, window.pod);
 }

--- a/features/facebookImport/src/model/analysis.js
+++ b/features/facebookImport/src/model/analysis.js
@@ -255,5 +255,6 @@ export async function analyzeZip(zipData, zipFile, facebookAccount, pod) {
 
 export async function analyzeFile(zipData, facebookAccount) {
     const zipFile = new ZipFile(zipData, window.pod);
+    await zipFile.refreshCachedEntries();
     return await analyzeZip(zipData, zipFile, facebookAccount, window.pod);
 }

--- a/features/facebookImport/src/model/analysis.js
+++ b/features/facebookImport/src/model/analysis.js
@@ -254,6 +254,6 @@ export async function analyzeZip(zipData, zipFile, facebookAccount, pod) {
 }
 
 export async function analyzeFile(zipData, facebookAccount) {
-    const zipFile = await ZipFile.createFor(zipData, window.pod);
+    const zipFile = await ZipFile.createWithCache(zipData, window.pod);
     return await analyzeZip(zipData, zipFile, facebookAccount, window.pod);
 }

--- a/features/facebookImport/src/model/importer.js
+++ b/features/facebookImport/src/model/importer.js
@@ -147,7 +147,6 @@ export async function importZip(zipFile, pod) {
 }
 
 export async function importData(zipData) {
-    const zipFile = new ZipFile(zipData, window.pod);
-    await zipFile.refreshCachedEntries();
+    const zipFile = await ZipFile.createFor(zipData, window.pod);
     return importZip(zipFile, window.pod);
 }

--- a/features/facebookImport/src/model/importer.js
+++ b/features/facebookImport/src/model/importer.js
@@ -147,6 +147,6 @@ export async function importZip(zipFile, pod) {
 }
 
 export async function importData(zipData) {
-    const zipFile = await ZipFile.createFor(zipData, window.pod);
+    const zipFile = await ZipFile.createWithCache(zipData, window.pod);
     return importZip(zipFile, window.pod);
 }

--- a/features/facebookImport/src/model/importer.js
+++ b/features/facebookImport/src/model/importer.js
@@ -148,5 +148,6 @@ export async function importZip(zipFile, pod) {
 
 export async function importData(zipData) {
     const zipFile = new ZipFile(zipData, window.pod);
+    await zipFile.refreshCachedEntries();
     return importZip(zipFile, window.pod);
 }

--- a/features/facebookImport/src/model/importers/utils/importer-util.js
+++ b/features/facebookImport/src/model/importers/utils/importer-util.js
@@ -12,24 +12,22 @@ async function relevantZipEntries(zipFile) {
 }
 
 async function readJSONFile(relativeFileName, zipFile) {
-    const fullEntryName = `${zipFile.id}/${relativeFileName}`;
+    let fullEntryName;
+    // TODO: This is a hack to handle the fact that ids are
+    // different between the browser pod and the app one.
+    if (zipFile.id.startsWith("polypod://")) {
+        fullEntryName = `${zipFile.id}/${relativeFileName}`;
+    } else {
+        fullEntryName = `FeatureFiles/${zipFile.id}/${relativeFileName}`;
+    }
+
     return readFullPathJSONFile(fullEntryName, zipFile);
 }
 
 async function readFullPathJSONFile(fullEntryName, zipFile) {
-    const entries = await zipFile.getEntries();
-    const dataZipEntry = entries.find((entryName) =>
-        entryName.endsWith(fullEntryName)
-    );
-
-    if (!dataZipEntry) {
+    if (!(await zipFile.hasEntry(fullEntryName))) {
         throw new MissingFileImportException(fullEntryName);
     }
-
-    // TODO: We should not need the lines above
-    //if (!(await zipFile.hasEntry(fullEntryName))) {
-    //    throw new MissingFileImportException(fullEntryName);
-    //}
 
     const rawContent = await zipFile.getContent(fullEntryName);
     const fileContent = new TextDecoder("utf-8").decode(rawContent);

--- a/features/facebookImport/src/model/importers/utils/importer-util.js
+++ b/features/facebookImport/src/model/importers/utils/importer-util.js
@@ -15,7 +15,7 @@ async function readJSONFile(relativeFileName, zipFile) {
     let fullEntryName;
     // TODO: This is a hack to handle the fact that ids are
     // different between the browser pod and the app one.
-    if (zipFile.id.startsWith("polypod://")) {
+    if (zipFile.id.toLowerCase().startsWith("polypod://")) {
         fullEntryName = `${zipFile.id}/${relativeFileName}`;
     } else {
         fullEntryName = `FeatureFiles/${zipFile.id}/${relativeFileName}`;

--- a/features/facebookImport/src/model/importers/utils/importer-util.js
+++ b/features/facebookImport/src/model/importers/utils/importer-util.js
@@ -26,7 +26,12 @@ async function readFullPathJSONFile(fullEntryName, zipFile) {
         throw new MissingFileImportException(fullEntryName);
     }
 
-    const rawContent = await zipFile.getContent(dataZipEntry);
+    // TODO: We should not need the lines above
+    //if (!(await zipFile.hasEntry(fullEntryName))) {
+    //    throw new MissingFileImportException(fullEntryName);
+    //}
+
+    const rawContent = await zipFile.getContent(fullEntryName);
     const fileContent = new TextDecoder("utf-8").decode(rawContent);
 
     if (!fileContent) {

--- a/features/facebookImport/src/model/storage.js
+++ b/features/facebookImport/src/model/storage.js
@@ -37,15 +37,33 @@ export class ZipFile {
     constructor(file, pod) {
         this._pod = pod;
         this._file = file;
+
+        this._entriesList = null;
+        this._entriesSet = null;
     }
 
     get id() {
         return this._file.id;
     }
 
-    async getEntries() {
+    async _readEntriesList() {
         const { polyOut } = this._pod;
-        return polyOut.readdir(this.id);
+        return await polyOut.readdir(this.id);
+    }
+
+    async refreshCachedEntries() {
+        this._entriesList = await this._readEntriesList();
+        this._entriesSet = new Set(this._entriesList);
+    }
+
+    async getEntries() {
+        if (this._entriesList !== null) return this._entriesList;
+        return await this._readEntriesList();
+    }
+
+    async hasEntry(entryId) {
+        if (this._entriesSet !== null) return this._entriesSet.has(entryId);
+        return await this._readEntriesList().includes(entryId);
     }
 
     async data() {

--- a/features/facebookImport/src/model/storage.js
+++ b/features/facebookImport/src/model/storage.js
@@ -38,12 +38,12 @@ export class ZipFile {
         this._pod = pod;
         this._file = file;
 
-        this._entriesSet = new Set();
+        this._entriesSet = null;
     }
 
     static async createFor(zipData, pod) {
         let zipFile = new this(zipData, pod);
-        await zipFile._refreshCachedEntries();
+        await zipFile._ensureCachedEntries();
         return zipFile;
     }
 
@@ -53,19 +53,22 @@ export class ZipFile {
 
     async _readEntriesList() {
         const { polyOut } = this._pod;
-        return await polyOut.readdir(this.id);
+        return polyOut.readdir(this.id);
     }
 
-    async _refreshCachedEntries() {
+    async _ensureCachedEntries() {
+        if (this._entriesSet !== null) return;
         const entriesList = await this._readEntriesList();
         this._entriesSet = new Set(entriesList);
     }
 
     async getEntries() {
+        await this._ensureCachedEntries();
         return [...this._entriesSet];
     }
 
     async hasEntry(entryId) {
+        await this._ensureCachedEntries();
         return this._entriesSet.has(entryId);
     }
 

--- a/features/facebookImport/src/model/storage.js
+++ b/features/facebookImport/src/model/storage.js
@@ -41,6 +41,12 @@ export class ZipFile {
         this._entriesSet = new Set();
     }
 
+    static async createFor(zipData, pod) {
+        let zipFile = new this(zipData, pod);
+        await zipFile._refreshCachedEntries();
+        return zipFile;
+    }
+
     get id() {
         return this._file.id;
     }
@@ -50,7 +56,7 @@ export class ZipFile {
         return await polyOut.readdir(this.id);
     }
 
-    async refreshCachedEntries() {
+    async _refreshCachedEntries() {
         const entriesList = await this._readEntriesList();
         this._entriesSet = new Set(entriesList);
     }

--- a/features/facebookImport/src/model/storage.js
+++ b/features/facebookImport/src/model/storage.js
@@ -41,12 +41,6 @@ export class ZipFile {
         this._entriesSet = null;
     }
 
-    static async createFor(zipData, pod) {
-        let zipFile = new this(zipData, pod);
-        await zipFile._ensureCachedEntries();
-        return zipFile;
-    }
-
     get id() {
         return this._file.id;
     }
@@ -86,3 +80,9 @@ export class ZipFile {
         return polyOut.readFile(entry);
     }
 }
+
+ZipFile.createWithCache = async function (zipData, pod) {
+    let zipFile = new ZipFile(zipData, pod);
+    await zipFile._ensureCachedEntries();
+    return zipFile;
+};

--- a/features/facebookImport/src/model/storage.js
+++ b/features/facebookImport/src/model/storage.js
@@ -38,8 +38,7 @@ export class ZipFile {
         this._pod = pod;
         this._file = file;
 
-        this._entriesList = null;
-        this._entriesSet = null;
+        this._entriesSet = new Set();
     }
 
     get id() {
@@ -52,18 +51,16 @@ export class ZipFile {
     }
 
     async refreshCachedEntries() {
-        this._entriesList = await this._readEntriesList();
-        this._entriesSet = new Set(this._entriesList);
+        const entriesList = await this._readEntriesList();
+        this._entriesSet = new Set(entriesList);
     }
 
     async getEntries() {
-        if (this._entriesList !== null) return this._entriesList;
-        return await this._readEntriesList();
+        return [...this._entriesSet];
     }
 
     async hasEntry(entryId) {
-        if (this._entriesSet !== null) return this._entriesSet.has(entryId);
-        return await this._readEntriesList().includes(entryId);
+        return this._entriesSet.has(entryId);
     }
 
     async data() {

--- a/features/facebookImport/test/mocks/zipfile-mock.js
+++ b/features/facebookImport/test/mocks/zipfile-mock.js
@@ -12,8 +12,6 @@ export class ZipFileMock {
         this._entries = {};
     }
 
-    async refreshCachedEntries() {}
-
     async hasEntry(entryId) {
         return entryId in this._entries;
     }

--- a/features/facebookImport/test/mocks/zipfile-mock.js
+++ b/features/facebookImport/test/mocks/zipfile-mock.js
@@ -12,6 +12,12 @@ export class ZipFileMock {
         this._entries = {};
     }
 
+    async refreshCachedEntries() {}
+
+    async hasEntry(entryId) {
+        return entryId in this._entries;
+    }
+
     async getEntries() {
         return Object.keys(this._entries);
     }


### PR DESCRIPTION
(Still a draft)

This caches the list of files inside `ZipFile`. 
A further improvement would be for importers to use `hasEntry` instead of manually iterating through the list of files.

Another possible improvement for a later PR could be to refactor `analyzeFile` and  `importData` to pass the same zip file.