### PR TITLE
PROD4POD-1123 - Fix missing variables in message story details

### DIFF
--- a/features/facebookImport/src/components/messagesMiniStory/messagesMinistory.jsx
+++ b/features/facebookImport/src/components/messagesMiniStory/messagesMinistory.jsx
@@ -7,6 +7,20 @@ import InfoButton from "../buttons/infoButton/infoButton.jsx";
 
 import "./messagesMinistory.css";
 
+const SummaryText = ({
+    messagesCount,
+    messagesThreadsData,
+    totalUsernamesCount,
+}) => (
+    <p>
+        {i18n.t("explore:messages.summary", {
+            messages: messagesCount,
+            threads: messagesThreadsData.length,
+            people: totalUsernamesCount,
+        })}
+    </p>
+);
+
 export const MessagesMiniStorySummary = ({
     messagesCount,
     messagesThreadsData,
@@ -17,28 +31,27 @@ export const MessagesMiniStorySummary = ({
             <p className="highlighted-number">
                 {messagesCount.toLocaleString("de-DE")}
             </p>
-            <p>
-                {i18n.t("explore:messages.summary", {
-                    messages: messagesCount,
-                    threads: messagesThreadsData.length,
-                    people: totalUsernamesCount,
-                })}
-            </p>
+            <SummaryText
+                messagesCount={messagesCount}
+                messagesThreadsData={messagesThreadsData}
+                totalUsernamesCount={totalUsernamesCount}
+            />
         </div>
     );
 };
 
 export const MessagesMiniStoryDetails = ({
-    totalUsernamesCount,
+    messagesCount,
     messagesThreadsData,
+    totalUsernamesCount,
 }) => {
     return (
         <>
-            <p>
-                {i18n.t("messagesMiniStory:number.chats", {
-                    number_chats: totalUsernamesCount,
-                })}
-            </p>
+            <SummaryText
+                messagesCount={messagesCount}
+                messagesThreadsData={messagesThreadsData}
+                totalUsernamesCount={totalUsernamesCount}
+            />
             <p> {i18n.t("messagesMiniStory:chart.title")}</p>
             <BarChart
                 data={messagesThreadsData}

--- a/features/facebookImport/src/locales/de/miniStories/messages.json
+++ b/features/facebookImport/src/locales/de/miniStories/messages.json
@@ -1,6 +1,5 @@
 {
     "headline": "Ihre Nachrichten",
-    "number.chats": "In Ihren Facebook Daten finden sich {{messages}} Nachrichten aus {{threads}} Chats mit {{people}} Personen.",
     "chart.title": "Anzahl ausgetauschter Nachrichten",
     "first.chat": "Erste Nachricht: ",
     "last.interaction": "Letzte Nachricht: "

--- a/features/facebookImport/src/locales/en/miniStories/messages.json
+++ b/features/facebookImport/src/locales/en/miniStories/messages.json
@@ -1,6 +1,5 @@
 {
     "headline": "Your messages",
-    "number.chats": "Your Facebook data contains {{messages}} messages from {{threads}} chats with {{people}} people.",
     "chart.title": "Number of messages exchanged",
     "first.chat": "First message: ",
     "last.interaction": "Last message: "

--- a/features/facebookImport/src/model/analyses/ministories/messages-analysis.js
+++ b/features/facebookImport/src/model/analyses/ministories/messages-analysis.js
@@ -75,8 +75,9 @@ export default class MessagesAnalysis extends RootAnalysis {
     renderDetails() {
         return (
             <MessagesMiniStoryDetails
-                totalUsernamesCount={this._totalUsernamesCount}
+                messagesCount={this._messagesCount}
                 messagesThreadsData={this._messagesThreadsData}
+                totalUsernamesCount={this._totalUsernamesCount}
             />
         );
     }


### PR DESCRIPTION
It appears the new translations used variables that don't exist, and
ultimately really just want the same text that's shown on the story's
summary.