### PR TITLE
Prod4 pod 1093/ios saturate

### DIFF
--- a/core/utils/poly-look/src/visualisations/charts/bubble-charts/bubbleCluster/bubbleCluster.js
+++ b/core/utils/poly-look/src/visualisations/charts/bubble-charts/bubbleCluster/bubbleCluster.js
@@ -64,14 +64,12 @@ export class BubbleCluster extends Chart {
     this._bubblePadding = bubblePadding;
     this._filter = filter;
 
-    this._filterActivationCondition = (d) =>
-      this._filter
-        ? this._filter.activationCondition
-          ? this._filter.activationCondition(d)
-            ? `url(#${this._filter.type})`
-            : null
-          : `url(#${this._filter.type})`
-        : null;
+    this._filterActivationCondition = (d) => {
+      if (!this._filter) return null;
+      const { activationCondition } = this._filter;
+      if (activationCondition && !activationCondition(d)) return null;
+      return `url(#${this._filter.type})`;
+    };
   }
 
   _makeHierarchy() {

--- a/core/utils/poly-look/src/visualisations/charts/bubble-charts/bubbleCluster/bubbleCluster.js
+++ b/core/utils/poly-look/src/visualisations/charts/bubble-charts/bubbleCluster/bubbleCluster.js
@@ -35,7 +35,12 @@ const defaultOnClickFunction = () => {};
  * @param {number|callback = 1} [opacity] - The opacity of the bubbles color 0 <= opacity <= 1 (callbacks receive event and data)
  * @param {boolean = true} [showValues] - Whether texts displaying the value of the bubble are added
  * @param {callback = () => {}} [onBubbleClick] - Bubble onclick function
- * @param {number|callback} [filter] - A filter that is applied to the icons eg saturate(0.5)(callbacks receive event and data)
+ * @param {Object} [filter] - A filter that is applied to the elements
+ * @param {SVG-Filter-Element} [filter.filterElement] - The svg filter element created (https://developer.mozilla.org/en-US/docs/Web/SVG/Element#filter_primitive_elements)
+ * @param {string} [filter.type] - Filter type has different meanings depending on the context it's used in (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/type)
+ * @param {string} [filter.in] - Where the filter is used (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/in)
+ * @param {string} [filter.values] - Values has different meanings depending on the context it's used in (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/values)
+ * @param {callback} [filter.activationCondition] - Condition applied to the bubbles when filter is active (receives d)
  */
 export class BubbleCluster extends Chart {
   constructor({
@@ -58,6 +63,15 @@ export class BubbleCluster extends Chart {
     this._onBubbleClick = onBubbleClick;
     this._bubblePadding = bubblePadding;
     this._filter = filter;
+
+    this._filterActivationCondition = (d) =>
+      this._filter
+        ? this._filter.activationCondition
+          ? this._filter.activationCondition(d)
+            ? `url(#${this._filter.type})`
+            : null
+          : `url(#${this._filter.type})`
+        : null;
   }
 
   _makeHierarchy() {
@@ -71,19 +85,17 @@ export class BubbleCluster extends Chart {
       .padding(this._bubblePadding);
   }
 
-  _updateBubbles(leaves) {
-    leaves
-      .selectAll(".bubble")
-      .style("fill", this._bubbleColor)
-      .style("stroke", "#f7fafc")
-      .style("vertical-align", "center")
-      .attr("fill-opacity", this._opacity);
-
-    leaves
-      .selectAll(".icon")
-      .attr("height", (d) => d.r * 2)
-      .attr("width", (d) => d.r * 2)
-      .style("filter", this._filter);
+  _setUpFilters() {
+    const filter = this._filter;
+    if (this._filter && this.chart.select(`.filter.${filter.type}`).empty())
+      this.chart
+        .append("filter")
+        .attr("class", `filter ${filter.type}`)
+        .attr("id", filter.type)
+        .append(filter.filterElement)
+        .attr("type", filter.type)
+        .attr("in", filter.in)
+        .attr("values", filter.values);
   }
 
   _addNewBubbleGroups(leaves) {
@@ -95,7 +107,23 @@ export class BubbleCluster extends Chart {
           ? `translate(${d.x - d.r},${d.y - d.r})`
           : `translate(${d.x},${d.y})`
       )
-      .on("click", this._onBubbleClick);
+      .on("click", this._onBubbleClick)
+      .style("-webkit-tap-highlight-color", "transparent");
+  }
+
+  _updateBubbles(leaves) {
+    leaves
+      .selectAll(".bubble")
+      .style("fill", this._bubbleColor)
+      .style("stroke", "#f7fafc")
+      .style("vertical-align", "center")
+      .attr("filter", this._filterActivationCondition);
+
+    leaves
+      .selectAll(".icon")
+      .attr("height", (d) => d.r * 2)
+      .attr("width", (d) => d.r * 2)
+      .attr("filter", this._filterActivationCondition);
   }
 
   _addBubbles(bubbleGroups) {
@@ -106,7 +134,7 @@ export class BubbleCluster extends Chart {
       .attr("class", "icon")
       .attr("height", (d) => d.r * 2)
       .attr("width", (d) => d.r * 2)
-      .style("filter", this._filter);
+      .attr("filter", this._filterActivationCondition);
 
     bubbleGroups
       .filter((d) => !d.data.icon)
@@ -156,6 +184,7 @@ export class BubbleCluster extends Chart {
     const hierarchicalData = this._makeHierarchy();
     const packLayout = this._pack();
     const root = packLayout(hierarchicalData);
+    this._setUpFilters();
     const leaves = this.chart.selectAll("g").data(root.leaves());
     leaves.exit().remove();
     this._updateBubbles(leaves);

--- a/features/facebookImport/src/components/postReactionTypesMiniStory/postReactionTypesMiniStory.jsx
+++ b/features/facebookImport/src/components/postReactionTypesMiniStory/postReactionTypesMiniStory.jsx
@@ -39,11 +39,15 @@ export function mapEmojiToReaction(reactions) {
 const PostReactionTypesMiniStory = ({ reactionData }) => {
     const [selectedReaction, setSelectedReaction] = useState("TOTAL");
 
-    const handleIconSelected = (e, d) => setSelectedReaction(d.data.title);
-    const iconSaturation = (d) =>
-        selectedReaction == d.data.title || selectedReaction == "TOTAL"
-            ? "saturate(1)"
-            : "saturate(0)";
+    const handleIconSelected = (_, d) => setSelectedReaction(d.data.title);
+    const iconFilter = {
+        filterElement: "feColorMatrix",
+        type: "saturate",
+        in: "SourceGraphic",
+        values: 0,
+        activationCondition: (d) =>
+            selectedReaction != d.data.title && selectedReaction != "TOTAL",
+    };
 
     const totalAmountOfReactions = reactionData.reduce(
         (prev, curr) => (prev.count || prev) + curr.count,
@@ -82,7 +86,7 @@ const PostReactionTypesMiniStory = ({ reactionData }) => {
                 data={mapEmojiToReaction(reactionData)}
                 onBubbleClick={handleIconSelected}
                 showValues={false}
-                filter={iconSaturation}
+                filter={iconFilter}
             />
             <ChartButtons
                 buttonsContent={extendedReactionData.map((r) => {


### PR DESCRIPTION
Trickier than I thought:

`.style("filter", <filter>)` does not work in ios (safari) for SVG's (does so in firefox and only firefox).

Solved by introducing new way filters are added => adding to chart and using on elements when activationContidition is true. 

The good thing is now all kinds of filters can be used and it's not limited to saturate.