### PR TITLE
PROD4POD-1097 - Relentlessly authenticate on Android as well

### DIFF
--- a/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -20,7 +20,10 @@ class MainActivity : AppCompatActivity() {
                 setContentView(R.layout.activity_main)
                 setSupportActionBar(findViewById(R.id.toolbar))
             } else {
-                finish()
+                // Since we do not have a dedicated unlocking activity yet,
+                // we simply keep restarting the activity until unlocking
+                // succeeds.
+                recreate()
             }
         }
     }


### PR DESCRIPTION
Originally it seemed like a bad workaround on iOS to just authenticate
in a loop, but turns out in practice it's a lot better than just closing
the app after one failed attempt.

Turns out the solution was pretty simple - just relaunch the activity
when authentication fails. I'm mildly surprised it works as intended,
but according to my tests it does.