### PR TITLE
Print per-package build timings

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -156,12 +156,20 @@ function executeProcess(executable, args, env = process.env) {
     });
 }
 
-const npm = (...args) =>
-    executeProcess("npm", args, { ...process.env, FORCE_COLOR: 1 });
+const npm = async (...args) => {
+    const start = new Date();
+    await executeProcess(
+        "npm",
+        ["--no-update-notifier", "--no-fund", ...args],
+        { ...process.env, FORCE_COLOR: 1 }
+    );
+    const elapsed = new Date() - start;
+    logDetail(`NPM finished in ${elapsed} ms`);
+};
 
 async function npmInstall(name) {
     logDetail(`${name}: Installing dependencies ...`);
-    await npm("ci", "--no-update-notifier", "--no-fund");
+    await npm("ci");
 }
 
 async function npmRun(script, pkg) {
@@ -264,7 +272,7 @@ async function main() {
 
     if (!["list", "list-deps", "clean"].includes(command)) {
         logDetail(`👷👷‍♀️ ...`);
-        await npm("ci", "--no-update-notifier", "--no-fund");
+        await npmInstall("/");
     }
 
     if (command === "lint") {


### PR DESCRIPTION
This should help us understand which parts of the process are slow.

While at it, I also reduced the noise a bit by adding
--no-update-notifier (and --no-fund, for good measure), to all NPM
invocations.

There's room for improvement though:

1. I experimented with adding a --quiet option for build.js that
surpresses all of the actual build output, but took longer than a few
minutes so I didn't bother at this point. It's easy enough to comment
out the console.log statements in executeProcess temporarily :P

2. We're invoking NPX for linting - that doesn't print any timings ATM,
but I suppose we're not too interested in those execution times so I
didn't bother for now.