### PR TITLE
Cleans up (using build.js clean) at the top level

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -281,6 +281,10 @@ async function main() {
         return 0;
     }
 
+    if (command === "clean") {
+        await npm("run", "clean");
+    }
+
     const metaManifest = parseManifest("build/packages.json");
     const nodeMajorVersion = parseInt(process.version.slice(1, 3), 10);
     if (nodeMajorVersion < metaManifest.requiredNodeMajorVersion) {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,9 @@
 {
+  "name": "@polypoly-eu/polyPod",
+  "description": "Common monorepo and build script dependencies",
+  "scripts": {
+    "clean": "rm -rf node_modules"
+  },
   "devDependencies": {
     "@types/jest": "^27.0.3",
     "@typescript-eslint/eslint-plugin": "^4.26.0",


### PR DESCRIPTION
By fleshing out the very barebones package.json we had, and simply adding a request to do it in the code. While I was at it, I've added a couple of keys to that same file, with reasonable defaults (including the name of the package).