### PR TITLE
Add proper logging on iOS

### DIFF
--- a/ios/PolyPodApp/FeatureContainer/FeatureContainerView.swift
+++ b/ios/PolyPodApp/FeatureContainer/FeatureContainerView.swift
@@ -257,7 +257,7 @@ class FeatureWebView: WKWebView {
         """
         evaluateJavaScript(script) { (_, error) in
             if error != nil {
-                print(
+                Log.error(
                     """
                     Failed to trigger polyNav action '\(action)': \
                     \(String(describing: error))
@@ -302,7 +302,7 @@ extension FeatureWebView: WKScriptMessageHandler {
                         jsExpression,
                         completionHandler: { result, error in
                             if error != nil {
-                                print(
+                                Log.error(
                                     """
                                     Received an error from JavaScript: \
                                     \(error!)
@@ -318,16 +318,16 @@ extension FeatureWebView: WKScriptMessageHandler {
 
     private func doLog(data: [String: Any]) {
         guard let text = data["text"] as? String else {
-            print("Error: WebView sent bad log message")
+            Log.error("WebView sent bad log message")
             return
         }
 
-        print("Message from FeatureContainer: \(text)")
+        Log.info("Message from FeatureContainer: \(text)")
     }
     
     private func doLogError(_ error: [String: Any]) {
         let message = error["message"] as? String ?? "Unknown"
-        print("Error from FeatureContainer: \(message)")
+        Log.error("Error from FeatureContainer: \(message)")
         errorHandler(message)
     }
 }

--- a/ios/PolyPodApp/Features/Feature.swift
+++ b/ios/PolyPodApp/Features/Feature.swift
@@ -58,7 +58,7 @@ private func readManifest(_ basePath: URL) -> FeatureManifest {
     if let manifest = FeatureManifest.load(path: manifestPath) {
         return manifest
     }
-    print("Failed to load feature manifest from: \(manifestPath)")
+    Log.error("Failed to load feature manifest from: \(manifestPath)")
     return FeatureManifest(
         name: nil,
         author: nil,
@@ -87,7 +87,7 @@ private func findThumbnail(featurePath: URL, thumbnailPath: String?) -> URL? {
     }
     let fullPath = featurePath.appendingPathComponent(thumbnailPath)
     if !FileManager.default.fileExists(atPath: fullPath.path) {
-        print("Error: Feature thumbnail at \(thumbnailPath) does not exist")
+        Log.error("Error: Feature thumbnail at \(thumbnailPath) does not exist")
         return nil
     }
     return fullPath

--- a/ios/PolyPodApp/Features/FeatureStorage.swift
+++ b/ios/PolyPodApp/Features/FeatureStorage.swift
@@ -12,7 +12,7 @@ class FeatureStorage {
             let featuresUrl = documentsUrl.appendingPathComponent("Features")
             return featuresUrl
         } catch {
-            print(error.localizedDescription);
+            Log.error("Failed to determine features path: \(error.localizedDescription)");
         }
         return URL(fileURLWithPath: "")
     }()
@@ -26,7 +26,7 @@ class FeatureStorage {
             let featuresUrl = documentsUrl.appendingPathComponent("Features")
             try FileManager.default.removeItem(at: featuresUrl)
         } catch {
-            print(error.localizedDescription);
+            Log.error("Failed to clean features: \(error.localizedDescription)");
         }
     }
     
@@ -45,7 +45,7 @@ class FeatureStorage {
                 }
             }
         } catch {
-            print(error.localizedDescription)
+            Log.error("Failed to list features: \(error.localizedDescription)")
         }
         
         return sortFeatures(featuresList)
@@ -89,7 +89,7 @@ class FeatureStorage {
         do {
             try FileManager.default.createDirectory(atPath: featureDirUrl.absoluteString, withIntermediateDirectories: true, attributes: nil)
         } catch {
-            print(error.localizedDescription);
+            Log.error("Failed to create features folder: \(error.localizedDescription)");
         }
     }
     
@@ -103,12 +103,12 @@ class FeatureStorage {
                     try FileManager.default.copyBundleFile(forResource: "pod", ofType: "html", toDestinationUrl: featuresFileUrl.appendingPathComponent(featureName))
                     try FileManager.default.copyBundleFile(forResource: "initIframe", ofType: "js", toDestinationUrl: featuresFileUrl.appendingPathComponent(featureName))
                     try importPodJs(toFeature: featureName, atUrl: featuresFileUrl)
-                    print("Imported feature: ", featureName)
+                    Log.info("Imported feature: \(featureName)")
                 } else {
-                    print("Feature for import not found: ", featureName)
+                    Log.error("Feature for import not found: \(featureName)")
                 }
             } catch {
-                print("Failed to import feature \(featureName): \(error.localizedDescription)");
+                Log.error("Failed to import feature \(featureName): \(error.localizedDescription)");
             }
         }
     }
@@ -124,7 +124,7 @@ class FeatureStorage {
             ofType: resourceType,
             atDestinationUrl: destinationUrl
         ) {
-            print("""
+            Log.info("""
                 Ignoring \(resourceName).\(resourceType) provided by \
                 \(featureName)
                 """)

--- a/ios/PolyPodApp/PodApi/Network/Network.swift
+++ b/ios/PolyPodApp/PodApi/Network/Network.swift
@@ -55,7 +55,7 @@ class Network: NetworkProtocol {
         semaphore.wait()
         
         if let errorMessage = errorMessage {
-            print("network.httpPost failed: \(errorMessage)")
+            Log.error("network.httpPost failed: \(errorMessage)")
         }
         return errorMessage
     }

--- a/ios/PolyPodApp/PodApi/PolyIn/Quads/PolyIn+Add.swift
+++ b/ios/PolyPodApp/PodApi/PolyIn/Quads/PolyIn+Add.swift
@@ -18,7 +18,7 @@ extension PolyIn {
             try managedContext.save()
             completionHandler(true)
         } catch {
-            print("Could not save. \(error)")
+            Log.error("Could not save. \(error)")
             completionHandler(false)
         }
     }
@@ -39,7 +39,7 @@ extension PolyIn {
                 node.setValue(childNode, forKey: key)
             } else {
                 if entity.attributesByName[key] == nil {
-                    print("Warning: Attempted to set attribute \(key) which is not in \(entityName)")
+                    Log.error("Warning: Attempted to set attribute \(key) which is not in \(entityName)")
                     continue
                 }
                 node.setValue(value, forKeyPath: key)

--- a/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
+++ b/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
@@ -100,7 +100,7 @@ extension PolyOut {
                 completionHandler(nil, PodApiError.unknown)
             }
         } else {
-            print("stat: No such file: \(filePath.path)")
+            Log.error("stat: No such file: \(filePath.path)")
             completionHandler(nil, PodApiError.noSuchFile(url))
         }
     }
@@ -119,7 +119,7 @@ extension PolyOut {
                 completionHandler(content, nil)
             }
         } catch {
-            print(error)
+            Log.error("fileRead for \(url) failed: \(String(describing: error))")
             completionHandler(nil, PolyOutError.platform(error))
         }
     }
@@ -211,7 +211,7 @@ extension PolyOut {
             completionHandler(newUrl)
         }
         catch {
-            print("importArchive for '\(url)' failed: \(error)")
+            Log.error("importArchive for '\(url)' failed: \(error)")
             completionHandler(nil)
         }
     }

--- a/ios/PolyPodApp/PodApi/PostOffice.swift
+++ b/ios/PolyPodApp/PodApi/PostOffice.swift
@@ -59,7 +59,7 @@ class PostOffice {
                 self.completeEvent(messageId: messageId, response: response, error: error, completionHandler: completionHandler)
             })
         default:
-            print("API unknown:", api)
+            Log.error("API unknown: \(api)")
         }
     }
     
@@ -96,7 +96,7 @@ extension PostOffice {
         case "has":
             handlePolyInHas(args: args, completionHandler: completionHandler)
         default:
-            print("PolyIn method unknown:", method)
+            Log.error("PolyIn method unknown: \(method)")
         }
     }
 
@@ -109,7 +109,7 @@ extension PostOffice {
                     Bad argument data: \(arg)
                     \(Thread.callStackSymbols.joined(separator: "\n"))
                 """
-                print(message)
+                Log.error(message)
                 completionHandler(nil, MessagePackValue(message))
                 return extendedDataSet
             }
@@ -219,7 +219,7 @@ extension PostOffice {
         case "removeArchive":
             handlePolyOutRemoveArchive(args: args, completionHandler: completionHandler)
         default:
-            print("PolyOut method unknown:", method)
+            Log.error("PolyOut method unknown: \(method)")
         }
     }
     
@@ -351,7 +351,7 @@ extension PostOffice {
         case "pickFile":
             handlePolyNavPickFile(args: args, completionHandler: completionHandler)
         default:
-            print("PolyNav method unknown:", method)
+            Log.error("PolyNav method unknown: \(method)")
         }
     }
     
@@ -389,7 +389,7 @@ extension PostOffice {
         case "getVersion":
             handleInfoGetVersion(completionHandler: completionHandler)
         default:
-            print("Info method unknown:", method)
+            Log.error("Info method unknown: \(method)")
         }
     }
     
@@ -408,7 +408,7 @@ extension PostOffice {
         case "httpPost":
             handleNetworkHttpPost(args: args, completionHandler: completionHandler)
         default:
-            print("PolyNav method unknown:", method)
+            Log.error("PolyNav method unknown: \(method)")
         }
     }
     

--- a/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
+++ b/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		E9F370DD262EE9EE006254C1 /* WidthReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F370DC262EE9EE006254C1 /* WidthReader.swift */; };
 		E9F370E1262EEB2C006254C1 /* ParagraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F370E0262EEB2C006254C1 /* ParagraphView.swift */; };
 		E9F370E7262EEF13006254C1 /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F370E6262EEF13006254C1 /* UIColorExtensions.swift */; };
+		E9F68ED227580A0B009ED2C1 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = E996EBD12756BBE900EAC9F7 /* Log.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -808,6 +809,7 @@
 				1ABADBF224EE70B500369791 /* DataFactory.swift in Sources */,
 				1ABADBFC24EE710B00369791 /* Quad+CoreDataProperties.swift in Sources */,
 				E9545ECA27359C38001E8C7F /* UserDefaultsExtensions.swift in Sources */,
+				E9F68ED227580A0B009ED2C1 /* Log.swift in Sources */,
 				1ABADBF424EE70E700369791 /* LocationTracker.swift in Sources */,
 				1ABADBF724EE710B00369791 /* NamedNode+CoreDataClass.swift in Sources */,
 				1ABADC0724EE717000369791 /* Bubblewrap.swift in Sources */,

--- a/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
+++ b/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		E98BA80226D4DD9A0039E41E /* PolyIn+Has.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0F7B6226AD841D00F4EFF4 /* PolyIn+Has.swift */; };
 		E98BA80326D4DD9D0039E41E /* PolyIn+Delete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0F7B6026AD840E00F4EFF4 /* PolyIn+Delete.swift */; };
 		E98D506A26F3741100C3FCF4 /* handleErrors.js in Resources */ = {isa = PBXBuildFile; fileRef = E98D506926F3741100C3FCF4 /* handleErrors.js */; };
+		E996EBD22756BBE900EAC9F7 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = E996EBD12756BBE900EAC9F7 /* Log.swift */; };
 		E9B2203C263314AD005E8881 /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CF1B2F2625866800216B70 /* Feature.swift */; };
 		E9B2203D263314AD005E8881 /* FeatureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF4689D2420D5F600E51B6D /* FeatureStorage.swift */; };
 		E9B2203E263314AD005E8881 /* FeatureManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97D3275263152CE00A5A180 /* FeatureManifest.swift */; };
@@ -257,6 +258,7 @@
 		E989B352269DDC9E000EE977 /* PolyNavTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolyNavTests.swift; sourceTree = "<group>"; };
 		E98BA7FE26D3CA2F0039E41E /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
 		E98D506926F3741100C3FCF4 /* handleErrors.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = handleErrors.js; sourceTree = "<group>"; };
+		E996EBD12756BBE900EAC9F7 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		E9CF1B2F2625866800216B70 /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
 		E9CF1B5C2625CDBB00216B70 /* FeatureListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureListView.swift; sourceTree = "<group>"; };
 		E9CF1B632625EA3200216B70 /* FeatureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureView.swift; sourceTree = "<group>"; };
@@ -433,6 +435,7 @@
 				E9545EAD273530ED001E8C7F /* UpdateNotification.swift */,
 				E93EC98B273D65D400E20512 /* Authentication.swift */,
 				E96817F0274D032A00206602 /* Language.swift */,
+				E996EBD12756BBE900EAC9F7 /* Log.swift */,
 			);
 			path = PolyPod;
 			sourceTree = "<group>";
@@ -846,6 +849,7 @@
 				1AF468B2242A34D700E51B6D /* PolyOut.swift in Sources */,
 				E9040D4726F0A30E00A88593 /* Info.swift in Sources */,
 				1A66F7692490DB8700ED4308 /* FetchRequestInit.swift in Sources */,
+				E996EBD22756BBE900EAC9F7 /* Log.swift in Sources */,
 				1A66F77D2493774100ED4308 /* NetworkSession.swift in Sources */,
 				E97D325626307CE100A5A180 /* ColorExtensions.swift in Sources */,
 				1A6F4DF424C1A76E00874DF9 /* PolyIn+Select.swift in Sources */,

--- a/ios/PolyPodApp/PolyPod/AppDelegate.swift
+++ b/ios/PolyPodApp/PolyPod/AppDelegate.swift
@@ -11,7 +11,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         let defaults = UserDefaults.standard
         if defaults.bool(forKey: UserDefaults.Keys.resetUserDefaults.rawValue) {
-            print("Resetting all user defaults")
+            Log.info("Resetting all user defaults")
             UserDefaults.standard.reset()
         }
         
@@ -24,7 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let managedContext = persistentContainer.viewContext
         let fetchRequest: NSFetchRequest<Quad> = Quad.fetchRequest()
         let count = try! managedContext.count(for: fetchRequest)
-        print("Number of quads in Core Data:", count)
+        Log.debug("Number of quads in Core Data: \(count)")
         
         self.registerUpdateNotificationCheck()
         
@@ -39,7 +39,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     private func handleUpdateNotificationCheck(_ task: BGTask) {
         task.expirationHandler = {
-            print("Update notification check expired")
+            Log.error("Update notification check expired")
             task.setTaskCompleted(success: false)
         }
         
@@ -69,7 +69,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.add(request) { error in
             if error != nil {
-                print("Error showing update notification: \(error!.localizedDescription)")
+                Log.error("Error showing update notification: \(error!.localizedDescription)")
             }
         }
     }
@@ -163,7 +163,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         do {
             try BGTaskScheduler.shared.submit(task)
         } catch {
-            print("Failed to schedule task \(AppDelegate.updateNotificationCheckIdentifier): \(error.localizedDescription)")
+            Log.error("Failed to schedule task \(AppDelegate.updateNotificationCheckIdentifier): \(error.localizedDescription)")
         }
     }
 }

--- a/ios/PolyPodApp/PolyPod/Authentication.swift
+++ b/ios/PolyPodApp/PolyPod/Authentication.swift
@@ -75,7 +75,7 @@ class Authentication {
             localizedReason: NSLocalizedString(reason, comment: "")
         ) { (success, error) in
             if !success {
-                print("Authentication failed: \(String(describing: error))")
+                Log.error("Authentication failed: \(String(describing: error))")
             }
             completeAction(success)
         }

--- a/ios/PolyPodApp/PolyPod/FeatureView.swift
+++ b/ios/PolyPodApp/PolyPod/FeatureView.swift
@@ -122,7 +122,7 @@ struct FeatureView: View {
             return
         }
         guard let url = URL(string: urlString) else {
-            print("Error: Invalid URL format: \(urlString)")
+            Log.error("openUrl: Invalid URL format: \(urlString)")
             return
         }
         let alert = UIAlertController(

--- a/ios/PolyPodApp/PolyPod/FilePicker.swift
+++ b/ios/PolyPodApp/PolyPod/FilePicker.swift
@@ -24,7 +24,7 @@ class FilePicker: NSObject, UIDocumentPickerDelegate {
         guard let mime = mime else { return "public.item" }
         if mime == "application/zip" { return "com.pkware.zip-archive" }
         // TODO: Throw proper error
-        print("Unsupported MIME type: \(mime)")
+        Log.error("Unsupported MIME type: \(mime)")
         return mimeToUti(nil)
     }
     
@@ -37,7 +37,7 @@ class FilePicker: NSObject, UIDocumentPickerDelegate {
                 fileSize = Int64(truncating: fileNumberSize)
             }
         } catch {
-            print(error.localizedDescription)
+            Log.error("Failed to load file data: \(error.localizedDescription)")
         }
         return ExternalFile(url: url.absoluteString, name: url.lastPathComponent, size: fileSize)
     }

--- a/ios/PolyPodApp/PolyPod/Log.swift
+++ b/ios/PolyPodApp/PolyPod/Log.swift
@@ -1,0 +1,25 @@
+import Foundation
+import os.log
+
+class Log {
+    static let log = OSLog(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: "application"
+    )
+    
+    static func debug(_ message: String) {
+        log(.debug, message)
+    }
+    
+    static func info(_ message: String) {
+        log(.info, message)
+    }
+    
+    static func error(_ message: String) {
+        log(.error, message)
+    }
+    
+    private static func log(_ type: OSLogType, _ message: String) {
+        os_log("%s", log: log, type: type, message)
+    }
+}


### PR DESCRIPTION
This should make it easier for us to understand crashes we cannot
reproduce. In my understanding, all the error level log messages we
write, are being stored on the device. Info level log messages aren't,
but I think all the cases I used info for are not incredibly helpful for
debugging issues that happen in the wild.

I did improve _some_ log messages, but there's still a lot of work to do
in terms of making them consistent, not duplicating the same strings so
much, and being more specific about where an issue occurred. A large
chunk of our error log messages in the API code also needs to throw an
actual error, so that it can propagate back to the feature. As opposed
to Android, a lot of errors are currently being swallowed.

But still, I think this is a good first step.