### PR TITLE
Take the new path for photos into account.

### DIFF
--- a/features/facebookImport/src/model/analyses/ministories/about-pictures-data-analysis.js
+++ b/features/facebookImport/src/model/analyses/ministories/about-pictures-data-analysis.js
@@ -48,8 +48,8 @@ export default class AboutPicturesDataAnalysis extends RootAnalysis {
      */
     async _userPicturesFromExport(zipFile) {
         const photoRegexes = [
-            /^photos_and_videos\/(.+)\.(jpg|jpeg)$/,
-            /^posts\/media\/(.+)\.(jpg|jpeg)$/,
+            /^photos_and_videos\/(.+)\.(jpg|jpeg)$/i,
+            /^posts\/media\/(.+)\.(jpg|jpeg)$/i,
         ];
         const relevantEntries = await relevantZipEntries(zipFile);
         return relevantEntries.filter((zipEntry) => {

--- a/features/facebookImport/src/model/analyses/ministories/about-pictures-data-analysis.js
+++ b/features/facebookImport/src/model/analyses/ministories/about-pictures-data-analysis.js
@@ -28,8 +28,12 @@ export default class AboutPicturesDataAnalysis extends RootAnalysis {
      * Determine the pictures posted by the user.
      *
      * At the moment, since we do not import posts and albums,
-     * we count only the number of picture files in the folder
-     * "photos_and_videos" where posted pictures are exported.
+     * we count only the number of picture files posted by the
+     * user. For that we look in a list of folders where user
+     * pictures are saved. Depending on the export, posted pictures
+     * are exported in one of two folders:
+     *   - "photos_and_videos"
+     *   - "posts/media"
      *
      * Depending on the export that folder might contain also
      * other picture files like "emptyalbum.png" which was not
@@ -43,12 +47,17 @@ export default class AboutPicturesDataAnalysis extends RootAnalysis {
      * simply include all pictures in that folder.
      */
     async _userPicturesFromExport(zipFile) {
+        const photoRegexes = [
+            /^photos_and_videos\/(.+)\.(jpg|jpeg)$/,
+            /^posts\/media\/(.+)\.(jpg|jpeg)$/,
+        ];
         const relevantEntries = await relevantZipEntries(zipFile);
-        return relevantEntries.filter((zipEntry) =>
-            /^photos_and_videos\/(.+)\.(jpg|jpeg)$/.test(
-                removeEntryPrefix(zipEntry)
-            )
-        );
+        return relevantEntries.filter((zipEntry) => {
+            const entryNameWithoutPrefix = removeEntryPrefix(zipEntry);
+            return photoRegexes.find((regex) =>
+                regex.test(entryNameWithoutPrefix)
+            );
+        });
     }
 
     async analyze({ zipFile }) {

--- a/features/facebookImport/test/ministory/about-pictures-data-analysis.test.js
+++ b/features/facebookImport/test/ministory/about-pictures-data-analysis.test.js
@@ -72,7 +72,7 @@ describe("Pictures ministory on export with JPEG pictures in posts/media locatio
     beforeAll(async () => {
         let zipFile = new ZipFileMock();
         zipFile.addNamedEntry(
-            "posts/media/TimelinePhotos_24T6AJAQ42/14567839_1208576379157271_232556476_n_21487783899157271.jpg",
+            "posts/media/TimelinePhotos_24T6AJAQ42/14567839_1208576379157271_232556476_n_21487783899157271.jpeg",
             ""
         );
 

--- a/features/facebookImport/test/ministory/about-pictures-data-analysis.test.js
+++ b/features/facebookImport/test/ministory/about-pictures-data-analysis.test.js
@@ -18,6 +18,10 @@ describe("Pictures ministory on export with no JPEG pictures in correct location
             "messages/inbox/user_2j57v4wtoa/photos/14567839_1208576379157271_232556476_n_21487783899157271.jpg",
             ""
         );
+        zipFile.addNamedEntry(
+            "photos/data/inbox/user_2j57v4wtoa/photos/14567839_1208576379157271_232556476_n_21487783899157271.jpg",
+            ""
+        );
         const { analysisResult } = await runAnalysisForExport(
             AboutPicturesDataAnalysis,
             zipFile
@@ -34,7 +38,7 @@ describe("Pictures ministory on export with no JPEG pictures in correct location
     });
 });
 
-describe("Pictures ministory on export with JPEG pictures in correct location", () => {
+describe("Pictures ministory on export with JPEG pictures in photos_and_videos location", () => {
     let analysis = null;
     let status = null;
 
@@ -42,6 +46,33 @@ describe("Pictures ministory on export with JPEG pictures in correct location", 
         let zipFile = new ZipFileMock();
         zipFile.addNamedEntry(
             "photos_and_videos/TimelinePhotos_24T6AJAQ42/14567839_1208576379157271_232556476_n_21487783899157271.jpg",
+            ""
+        );
+
+        const { analysisResult } = await runAnalysisForExport(
+            AboutPicturesDataAnalysis,
+            zipFile
+        );
+        ({ analysis, status } = analysisResult);
+    });
+
+    it("has success status", async () => {
+        expectAnalysisSuccessStatus(status);
+    });
+
+    it("is active", async () => {
+        expectActiveAnalysis(analysis);
+    });
+});
+
+describe("Pictures ministory on export with JPEG pictures in posts/media location", () => {
+    let analysis = null;
+    let status = null;
+
+    beforeAll(async () => {
+        let zipFile = new ZipFileMock();
+        zipFile.addNamedEntry(
+            "posts/media/TimelinePhotos_24T6AJAQ42/14567839_1208576379157271_232556476_n_21487783899157271.jpg",
             ""
         );
 


### PR DESCRIPTION
In newer exports photos are at `posts/media`. Before they were in the `photos_and_videos` folder. This takes both these folders into account in the `AboutPicturesDataAnalysis` mini-story.