### PR TITLE
Restrict build paths

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -1,5 +1,16 @@
 name: Testing polyPod in iOS
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'ios/**'
+      - 'core/**'
+      - 'features/**'
+      - 'build/**'
+  pull_request
+      - 'ios/**'
+      - 'core/**'
+      - 'features/**'
+      - 'build/**'
 jobs:
     test:
         name: Testing polyPod iOS app

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -6,7 +6,7 @@ on:
       - 'core/**'
       - 'features/**'
       - 'build/**'
-  pull_request
+  pull_request:
       - 'ios/**'
       - 'core/**'
       - 'features/**'

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -7,6 +7,7 @@ on:
       - 'features/**'
       - 'build/**'
   pull_request:
+    paths:
       - 'ios/**'
       - 'core/**'
       - 'features/**'


### PR DESCRIPTION
Not a lot, but enough. Originally intended to spin off the build step, but it's just a command, so it eventually ended up this way.