### PR TITLE
PROD4POD-621 - Add Explore Further sections

### DIFF
--- a/features/polyExplorer/src/components/entityList/entityList.css
+++ b/features/polyExplorer/src/components/entityList/entityList.css
@@ -2,6 +2,10 @@
     overflow-y: scroll;
 }
 
+.entity-list.expand {
+    overflow-y: visible;
+}
+
 .entity-list .entity-group {
     display: flex;
     flex-direction: column;

--- a/features/polyExplorer/src/components/entityShortInfo/entityShortInfo.css
+++ b/features/polyExplorer/src/components/entityShortInfo/entityShortInfo.css
@@ -4,7 +4,6 @@
     width: 100%;
     padding: 8px;
     border: none;
-    background-color: var(--color-background-dark);
     outline: none;
     margin: 0;
 }

--- a/features/polyExplorer/src/screens/stories/digitalGiantsStory.jsx
+++ b/features/polyExplorer/src/screens/stories/digitalGiantsStory.jsx
@@ -8,6 +8,7 @@ import SectionTitle from "../../components/clusterStories/sectionTitle.jsx";
 import { Tabs, Tab } from "@polypoly-eu/poly-look";
 import { createJurisdictionLinks } from "./story-utils";
 import { PolyChart } from "@polypoly-eu/poly-look";
+import EntityList from "../../components/entityList/entityList.jsx";
 
 const i18nHeader = "clusterDigitalGiantsStory";
 const i18nHeaderCommon = "clusterStoryCommon";
@@ -103,6 +104,7 @@ const DigitalGiantsStory = () => {
             <SectionTitle
                 title={i18n.t(`${i18nHeaderCommon}:section.explore.further`)}
             />
+            <EntityList entities={bigSix} expand={true} />
         </ClusterStory>
     );
 };

--- a/features/polyExplorer/src/screens/stories/messengerStory.jsx
+++ b/features/polyExplorer/src/screens/stories/messengerStory.jsx
@@ -5,8 +5,10 @@ import { ExplorerContext } from "../../context/explorer-context.jsx";
 import i18n from "../../i18n.js";
 import SectionTitle from "../../components/clusterStories/sectionTitle.jsx";
 import OrderedList from "../../components/orderedList/orderedList.jsx";
+import EntityList from "../../components/entityList/entityList.jsx";
 
 const i18nHeader = "clusterMessengerStory";
+const i18nHeaderCommon = "clusterStoryCommon";
 
 const MessengerStory = () => {
     const { products } = useContext(ExplorerContext);
@@ -60,6 +62,10 @@ const MessengerStory = () => {
             <p>{i18n.t(`${i18nHeader}:overview.paragraph.one`)}</p>
             <div className="chart-container"></div>
             <p>{i18n.t(`${i18nHeader}:overview.paragraph.two`)}</p>
+            <SectionTitle
+                title={i18n.t(`${i18nHeaderCommon}:section.explore.further`)}
+            />
+            <EntityList entities={Object.values(products)} expand={true} />
         </ClusterStory>
     );
 };


### PR DESCRIPTION
While working on this, I had to make some more improvements to EntityList:

1. Add an attribute to expand it, avoiding all the infinite scrolling logic -
   Probably works without, but it seemed wrong to run all that code we know is
   not needed.

2. Avoid re-render loops when using entity arrays - the useMemo I added.

3. Removing the hard coded background from EntityShortInfo - funny enough,
   that's all it took in terms of "theming", CSS FTW.