### PR TITLE
Refactoring and documentation

### DIFF
--- a/core/api/pod-api/src/api.ts
+++ b/core/api/pod-api/src/api.ts
@@ -102,6 +102,10 @@ export interface PolyIn {
     has(...quads: RDF.Quad[]): Promise<boolean>;
 }
 
+/**
+ * `Entry` is used to store filesystem directory entries in a (roughly)
+ * platform independent way.
+ */
 export interface Entry {
     id: string;
     path: string;

--- a/core/api/pod-api/src/api.ts
+++ b/core/api/pod-api/src/api.ts
@@ -113,7 +113,7 @@ export interface Entry {
  *
  * Both of these aspects are separated out into their own modules:
  * - [[FS]] for Node.js-style file-system access
- * - [[Fetch]] for DOM-style HTTP requests
+ * - [[Fetch]] for DOM-style HTTP requests (deprecated)
  */
 export interface PolyOut extends Omit<FS, "readdir"> {
     /**
@@ -121,7 +121,12 @@ export interface PolyOut extends Omit<FS, "readdir"> {
      * A standard-compliant implementation of `Fetch`. This feature is deprecated in favor of the [[Network]] interface
      */
     readonly fetch: Fetch;
-    readDir(id: string): Promise<Entry[]>;
+
+    /**
+     * @param pathToDir system-dependent path to read.
+     * @returns a Promise with id-path pairs [[Entry]] as payload.
+     */
+    readDir(pathToDir: string): Promise<Entry[]>;
 }
 
 /**

--- a/core/api/pod-api/src/default.ts
+++ b/core/api/pod-api/src/default.ts
@@ -105,9 +105,11 @@ export class DefaultPod implements Pod {
             }
 
             readDir(path: string): Promise<Entry[]> {
-                //mock readdir
                 const newFiles = fs.readdir(path).then((files) => {
-                    const objectFiles = files.map((file) => ({ id: file, path: file }));
+                    const objectFiles = files.map((file) => ({
+                        id: path + "/" + file,
+                        path: file,
+                    }));
                     return new Promise<Entry[]>((resolve) => {
                         resolve(objectFiles);
                     });

--- a/core/api/pod-api/src/spec.ts
+++ b/core/api/pod-api/src/spec.ts
@@ -140,7 +140,7 @@ export class PodSpec {
 
                             await polyOut.writeFile(path, content, { encoding: "utf-8" });
                             const filesWithPath = (await polyOut.readDir(this.path)).map(
-                                (path) => this.path + "/" + path["id"]
+                                (path) => this.path + "/" + path["path"]
                             );
                             assert.include(filesWithPath, path);
                         })


### PR DESCRIPTION
My initial idea was to eliminate `readdir` from `FS`, but it's actually used somewhere. Finally did a bit of refactoring mainly renaming identifiers and changing a bit the default implementation so that it actually uses a (roughtly) unique ID for `Entry` `id`

> It might not be a bad idea to enforce that's an ID by making it, for instance, an URI (which, IIRC, is what it actually is).

Also added a bit of doccing for good measure.