### PR TITLE
[Chore] {PROD4POD-1214} Manifest-parser maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ node_modules/
 
 # Andoid specific local config
 android/app/local.properties
+
+# Cypress directories
+**/cypress/support

--- a/core/api/manifest-parser/.npmignore
+++ b/core/api/manifest-parser/.npmignore
@@ -1,8 +1,0 @@
-.idea
-tsconfig.*
-dist/tests
-src
-*.config.js
-*.tgz
-.eslintrc.js
-.github

--- a/core/api/manifest-parser/rollup.config.js
+++ b/core/api/manifest-parser/rollup.config.js
@@ -21,7 +21,7 @@ export default {
     external: [
         "@pnpm/read-package-json",
         "fp-ts/lib/Either",
-        "fp-ts/lib/pipeable",
+        "fp-ts/function",
         "io-ts/lib/Decoder",
         "path",
         "semver",

--- a/core/api/manifest-parser/src/manifest.ts
+++ b/core/api/manifest-parser/src/manifest.ts
@@ -1,7 +1,7 @@
 import * as Decode from "io-ts/lib/Decoder";
 import { fold } from "fp-ts/lib/Either";
 import readPkg from "@pnpm/read-package-json";
-import { pipe } from "fp-ts/lib/pipeable";
+import { pipe } from "fp-ts/function";
 import { parse as parseSemVer, SemVer, Range } from "semver";
 import { normalize, isAbsolute, join, dirname } from "path";
 import { promises as fs } from "fs";

--- a/core/api/manifest-parser/src/manifest.ts
+++ b/core/api/manifest-parser/src/manifest.ts
@@ -32,7 +32,6 @@ export interface FeatureManifest {
 
 export interface Manifest extends EngineManifest, MainManifest, RootManifest, FeatureManifest {}
 
-// TODO duplicated code with podigree, should be a library
 function expect<I, A>(input: I, msg: string, decoder: Decode.Decoder<I, A>): A {
     return pipe(
         decoder.decode(input),


### PR DESCRIPTION
For the time being, it's just a bit of maintenance, bringing it up to date, eliminating deprecations and old files. It sets the stage for further documentation and actual use in the features, as indicated in PROD4POD-1214.
> There are a couple of TODOs that I can't figure out. This is the reason why we should never commit TODO comments to main, and possibly neither we should do it to branches.