### PR TITLE
Upgrades set-up node

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -19,9 +19,11 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v2
               with:
                   node-version: 16
+                  cache: "npm"
+                  cache-dependency-path: "**/package-lock.json"
             - name: Lock xcode version
               run: sudo xcode-select -switch /Applications/Xcode_12.4.app
             - name: Build core and features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v2
               with:
-                  node-version: 16.8
+                  node-version: 16
+                  cache: "npm"
+                  cache-dependency-path: "**/package-lock.json"
             - name: Checks paths to rebuild Android
               uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 #v2.10.2
               id: changes

--- a/build/README.md
+++ b/build/README.md
@@ -7,13 +7,13 @@ that compiles to JavaScript) in the right order.
 
 The polyPod core code, as well as all the bundled features, are separated into
 several NPM packages that include each other via file URLs. Unfortunately, NPM
-does, at the time of writing, not support building a tree of dependent packages, so
+does, at the time of writing, not support building a tree of dependent packages,
 it's up to us to build everything in the right order.
 
 We experimented with a few tools that should eliminate all, or at least some of
 the logic in this module, such as Yarn and pnpm workspaces, and while we could
 get those to work with a few workarounds, in the end we decided to stick with
-plain `npm`. It's probably not the best package manager, but the most widely
+plain NPM. It's probably not the best package manager, but the most widely
 understood and supported one in the JavaScript ecosystem.
 
 Still, hopefully we will be able to eliminate this module one day.

--- a/build/README.md
+++ b/build/README.md
@@ -13,7 +13,7 @@ it's up to us to build everything in the right order.
 We experimented with a few tools that should eliminate all, or at least some of
 the logic in this module, such as Yarn and pnpm workspaces, and while we could
 get those to work with a few workarounds, in the end we decided to stick with
-plain NPM. It's probably not the best package manager, but the most widely
+plain `npm`. It's probably not the best package manager, but the most widely
 understood and supported one in the JavaScript ecosystem.
 
 Still, hopefully we will be able to eliminate this module one day.

--- a/build/README.md
+++ b/build/README.md
@@ -7,7 +7,7 @@ that compiles to JavaScript) in the right order.
 
 The polyPod core code, as well as all the bundled features, are separated into
 several NPM packages that include each other via file URLs. Unfortunately, NPM
-does, at the time of writing, not support building a tree of dependent packages,
+does, at the time of writing, not support building a tree of dependent packages, so
 it's up to us to build everything in the right order.
 
 We experimented with a few tools that should eliminate all, or at least some of


### PR DESCRIPTION
To be able to use advanced cache features. Using the latest node version for LTS 16 instead of locking to 16.8, which was done because of a node upgrade snafu. That's the least important, however, what matters is that the new `setup-node` is able to cache all node_modules from scratch, without needing complicated setups.
This is saving quite a bit, a couple of minutes when cache is hit. Might be more in iOS, taking into account the unpredictable nature of that. And it might be even more, if we eliminate auditing from the build (which we probably should)
![Captura de pantalla de 2022-01-04 08-31-58](https://user-images.githubusercontent.com/500/148024592-37b186c3-9ade-40b9-b019-740386203051.png)

> Changes in the README.md were done to trigger builds, although they should probably stay anyway.

It's a 4 minute difference in iOS
![Captura de pantalla de 2022-01-04 08-37-29](https://user-images.githubusercontent.com/500/148025108-bb1bdd39-4827-4845-bb04-8326ee8125c7.png)
Reducing total time by almost 40% So it's a big win.