### PR TITLE
Different speed-ups to the install/build process

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -166,7 +166,7 @@ const npm = async (...args) => {
         { ...process.env, FORCE_COLOR: 1 }
     );
     const elapsed = new Date() - start;
-    logDetail(`NPM finished in ${elapsed} ms`);
+    logDetail(`${ANSIFont2("npm")} finished in ${elapsed} ms`);
 };
 
 async function npmInstall(name) {
@@ -255,6 +255,10 @@ async function processAll(packageTree, command) {
 
 function ANSIBold(string) {
     return `\x1b[1m${string}\x1b[0m`;
+}
+
+function ANSIFont2(string) {
+    return `\u001b[11m${string}\u001b[10m`;
 }
 
 function logSuccess(command, timeLapsed) {

--- a/build/index.js
+++ b/build/index.js
@@ -167,7 +167,7 @@ const npm = async (...args) => {
     );
     const elapsed = new Date() - start;
     const realCommand = args[args.length - 1];
-    logDetail(` ${ANSIFont2("npm " + realCommand)} finished in ${elapsed} ms`);
+    logDetail(` ${ANSIInvert("npm " + realCommand)} finished in ${elapsed} ms`);
 };
 
 async function npmInstall(name) {
@@ -258,7 +258,7 @@ function ANSIBold(string) {
     return `\x1b[1m${string}\x1b[0m`;
 }
 
-function ANSIFont2(string) {
+function ANSIInvert(string) {
     return `\x1b[7m${string}\x1b[27m`;
 }
 

--- a/build/index.js
+++ b/build/index.js
@@ -258,7 +258,7 @@ function ANSIBold(string) {
 }
 
 function ANSIFont2(string) {
-    return `\u001b[11m${string}\u001b[10m`;
+    return `\x1b[7m${string}\x1b[27m`;
 }
 
 function logSuccess(command, timeLapsed) {

--- a/build/index.js
+++ b/build/index.js
@@ -325,4 +325,4 @@ async function main() {
     }
 }
 
-module.exports = () => main().then(process.exit);
+main().then(process.exit);

--- a/build/index.js
+++ b/build/index.js
@@ -325,4 +325,4 @@ async function main() {
     }
 }
 
-main().then(process.exit);
+module.exports = () => main().then(process.exit);

--- a/build/index.js
+++ b/build/index.js
@@ -171,7 +171,7 @@ const npm = async (...args) => {
 
 async function npmInstall(name) {
     logDetail(`${name}: Installing dependencies ...`);
-    await npm("ci");
+    await npm("--no-audit", "--prefer-offline", "ci");
 }
 
 async function npmRun(script, pkg) {

--- a/build/index.js
+++ b/build/index.js
@@ -166,7 +166,8 @@ const npm = async (...args) => {
         { ...process.env, FORCE_COLOR: 1 }
     );
     const elapsed = new Date() - start;
-    logDetail(`${ANSIFont2("npm")} finished in ${elapsed} ms`);
+    const realCommand = args[args.length - 1];
+    logDetail(` ${ANSIFont2("npm " + realCommand)} finished in ${elapsed} ms`);
 };
 
 async function npmInstall(name) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@polypoly-eu/polyPod",
   "description": "Common monorepo and build script dependencies",
   "scripts": {
-    "clean": "rm -rf node_modules"
+    "clean": "rm -rf node_modules",
+    "build" : "node build/index.js"
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Common monorepo and build script dependencies",
   "scripts": {
     "clean": "rm -rf node_modules",
-    "build" : "node build/index.js"
+    "build" : "./build.js"
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "@polypoly-eu/polyPod",
   "description": "Common monorepo and build script dependencies",
   "scripts": {
-    "clean": "rm -rf node_modules",
-    "build" : "./build.js"
+    "clean": "rm -rf node_modules"
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",


### PR DESCRIPTION
I wanted to make it independent from #578 to assess the impact, if there's any.

> In fact, there's none since when installing from scratch, auditing is done at the self same time. So this PR is mainly a no-op in terms of time.

I'll use this PR to make some more, mostly cosmetic, changes to `build.js`, to understand more clearly what's going on.

There does seem to be a speedup in iOS, see [this](https://github.com/polypoly-eu/polyPod/runs/4699607045?check_suite_focus=true) vs [this](https://github.com/polypoly-eu/polyPod/runs/4699579215?check_suite_focus=true) but MacOS in GHA is so unpredictable, that who know what's happening here.