### PR TITLE
Android build maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
             - uses: actions/setup-java@v1
               if: steps.changes.outputs.android == 'true'
               with:
-                  java-version: 8
+                  java-version: 11
             - name: Test android
               if: steps.changes.outputs.android == 'true'
               working-directory: android

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.synnapps:carouselview:0.1.6'
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation group: 'org.apache.jena', name: 'jena-core', version: '4.2.0'
+    implementation group: 'org.apache.jena', name: 'jena-core', version: '3.17.0'
     implementation 'androidx.work:work-runtime:2.3.4'
     implementation 'androidx.biometric:biometric:1.1.0'
     implementation 'androidx.biometric:biometric-ktx:1.2.0-alpha03'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -119,7 +119,7 @@ dependencies {
     implementation "androidx.preference:preference-ktx:1.1.1"
     implementation 'com.google.android.material:material:1.2.0'
     implementation 'org.slf4j:slf4j-api:1.7.30'
-    implementation 'com.synnapps:carouselview:0.1.6'
+    implementation 'com.synnapps:carouselview:0.1.5'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation group: 'org.apache.jena', name: 'jena-core', version: '3.17.0'
     implementation 'androidx.work:work-runtime:2.3.4'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,6 +102,7 @@ android {
 dependencies {
     implementation project(":bubblewrap")
     implementation project(":polyOut")
+    implementation 'org.msgpack:msgpack-core:0.8.20'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.core:core-ktx:1.3.1'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.synnapps:carouselview:0.1.6'
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation group: 'org.apache.jena', name: 'jena-core', version: '3.17.0'
+    implementation group: 'org.apache.jena', name: 'jena-core', version: '4.2.0'
     implementation 'androidx.work:work-runtime:2.3.4'
     implementation 'androidx.biometric:biometric:1.1.0'
     implementation 'androidx.biometric:biometric-ktx:1.2.0-alpha03'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,6 +99,10 @@ android {
     }
 }
 
+repositories {
+    jcenter()
+}
+
 dependencies {
     implementation project(":bubblewrap")
     implementation project(":polyOut")
@@ -115,7 +119,7 @@ dependencies {
     implementation "androidx.preference:preference-ktx:1.1.1"
     implementation 'com.google.android.material:material:1.2.0'
     implementation 'org.slf4j:slf4j-api:1.7.30'
-    implementation 'com.synnapps:carouselview:0.1.5'
+    implementation 'com.synnapps:carouselview:0.1.6'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation group: 'org.apache.jena', name: 'jena-core', version: '3.17.0'
     implementation 'androidx.work:work-runtime:2.3.4'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation "androidx.webkit:webkit:1.3.0"
-    implementation "androidx.preference:preference:1.1.1"
+    implementation "androidx.preference:preference-ktx:1.1.1"
     implementation 'com.google.android.material:material:1.2.0'
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.synnapps:carouselview:0.1.5'

--- a/android/app/src/main/kotlin/coop/polypoly/polypod/FeatureFragment.kt
+++ b/android/app/src/main/kotlin/coop/polypoly/polypod/FeatureFragment.kt
@@ -251,7 +251,7 @@ open class FeatureFragment : Fragment() {
                 context?.contentResolver
                     ?.query(returnUri, null, null, null, null)
             }?.use { cursor ->
-                if (cursor != null && cursor.moveToFirst()) {
+                if (cursor.moveToFirst()) {
                     val nameIndex =
                         cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
                     val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.3.0'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.4.0'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.4'
@@ -16,7 +16,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/java-fetch/build.gradle
+++ b/android/java-fetch/build.gradle
@@ -5,10 +5,6 @@ plugins {
     id "com.github.johnrengelman.shadow" version "6.0.0"
 }
 
-repositories {
-    jcenter()
-}
-
 import groovy.json.JsonSlurper
 def packageJson = new JsonSlurper().parse file('package.json')
 version = packageJson.version

--- a/android/java-fetch/build.gradle
+++ b/android/java-fetch/build.gradle
@@ -28,7 +28,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 task testJar(type: ShadowJar) {
     archiveClassifier = 'tests'
     from sourceSets.test.output
-    configurations = [project.configurations.testRuntime]
+    configurations = [project.configurations.testRuntimeClasspath]
 }
 
 task mochaTest(type: Exec) {

--- a/core/communication/bubblewrap/build.gradle
+++ b/core/communication/bubblewrap/build.gradle
@@ -13,7 +13,7 @@ def packageJson = new JsonSlurper().parse file('package.json')
 version = packageJson.version
 
 dependencies {
-    compile 'org.msgpack:msgpack-core:0.8.20'
+    implementation 'org.msgpack:msgpack-core:0.8.20'
     testImplementation 'org.graalvm.js:js:20.1.0'
     testImplementation 'net.jqwik:jqwik:1.3.3'
     testImplementation 'org.assertj:assertj-core:3.17.1'

--- a/core/communication/bubblewrap/build.gradle
+++ b/core/communication/bubblewrap/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id "com.github.node-gradle.node" version "2.2.4"
 }
 
-repositories {
-    jcenter()
-}
-
 import groovy.json.JsonSlurper
 def packageJson = new JsonSlurper().parse file('package.json')
 version = packageJson.version


### PR DESCRIPTION
As usual, this is a revision of the Android build looking for possible upgrades; main issue here was the upgrade of the Gradle plugin for Android studio and fixing of the corresponding problems with outdated Gradle configurations. Fell free to comment or outright dismiss.

I would say the only major change, besides the gradle plugin (that has leapt 3 majors) is the Java version in the test configuration. The rest are minor changes, some version upgrades, elimination of jcenter almost everywhere. This should have no major impact, except prevent from deprecations in the near future (they will hit us anyway)

> Would it be interesting to consider [this new implementation of CarouselView](https://github.com/jama5262/CarouselView) which is in a Maven repository?

I've compiled it locally with Android Studio 2020.3.1 Patch 4 without any problem.
![Captura de pantalla de 2022-01-06 20-45-06](https://user-images.githubusercontent.com/500/148442170-6228fa3b-5dc5-41f3-acae-b094988a78b6.png)
I've checked the Android studio page, and it's not a big deal that version 11 is used for built and test, as long as the features used also have support by Android Studio, as they apparently have. So there might be something I'm missing here, but I have kept the minSdkVersion as it was, no change there, as you can see.

So I guess this closes #420 