### PR TITLE
[Task] {PROD4POD-1194} Trying to make silly-i18n more serviceable to current usage (in polyExplorer and others)

### DIFF
--- a/core/utils/silly-i18n/src/index.js
+++ b/core/utils/silly-i18n/src/index.js
@@ -158,15 +158,6 @@ export class I18nSection extends I18n {
      * @returns The translated string.
      */
     t(key, options = {}) {
-        let translation = this._translations[this._section][key];
-        if (!translation) {
-            throw new TranslationKeyError(
-                `We do not have a ${key} key for language ${this.language} and section ${this._section}`
-            );
-        }
-
-        for (let [name, value] of Object.entries(options))
-            translation = translation.replace(`{{${name}}}`, value);
-        return translation;
+        return super.t(`${this._section}:${key}`, options);
     }
 }

--- a/core/utils/silly-i18n/src/index.js
+++ b/core/utils/silly-i18n/src/index.js
@@ -92,7 +92,6 @@ export class I18n {
         }
         this.language = language in translations ? language : fallbackLanguage;
         this._translations = translations[this.language];
-        Object.freeze(this);
     }
 
     /**
@@ -145,8 +144,7 @@ export class I18nSection extends I18n {
      * @throws NonExistingSectionError - if the `section` key is not included in the translations hash
      */
     constructor(i18n, section) {
-        this.language = i18n.language;
-        this._translations = i18n._translations;
+        super(i18n.language, { [i18n.language]: i18n._translations });
         this._key = section;
         Object.freeze(this);
     }

--- a/core/utils/silly-i18n/src/index.js
+++ b/core/utils/silly-i18n/src/index.js
@@ -145,8 +145,8 @@ export class I18nSection extends I18n {
      * @throws NonExistingSectionError - if the `section` key is not included in the translations hash
      */
     constructor(i18n, section) {
-        const { language, translation, fallbackLanguage } = i18n;
-        super(language, translation, fallbackLanguage);
+        this.language = i18n.language;
+        this._translations = i18n._translations;
         this._key = section;
         Object.freeze(this);
     }

--- a/core/utils/silly-i18n/src/index.js
+++ b/core/utils/silly-i18n/src/index.js
@@ -51,11 +51,11 @@ export class I18n {
     /**
      * Class constructor
      *
-     * @param language - two-letter language code, which should be a key in the translation hash.
+     * @param {string} language - two-letter language code, which should be a key in the translation hash.
      *     If this key does not exist, `fallbackLanguage` will be used.
-     * @param translations - translations hash. This is going to have the format `namespace ⇒ key ⇒ string`
+     * @param {Object} translations - translations hash. This is going to have the format `namespace ⇒ key ⇒ string`
      *     within every language. Only the language that's detected will be used.
-     * @param fallbackLanguage - "default" language to use in case the one in `language`
+     * @param {string} [ fallbackLanguage = language ] - "default" language to use in case the one in `language`
      *     is not a part of the `translations` hash.
      *     It's an optional parameter, that defaults to the first key
      *     in the `translations` hash, so you might want to use arrange it
@@ -81,8 +81,8 @@ export class I18n {
     /**
      * Obtains the (translated) string for a `namespace:key` defined in the translations hash.
      *
-     * @param key - the translation key in the `namespace:key` format
-     * @param options - simple templating capabilities; this will be a key-value hash, so that `{{{key}}}` will be substituted by the key value in this hash
+     * @param {string} key - the translation key in the `namespace:key` format
+     * @param {Object} options - simple templating capabilities; this will be a key-value hash, so that `{{{key}}}` will be substituted by the key value in this hash
      * @throws TranslationKeyError - if the translation key does not have the correct format, or is missing the key part, or the key does not exist.
      * @returns The translated string.
      */

--- a/core/utils/silly-i18n/src/index.js
+++ b/core/utils/silly-i18n/src/index.js
@@ -145,8 +145,10 @@ export class I18nSection extends I18n {
      * @throws NonExistingSectionError - if the `section` key is not included in the translations hash
      */
     constructor(i18n, section) {
-        this.key = section;
-        return undefined;
+        const { language, translation, fallbackLanguage } = i18n;
+        super(language, translation, fallbackLanguage);
+        this._key = section;
+        Object.freeze(this);
     }
 
     /**

--- a/core/utils/silly-i18n/src/index.js
+++ b/core/utils/silly-i18n/src/index.js
@@ -145,7 +145,7 @@ export class I18nSection extends I18n {
      */
     constructor(i18n, section) {
         super(i18n.language, { [i18n.language]: i18n._translations });
-        this._key = section;
+        this._section = section;
         Object.freeze(this);
     }
 
@@ -158,10 +158,10 @@ export class I18nSection extends I18n {
      * @returns The translated string.
      */
     t(key, options = {}) {
-        let translation = this._translations[this.key][keyInNamespace];
+        let translation = this._translations[this._section][key];
         if (!translation) {
             throw new TranslationKeyError(
-                `We do not have a ${keyInNamespace} key for language ${this.language}`
+                `We do not have a ${key} key for language ${this.language} and section ${this._section}`
             );
         }
 

--- a/core/utils/silly-i18n/test/basic.test.js
+++ b/core/utils/silly-i18n/test/basic.test.js
@@ -1,6 +1,7 @@
 import {
     determineLanguage,
     LanguageError,
+    NonExistingSectionError,
     TranslationKeyError,
     I18n,
 } from "../src/index.js";
@@ -37,6 +38,17 @@ describe("Test basic configuration", () => {
         }
         expect(thrownError).toBeInstanceOf(TranslationKeyError);
         expect(thrownError.message).toEqual(expect.stringMatching(/format/));
+    });
+
+    it("Throws when the namespace does not exist", () => {
+        let thrownError;
+        try {
+            i18n.t("WAT:WOOT");
+        } catch (error) {
+            thrownError = error;
+        }
+        expect(thrownError).toBeInstanceOf(NonExistingSectionError);
+        expect(thrownError.message).toEqual(expect.stringMatching(/section/));
     });
 
     it("Throws when key not found", () => {

--- a/core/utils/silly-i18n/test/section.test.js
+++ b/core/utils/silly-i18n/test/section.test.js
@@ -1,14 +1,6 @@
-import {
-    determineLanguage,
-    LanguageError,
-    NonExistingSectionError,
-    TranslationKeyError,
-    I18n,
-    I18nSection,
-} from "../src/index.js";
+import { TranslationKeyError, I18n, I18nSection } from "../src/index.js";
 
 const LANGUAGE = "foo";
-const FALLBACK_LANGUAGE = "en";
 let i18n, i18ns;
 
 beforeAll(() => {

--- a/core/utils/silly-i18n/test/section.test.js
+++ b/core/utils/silly-i18n/test/section.test.js
@@ -22,4 +22,7 @@ describe("Test basic configuration", () => {
     it("is created correctly", () => {
         expect(i18ns).toBeInstanceOf(I18nSection);
     });
+    it("Translates correctly", () => {
+        expect(i18ns.t("bar")).toBe("baz");
+    });
 });

--- a/core/utils/silly-i18n/test/section.test.js
+++ b/core/utils/silly-i18n/test/section.test.js
@@ -1,0 +1,25 @@
+import {
+    determineLanguage,
+    LanguageError,
+    NonExistingSectionError,
+    TranslationKeyError,
+    I18n,
+    I18nSection,
+} from "../src/index.js";
+
+const LANGUAGE = "foo";
+const FALLBACK_LANGUAGE = "en";
+let i18n, i18ns;
+
+beforeAll(() => {
+    i18n = new I18n(LANGUAGE, {
+        [LANGUAGE]: { quux: { bar: "baz" }, options: { opt: "{{opt}}" } },
+    });
+    i18ns = new I18nSection(i18n, "quux");
+});
+
+describe("Test basic configuration", () => {
+    it("is created correctly", () => {
+        expect(i18ns).toBeInstanceOf(I18nSection);
+    });
+});

--- a/core/utils/silly-i18n/test/section.test.js
+++ b/core/utils/silly-i18n/test/section.test.js
@@ -26,7 +26,7 @@ describe("Test basic configuration", () => {
         }
         expect(thrownError).toBeInstanceOf(TranslationKeyError);
         expect(thrownError.message).toEqual(
-            expect.stringMatching(/do not have/)
+            expect.stringMatching(/does not have/)
         );
     });
 });

--- a/core/utils/silly-i18n/test/section.test.js
+++ b/core/utils/silly-i18n/test/section.test.js
@@ -25,4 +25,16 @@ describe("Test basic configuration", () => {
     it("Translates correctly", () => {
         expect(i18ns.t("bar")).toBe("baz");
     });
+    it("Throws when key not found", () => {
+        let thrownError;
+        try {
+            i18ns.t("WAT");
+        } catch (error) {
+            thrownError = error;
+        }
+        expect(thrownError).toBeInstanceOf(TranslationKeyError);
+        expect(thrownError.message).toEqual(
+            expect.stringMatching(/do not have/)
+        );
+    });
 });

--- a/features/polyExplorer/.gitignore
+++ b/features/polyExplorer/.gitignore
@@ -3,3 +3,4 @@
 /scripts/convert-polypedia-data.log
 /cypress/screenshots/**/*(failed)*
 /cypress/videos
+/cypress/support

--- a/features/polyExplorer/src/components/dataRegionsLegend/dataRegionsLegend.jsx
+++ b/features/polyExplorer/src/components/dataRegionsLegend/dataRegionsLegend.jsx
@@ -4,7 +4,7 @@ import "./dataRegionsLegend.css";
 import i18n from "../../i18n.js";
 import { I18nSection } from "@polypoly-eu/silly-i18n";
 
-const i18nC = new I18nSection( i18n, "common");
+const i18nC = new I18nSection(i18n, "common");
 
 const DataRegionsLegend = () => {
     return (

--- a/features/polyExplorer/src/components/dataRegionsLegend/dataRegionsLegend.jsx
+++ b/features/polyExplorer/src/components/dataRegionsLegend/dataRegionsLegend.jsx
@@ -2,6 +2,9 @@ import React from "react";
 
 import "./dataRegionsLegend.css";
 import i18n from "../../i18n.js";
+import { I18nSection } from "@polypoly-eu/silly-i18n";
+
+const i18nC = new I18nSection( i18n, "common");
 
 const DataRegionsLegend = () => {
     return (
@@ -13,28 +16,28 @@ const DataRegionsLegend = () => {
                 <div className="legend">
                     <div>
                         <div className="circle China"></div>
-                        <p>{i18n.t("common:jurisdiction.china")}</p>
+                        <p>{i18nC.t("jurisdiction.china")}</p>
                     </div>
                     <div>
                         <div className="circle Five-Eyes"></div>
-                        <p>{i18n.t("common:jurisdiction.fiveEyes")}</p>
+                        <p>{i18nC.t("jurisdiction.fiveEyes")}</p>
                     </div>
                     <div>
                         <div className="circle Russia"></div>
-                        <p>{i18n.t("common:jurisdiction.russia")}</p>
+                        <p>{i18nC.t("jurisdiction.russia")}</p>
                     </div>
                     <div>
                         <div className="circle EU-GDPR"></div>
-                        <p>{i18n.t("common:jurisdiction.euGdpr")}</p>
+                        <p>{i18nC.t("jurisdiction.euGdpr")}</p>
                     </div>
                     <div>
                         <div className="circle Others"></div>
-                        <p>{i18n.t("common:jurisdiction.undisclosed")}</p>
+                        <p>{i18nC.t("jurisdiction.undisclosed")}</p>
                     </div>
                 </div>
             </div>
             <div className="source">
-                <p>{i18n.t("common:source")}: polyPedia</p>
+                <p>{i18nC.t("source")}: polyPedia</p>
             </div>
         </div>
     );

--- a/features/polyExplorer/src/components/discoverCard/discoverCard.jsx
+++ b/features/polyExplorer/src/components/discoverCard/discoverCard.jsx
@@ -9,10 +9,7 @@ const i18nP = new I18nSection(i18n, "clusterStoriesPreview");
 const DiscoverCard = ({ story }) => {
     return (
         <div className="discover-container">
-            <img
-                src={story.img.src}
-                alt={i18nP.t(story.img.alt)}
-            />
+            <img src={story.img.src} alt={i18nP.t(story.img.alt)} />
             <h3>{i18nP.t(story.title)}</h3>
             <p>{i18nP.t(story.previewText)}</p>
             <LinkButton route={story.route} className="discover-button">

--- a/features/polyExplorer/src/components/discoverCard/discoverCard.jsx
+++ b/features/polyExplorer/src/components/discoverCard/discoverCard.jsx
@@ -9,9 +9,9 @@ const i18nP = new I18nSection(i18n, "clusterStoriesPreview");
 const DiscoverCard = ({ story }) => {
     return (
         <LinkButton route={story.route} className="preview">
-            <img src={story.img.src} alt={i18nP.t("story.img.alt")} />
-            <h3>{i18nP.t("story.title}")}</h3>
-            <p>{i18nP.t("story.previewText")}</p>
+            <img src={story.img.src} alt={i18nP.t(story.img.alt)} />
+            <h3>{i18nP.t(story.title)}</h3>
+            <p>{i18nP.t(story.previewText)}</p>
         </LinkButton>
     );
 };

--- a/features/polyExplorer/src/components/discoverCard/discoverCard.jsx
+++ b/features/polyExplorer/src/components/discoverCard/discoverCard.jsx
@@ -3,17 +3,18 @@ import LinkButton from "../buttons/linkButton/linkButton.jsx";
 import i18n from "../../i18n";
 
 import "./discoverCard.css";
+import { I18nSection } from "@polypoly-eu/silly-i18n";
 
-const i18nHeader = "clusterStoriesPreview";
+const i18nP = new I18nSection(i18n,"clusterStoriesPreview");
 const DiscoverCard = ({ story }) => {
     return (
         <LinkButton route={story.route} className="preview">
             <img
                 src={story.img.src}
-                alt={i18n.t(`${i18nHeader}:${story.img.alt}`)}
+                alt={i18nP.t("story.img.alt")}
             />
-            <h3>{i18n.t(`${i18nHeader}:${story.title}`)}</h3>
-            <p>{i18n.t(`${i18nHeader}:${story.previewText}`)}</p>
+            <h3>{i18nP.t("story.title}")}</h3>
+            <p>{i18nP.t("story.previewText")}</p>
         </LinkButton>
     );
 };

--- a/features/polyExplorer/src/components/discoverCard/discoverCard.jsx
+++ b/features/polyExplorer/src/components/discoverCard/discoverCard.jsx
@@ -5,14 +5,11 @@ import i18n from "../../i18n";
 import "./discoverCard.css";
 import { I18nSection } from "@polypoly-eu/silly-i18n";
 
-const i18nP = new I18nSection(i18n,"clusterStoriesPreview");
+const i18nP = new I18nSection(i18n, "clusterStoriesPreview");
 const DiscoverCard = ({ story }) => {
     return (
         <LinkButton route={story.route} className="preview">
-            <img
-                src={story.img.src}
-                alt={i18nP.t("story.img.alt")}
-            />
+            <img src={story.img.src} alt={i18nP.t("story.img.alt")} />
             <h3>{i18nP.t("story.title}")}</h3>
             <p>{i18nP.t("story.previewText")}</p>
         </LinkButton>

--- a/features/polyExplorer/src/components/discoverCard/discoverCard.jsx
+++ b/features/polyExplorer/src/components/discoverCard/discoverCard.jsx
@@ -8,25 +8,17 @@ import { I18nSection } from "@polypoly-eu/silly-i18n";
 const i18nP = new I18nSection(i18n, "clusterStoriesPreview");
 const DiscoverCard = ({ story }) => {
     return (
-<<<<<<< HEAD
-        <LinkButton route={story.route} className="preview">
-            <img src={story.img.src} alt={i18nP.t(story.img.alt)} />
-            <h3>{i18nP.t(story.title)}</h3>
-            <p>{i18nP.t(story.previewText)}</p>
-        </LinkButton>
-=======
         <div className="discover-container">
             <img
                 src={story.img.src}
-                alt={i18n.t(`${i18nHeader}:${story.img.alt}`)}
+                alt={i18nP.t(story.img.alt)}
             />
-            <h3>{i18n.t(`${i18nHeader}:${story.title}`)}</h3>
-            <p>{i18n.t(`${i18nHeader}:${story.previewText}`)}</p>
+            <h3>{i18nP.t(story.title)}</h3>
+            <p>{i18nP.t(story.previewText)}</p>
             <LinkButton route={story.route} className="discover-button">
                 {i18n.t("clusterStoriesPreview:story.button.discover")}
             </LinkButton>
         </div>
->>>>>>> main
     );
 };
 

--- a/features/polyExplorer/src/locales/en/stories/clusterStoriesPreview.json
+++ b/features/polyExplorer/src/locales/en/stories/clusterStoriesPreview.json
@@ -1,7 +1,7 @@
 {
   "story.messenger.title": "Why most messenger apps are (not really) for free.",
   "story.messenger.summarize": "When a digital service is offered free of charge the users and their data are usually the product that makes money.",
-  "story.messenger.alt": "Messanger story",
+  "story.messenger.alt": "Messenger story",
   "story.digitalGiants.title": "Digital Giants – How the big six treat our data.",
   "story.digitalGiants.summarize": "Some very few, very big tech companies control big chunks of our data. Here is what we found about them and their way of handling our data.",
   "story.digitalGiants.alt": "Digital gigants story"


### PR DESCRIPTION
Essentially, try to reduce boilerplate by creating a new class that includes as attribute the `section` (called "header" sometimes) that's reused in most, if not all, polyExplorer (and others) files.

Also:
* improve a bit documentation by indicating types and default values (after pioneering work done by @RichardSto )
* Refactor a couple of polyExplorer components to use this new feature.

> Come to think of this, the pattern should actually be inverted: a i18n object should be constructed out of a set of Section objects, which should also be enabled to work by themselves. That would avoid the [usual pattern](https://github.com/polypoly-eu/polyPod/blob/main/features/facebookImport/src/i18n.js)