### PR TITLE
Adds sync to the build script

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -8,11 +8,11 @@ const { performance } = require("perf_hooks");
 const validCommands = [
     "build",
     "clean",
-    "test",
     "lint",
     "lintfix",
     "list",
     "list-deps",
+    "test",
 ];
 
 function parseCommandLine() {

--- a/build/index.js
+++ b/build/index.js
@@ -198,8 +198,11 @@ const commands = {
     build: (pkg) => npmInstall(pkg.name).then(() => npmRun("build", pkg)),
     test: (pkg) => npmRun("test", pkg),
     clean: (pkg) => cleanPackage(pkg),
-    sync: (pkg) => {
-        fs.rmSync("package-lock.json"); npmRun("i", pkg)
+    sync: () => {
+        if (fs.existsSync("package-lock.json")) { 
+            fs.rmSync("package-lock.json");
+        }
+        npm("i");
     },
 };
 

--- a/build/index.js
+++ b/build/index.js
@@ -12,6 +12,7 @@ const validCommands = [
     "lintfix",
     "list",
     "list-deps",
+    "sync",
     "test",
 ];
 
@@ -197,6 +198,7 @@ const commands = {
     build: (pkg) => npmInstall(pkg.name).then(() => npmRun("build", pkg)),
     test: (pkg) => npmRun("test", pkg),
     clean: (pkg) => cleanPackage(pkg),
+    sync: (pkg) => npm("i"),
 };
 
 async function executeCommand(pkg, command) {

--- a/build/index.js
+++ b/build/index.js
@@ -194,16 +194,19 @@ async function cleanPackage(pkg) {
         await fsPromises.rm(path, { recursive: true, force: true });
 }
 
+async function syncPackage(pkg) {
+    logDetail(`🕑 ${pkg.name} ...`);
+    if (fs.existsSync("package-lock.json")) { 
+        fs.rmSync("package-lock.json");
+    }
+    await npm("i");
+}
+
 const commands = {
     build: (pkg) => npmInstall(pkg.name).then(() => npmRun("build", pkg)),
     test: (pkg) => npmRun("test", pkg),
     clean: (pkg) => cleanPackage(pkg),
-    sync: () => {
-        if (fs.existsSync("package-lock.json")) { 
-            fs.rmSync("package-lock.json");
-        }
-        npm("i");
-    },
+    sync: (pkg) => syncPackage(pkg),
 };
 
 async function executeCommand(pkg, command) {

--- a/build/index.js
+++ b/build/index.js
@@ -12,7 +12,7 @@ const validCommands = [
     "lintfix",
     "list",
     "list-deps",
-    "sync",
+    "sync-deps",
     "test",
 ];
 
@@ -206,7 +206,7 @@ const commands = {
     build: (pkg) => npmInstall(pkg.name).then(() => npmRun("build", pkg)),
     test: (pkg) => npmRun("test", pkg),
     clean: (pkg) => cleanPackage(pkg),
-    sync: (pkg) => syncPackage(pkg),
+    "sync-deps": (pkg) => syncPackage(pkg),
 };
 
 async function executeCommand(pkg, command) {

--- a/build/index.js
+++ b/build/index.js
@@ -198,7 +198,9 @@ const commands = {
     build: (pkg) => npmInstall(pkg.name).then(() => npmRun("build", pkg)),
     test: (pkg) => npmRun("test", pkg),
     clean: (pkg) => cleanPackage(pkg),
-    sync: (pkg) => npm("i"),
+    sync: (pkg) => {
+        fs.rmSync("package-lock.json"); npmRun("i", pkg)
+    },
 };
 
 async function executeCommand(pkg, command) {


### PR DESCRIPTION
The use case for this is when there are some security updates in an upstream package (anything in core), that's included also in the `package-lock.json` of downstream dependencies (features). So it was incredibly tedious to rebuild every single package from the one that had been modified. If it was a cornerstone package such as `pod-api` it needed *a lot* of `cd`ing and `npm i`ing.
This, together with the `--start` feature that @fhd added, will really simplify and save a lot of time (mine mainly for the time being, but who knows)