### PR TITLE
Fix black SVG artefacts

### DIFF
--- a/features/polyExplorer/src/static/images/stories/digital-giants/card-image.svg
+++ b/features/polyExplorer/src/static/images/stories/digital-giants/card-image.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 328 169" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg viewBox="0 0 328 169" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <rect y="3.05176e-05" width="328" height="169" fill="url(#paint0_linear)"/>
 <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="328" height="170">
 <rect y="0.000274658" width="328" height="169" fill="#D8D8D8"/>

--- a/features/polyExplorer/src/static/images/stories/messenger/card-image.svg
+++ b/features/polyExplorer/src/static/images/stories/messenger/card-image.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 328 169" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg viewBox="0 0 328 169" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="328" height="169">
 <rect width="328" height="169" fill="#0F1938"/>
 </mask>


### PR DESCRIPTION
These were introduced by 25606f1f2de9288ab987a5d09dcce942b6c2dbd3 - I
think it was an accident. Given how we get those SVG images from
designers, I don't think we want to ever manually modify them.