### PR TITLE
Upgrade shx → shelljs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "rollup": "^2.60.2",
         "rollup-plugin-css-only": "^3.1.0",
         "rollup-plugin-svg": "^2.0.0",
-        "shx": "^0.3.3",
+        "shx": "^0.3.4",
         "svelte": "^3.38.2",
         "ts-jest": "^27.0.7",
         "typedoc": "^0.22.10",
@@ -4033,6 +4033,7 @@
     },
     "node_modules/interpret": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true,
       "engines": {
@@ -6060,6 +6061,7 @@
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "dependencies": {
@@ -6070,12 +6072,17 @@
       }
     },
     "node_modules/rechoir/node_modules/resolve": {
-      "version": "1.20.0",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
+      "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.8.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6378,8 +6385,9 @@
       }
     },
     "node_modules/shelljs": {
-      "version": "0.8.4",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "dev": true,
       "dependencies": {
         "glob": "^7.0.0",
@@ -6405,12 +6413,13 @@
       }
     },
     "node_modules/shx": {
-      "version": "0.3.3",
-      "integrity": "sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.3",
-        "shelljs": "^0.8.4"
+        "shelljs": "^0.8.5"
       },
       "bin": {
         "shx": "lib/cli.js"
@@ -10372,6 +10381,7 @@
     },
     "interpret": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
@@ -11875,6 +11885,7 @@
     },
     "rechoir": {
       "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
@@ -11882,12 +11893,14 @@
       },
       "dependencies": {
         "resolve": {
-          "version": "1.20.0",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
+          "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
           "dev": true,
           "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
+            "is-core-module": "^2.8.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
           }
         }
       }
@@ -12110,8 +12123,9 @@
       "dev": true
     },
     "shelljs": {
-      "version": "0.8.4",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -12131,12 +12145,13 @@
       }
     },
     "shx": {
-      "version": "0.3.3",
-      "integrity": "sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.3",
-        "shelljs": "^0.8.4"
+        "shelljs": "^0.8.5"
       }
     },
     "side-channel": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "rollup": "^2.60.2",
     "rollup-plugin-css-only": "^3.1.0",
     "rollup-plugin-svg": "^2.0.0",
-    "shx": "^0.3.3",
+    "shx": "^0.3.4",
     "svelte": "^3.38.2",
     "ts-jest": "^27.0.7",
     "typedoc": "^0.22.10",


### PR DESCRIPTION
Mainly to take care of [this vulnerability](https://github.com/polypoly-eu/polyPod/security/dependabot/package-lock.json/shelljs/open). It does not look as if we're really affected by it, but OTOH, upgrading one notch is not such a big deal, so I guess it's OK.