### PR TITLE
Upgrades socket.io → engine.io

### DIFF
--- a/core/utils/dummy-server/package-lock.json
+++ b/core/utils/dummy-server/package-lock.json
@@ -9,7 +9,6 @@
             "version": "0.0.2",
             "dependencies": {
                 "express": "^4.17.1",
-                "socket.io": "^3.1.2",
                 "socket.io-client": "3.1.2"
             },
             "bin": {
@@ -19,6 +18,7 @@
             "devDependencies": {
                 "@babel/core": "^7.14.6",
                 "@babel/preset-env": "^7.14.7",
+                "socket.io": "^4.4.1",
                 "supertest": "^6.1.3"
             }
         },
@@ -1553,17 +1553,20 @@
         "node_modules/@types/cookie": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+            "dev": true
         },
         "node_modules/@types/cors": {
             "version": "2.8.12",
             "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
-            "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
+            "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
+            "dev": true
         },
         "node_modules/@types/node": {
-            "version": "16.4.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.0.tgz",
-            "integrity": "sha512-HrJuE7Mlqcjj+00JqMWpZ3tY8w7EUd+S0U3L1+PQSWiXZbOgyQDvi+ogoUxaHApPJq5diKxYBQwA3iIlNcPqOg=="
+            "version": "17.0.8",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+            "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
+            "dev": true
         },
         "node_modules/accepts": {
             "version": "1.3.7",
@@ -1665,6 +1668,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+            "dev": true,
             "engines": {
                 "node": "^4.5.0 || >= 5.9"
             }
@@ -1882,6 +1886,7 @@
             "version": "2.8.5",
             "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
             "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "dev": true,
             "dependencies": {
                 "object-assign": "^4",
                 "vary": "^1"
@@ -1960,17 +1965,21 @@
             }
         },
         "node_modules/engine.io": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
-            "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.1.tgz",
+            "integrity": "sha512-AyMc20q8JUUdvKd46+thc9o7yCZ6iC6MoBCChG5Z1XmFMpp+2+y/oKvwpZTUJB0KCjxScw1dV9c2h5pjiYBLuQ==",
+            "dev": true,
             "dependencies": {
+                "@types/cookie": "^0.4.1",
+                "@types/cors": "^2.8.12",
+                "@types/node": ">=10.0.0",
                 "accepts": "~1.3.4",
                 "base64id": "2.0.0",
                 "cookie": "~0.4.1",
                 "cors": "~2.8.5",
                 "debug": "~4.3.1",
-                "engine.io-parser": "~4.0.0",
-                "ws": "~7.4.2"
+                "engine.io-parser": "~5.0.0",
+                "ws": "~8.2.3"
             },
             "engines": {
                 "node": ">=10.0.0"
@@ -2024,32 +2033,34 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/engine.io/node_modules/base64-arraybuffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz",
+            "integrity": "sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
         "node_modules/engine.io/node_modules/cookie": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
             "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
         },
-        "node_modules/engine.io/node_modules/ws": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+        "node_modules/engine.io/node_modules/engine.io-parser": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.2.tgz",
+            "integrity": "sha512-wuiO7qO/OEkPJSFueuATIXtrxF7/6GTbAO9QLv7nnbjwZ5tYhLm9zxvLwxstRs0dcT0KUlWTjtIOs1T86jt12g==",
+            "dev": true,
+            "dependencies": {
+                "base64-arraybuffer": "~1.0.1"
+            },
             "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
+                "node": ">=10.0.0"
             }
         },
         "node_modules/escalade": {
@@ -2478,6 +2489,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2798,28 +2810,27 @@
             }
         },
         "node_modules/socket.io": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.2.tgz",
-            "integrity": "sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
+            "integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
+            "dev": true,
             "dependencies": {
-                "@types/cookie": "^0.4.0",
-                "@types/cors": "^2.8.8",
-                "@types/node": ">=10.0.0",
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
-                "debug": "~4.3.1",
-                "engine.io": "~4.1.0",
-                "socket.io-adapter": "~2.1.0",
-                "socket.io-parser": "~4.0.3"
+                "debug": "~4.3.2",
+                "engine.io": "~6.1.0",
+                "socket.io-adapter": "~2.3.3",
+                "socket.io-parser": "~4.0.4"
             },
             "engines": {
                 "node": ">=10.0.0"
             }
         },
         "node_modules/socket.io-adapter": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
-            "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg=="
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
+            "integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
+            "dev": true
         },
         "node_modules/socket.io-client": {
             "version": "3.1.2",
@@ -3083,6 +3094,27 @@
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/xmlhttprequest-ssl": {
@@ -4171,17 +4203,20 @@
         "@types/cookie": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+            "dev": true
         },
         "@types/cors": {
             "version": "2.8.12",
             "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
-            "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
+            "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
+            "dev": true
         },
         "@types/node": {
-            "version": "16.4.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.0.tgz",
-            "integrity": "sha512-HrJuE7Mlqcjj+00JqMWpZ3tY8w7EUd+S0U3L1+PQSWiXZbOgyQDvi+ogoUxaHApPJq5diKxYBQwA3iIlNcPqOg=="
+            "version": "17.0.8",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+            "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
+            "dev": true
         },
         "accepts": {
             "version": "1.3.7",
@@ -4264,7 +4299,8 @@
         "base64id": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-            "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
+            "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+            "dev": true
         },
         "body-parser": {
             "version": "1.19.0",
@@ -4438,6 +4474,7 @@
             "version": "2.8.5",
             "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
             "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "dev": true,
             "requires": {
                 "object-assign": "^4",
                 "vary": "^1"
@@ -4493,29 +4530,43 @@
             "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
         },
         "engine.io": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
-            "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.1.tgz",
+            "integrity": "sha512-AyMc20q8JUUdvKd46+thc9o7yCZ6iC6MoBCChG5Z1XmFMpp+2+y/oKvwpZTUJB0KCjxScw1dV9c2h5pjiYBLuQ==",
+            "dev": true,
             "requires": {
+                "@types/cookie": "^0.4.1",
+                "@types/cors": "^2.8.12",
+                "@types/node": ">=10.0.0",
                 "accepts": "~1.3.4",
                 "base64id": "2.0.0",
                 "cookie": "~0.4.1",
                 "cors": "~2.8.5",
                 "debug": "~4.3.1",
-                "engine.io-parser": "~4.0.0",
-                "ws": "~7.4.2"
+                "engine.io-parser": "~5.0.0",
+                "ws": "~8.2.3"
             },
             "dependencies": {
+                "base64-arraybuffer": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz",
+                    "integrity": "sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA==",
+                    "dev": true
+                },
                 "cookie": {
                     "version": "0.4.1",
                     "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-                    "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+                    "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+                    "dev": true
                 },
-                "ws": {
-                    "version": "7.4.6",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-                    "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-                    "requires": {}
+                "engine.io-parser": {
+                    "version": "5.0.2",
+                    "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.2.tgz",
+                    "integrity": "sha512-wuiO7qO/OEkPJSFueuATIXtrxF7/6GTbAO9QLv7nnbjwZ5tYhLm9zxvLwxstRs0dcT0KUlWTjtIOs1T86jt12g==",
+                    "dev": true,
+                    "requires": {
+                        "base64-arraybuffer": "~1.0.1"
+                    }
                 }
             }
         },
@@ -4882,7 +4933,8 @@
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
         },
         "object-inspect": {
             "version": "1.11.0",
@@ -5146,25 +5198,24 @@
             }
         },
         "socket.io": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.2.tgz",
-            "integrity": "sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
+            "integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
+            "dev": true,
             "requires": {
-                "@types/cookie": "^0.4.0",
-                "@types/cors": "^2.8.8",
-                "@types/node": ">=10.0.0",
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
-                "debug": "~4.3.1",
-                "engine.io": "~4.1.0",
-                "socket.io-adapter": "~2.1.0",
-                "socket.io-parser": "~4.0.3"
+                "debug": "~4.3.2",
+                "engine.io": "~6.1.0",
+                "socket.io-adapter": "~2.3.3",
+                "socket.io-parser": "~4.0.4"
             }
         },
         "socket.io-adapter": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
-            "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg=="
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
+            "integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
+            "dev": true
         },
         "socket.io-client": {
             "version": "3.1.2",
@@ -5350,6 +5401,13 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+        },
+        "ws": {
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "dev": true,
+            "requires": {}
         },
         "xmlhttprequest-ssl": {
             "version": "1.6.3",

--- a/core/utils/dummy-server/package.json
+++ b/core/utils/dummy-server/package.json
@@ -22,12 +22,12 @@
     },
     "dependencies": {
         "express": "^4.17.1",
+        "socket.io": "^4.4.1",
         "socket.io-client": "3.1.2"
     },
     "devDependencies": {
         "@babel/core": "^7.14.6",
         "@babel/preset-env": "^7.14.7",
-        "socket.io": "^4.4.1",
         "supertest": "^6.1.3"
     },
     "bin": {

--- a/core/utils/dummy-server/package.json
+++ b/core/utils/dummy-server/package.json
@@ -22,12 +22,12 @@
     },
     "dependencies": {
         "express": "^4.17.1",
-        "socket.io": "^3.1.2",
         "socket.io-client": "3.1.2"
     },
     "devDependencies": {
         "@babel/core": "^7.14.6",
         "@babel/preset-env": "^7.14.7",
+        "socket.io": "^4.4.1",
         "supertest": "^6.1.3"
     },
     "bin": {


### PR DESCRIPTION
Takes care of [this alert](https://github.com/polypoly-eu/polyPod/security/dependabot/core/utils/dummy-server/package-lock.json/engine.io/open). Since `dummy-server` is just that, used for tests and so on, making it crash is not such a great deal so impact is not exceptional, but then we don't know what this is going to be used for in the future, and it's just an upgrade to a newer version that might improve performance and suchlike. So we're in with that.