### PR TITLE
[Task] Split install and build in build.js

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -20,6 +20,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v2
             - uses: actions/setup-node@v2
+              id: setup
               with:
                   node-version: 16
                   cache: "npm"

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -26,6 +26,9 @@ jobs:
                   cache-dependency-path: "**/package-lock.json"
             - name: Lock xcode version
               run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+            - name: Installs deps only if needed
+              if: steps.setup.outputs.cache-hit != 'true'
+              run: ./build.js install
             - name: Build core and features
               run: ./build.js
             - name: Build and test iOS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
               with:
                   node-version: 16
                   cache: "npm"
-                  cache-dependency-path: "**/package-lock.json"
+                  cache-dependency-path: **/package-lock.json
             - name: Checks paths to rebuild Android
               uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 #v2.10.2
               id: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,9 @@ jobs:
             - name: Lint core and features
               if: steps.changes.outputs.js == 'true'
               run: ./build.js lint
+            - name: Installs deps only if needed
+              if: steps.setup.outputs.cache-hit != 'true'
+              run: ./build.js install
             - name: Build core and features
               if: steps.changes.outputs.coreAndFeatures == 'true' || steps.changes.outputs.android == 'true'
               run: ./build.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
+              id: setup
               with:
                   node-version: 16
                   cache: "npm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
               with:
                   node-version: 16
                   cache: "npm"
-                  cache-dependency-path: **/package-lock.json
+                  cache-dependency-path: "**/package-lock.json"
             - name: Checks paths to rebuild Android
               uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 #v2.10.2
               id: changes

--- a/build/index.js
+++ b/build/index.js
@@ -10,6 +10,7 @@ const { performance } = require("perf_hooks");
 const validCommands = [
     "build",
     "clean",
+    "install",
     "lint",
     "lintfix",
     "list",
@@ -210,7 +211,8 @@ async function syncPackage(pkg) {
 }
 
 const commands = {
-    build: (pkg) => npmInstall(pkg.name).then(() => npmRun("build", pkg)),
+    install: (pkg) => npmInstall(pkg.name),
+    build: (pkg) => npmRun("build", pkg),
     test: (pkg) => npmRun("test", pkg),
     clean: (pkg) => cleanPackage(pkg),
     "sync-deps": (pkg) => syncPackage(pkg),

--- a/core/api/fetch-spec/package-lock.json
+++ b/core/api/fetch-spec/package-lock.json
@@ -12,7 +12,7 @@
         "@types/chai": "^4.2.14",
         "@types/chai-as-promised": "^7.1.3",
         "@types/node-fetch": "^2.5.8",
-        "chai": "^4.2.0",
+        "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "node-fetch": "^2.6.1",
         "ts-node": "^9.1.1"
@@ -28,7 +28,7 @@
       "dev": true,
       "dependencies": {
         "express": "^4.17.1",
-        "socket.io": "^3.1.2",
+        "socket.io": "^4.4.1",
         "socket.io-client": "3.1.2"
       },
       "bin": {
@@ -342,7 +342,7 @@
         "@babel/core": "^7.14.6",
         "@babel/preset-env": "^7.14.7",
         "express": "^4.17.1",
-        "socket.io": "^3.1.2",
+        "socket.io": "^4.4.1",
         "socket.io-client": "3.1.2",
         "supertest": "^6.1.3"
       }

--- a/core/api/fetch-spec/package.json
+++ b/core/api/fetch-spec/package.json
@@ -10,7 +10,7 @@
   "module": "dist/index.es.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/polypoly-eu/polyPod.git"
+    "url": "https://github.com/polypoly-eu/polyPod"
   },
   "scripts": {
     "build": "shx rm -rf tsconfig.tsbuildinfo dist && tsc --emitDeclarationOnly && rollup -c",

--- a/core/api/fetch-spec/package.json
+++ b/core/api/fetch-spec/package.json
@@ -27,7 +27,7 @@
     "@types/chai": "^4.2.14",
     "@types/chai-as-promised": "^7.1.3",
     "@types/node-fetch": "^2.5.8",
-    "chai": "^4.2.0",
+    "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "node-fetch": "^2.6.1",
     "ts-node": "^9.1.1"


### PR DESCRIPTION
I have been checking tests after cache activation, and found that there was 0 improvements in the build times. Then I've gone and read what `npm ci` actually does, which is, wait for it, delete `node_modules`  and rebuild it from package-lock.json. So we were creating a very efficient cache that was very efficiently deleted and rebuilt.
The problem is that, so far, installation and build were done in the same step. That's a problem, because we can't effectively use the cache. So what this PR proposes is splitting these two, really separate, tasks, and peform installation *only* if there's a cache miss and then we need to rebuild.