### PR TITLE
PROD4POD-1272 adjusted intro images to be anchored to the right

### DIFF
--- a/features/polyExplorer/src/components/clusterStory/clusterStory.css
+++ b/features/polyExplorer/src/components/clusterStory/clusterStory.css
@@ -42,11 +42,17 @@
     padding-top: 25px;
 }
 
+.cluster-story .cluster-story-img-container {
+    max-width: var(--max-width);
+    display: flex;
+    justify-content: end;
+    margin: 0 -16px 60px -16px;
+}
+
 .cluster-story .cluster-story-img {
     width: 348px;
     height: 468px;
     display: block;
-    margin: 0 auto 60px auto;
 }
 
 .cluster-story .big-first-letter::first-letter {

--- a/features/polyExplorer/src/screens/stories/digitalGiantsStory.jsx
+++ b/features/polyExplorer/src/screens/stories/digitalGiantsStory.jsx
@@ -153,11 +153,13 @@ const DigitalGiantsStory = () => {
             <p className="big-first-letter">
                 {i18n.t(`${i18nHeader}:intro.p.1`)}
             </p>
-            <img
-                className="cluster-story-img"
-                src="images/stories/digital-giants/intro.svg"
-                alt={i18n.t(`${i18nHeader}:intro.image.alt`)}
-            />
+            <div className="cluster-story-img-container">
+                <img
+                    className="cluster-story-img"
+                    src="images/stories/digital-giants/intro.svg"
+                    alt={i18n.t(`${i18nHeader}:intro.image.alt`)}
+                />
+            </div>
             <GradientCircleList
                 introText={i18n.t(`${i18nHeader}:intro.p.2`)}
                 list={bigSixNames}

--- a/features/polyExplorer/src/screens/stories/messengerStory.jsx
+++ b/features/polyExplorer/src/screens/stories/messengerStory.jsx
@@ -198,11 +198,13 @@ const MessengerStory = () => {
             <p className="big-first-letter">
                 {i18n.t(`${i18nHeader}:intro.paragraph.one`)}
             </p>
-            <img
-                className="cluster-story-img"
-                src="images/stories/messenger/intro-guy.svg"
-                alt={i18n.t(`${i18nHeader}:intro.image.alt`)}
-            />
+            <div className="cluster-story-img-container">
+                <img
+                    className="cluster-story-img"
+                    src="images/stories/messenger/intro-guy.svg"
+                    alt={i18n.t(`${i18nHeader}:intro.image.alt`)}
+                />
+            </div>
             <p>{i18n.t(`${i18nHeader}:intro.paragraph.two`)}</p>
             <GradientCircleList
                 introText={i18n.t(`${i18nHeader}:intro.paragraph.two`)}


### PR DESCRIPTION
As the images where previously centered in the contents container, the images would have a space from the right and left that would create a discontinuity. The images are now corrected to remove this spacing.   