### PR TITLE
Add docs to ignored directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ android/app/local.properties
 
 # Cypress directories
 **/cypress/support
+
+# Generated docs
+docs/


### PR DESCRIPTION
These will crop up when you start to use `jsdoc`/`typedoc`