### PR TITLE
HTRT info button keeps track of activeTab

### DIFF
--- a/core/utils/poly-look/src/react-components/tabs/tabs.jsx
+++ b/core/utils/poly-look/src/react-components/tabs/tabs.jsx
@@ -4,7 +4,7 @@ import Tab from "./tab.jsx";
 
 import "./tabs.css";
 
-const Tabs = ({ children, swipe = true }) => {
+const Tabs = ({ children, swipe = true, onTabChange = () => {} }) => {
   const [activeTabId, setActiveTabId] = useState(children[0].props.id);
 
   const swiperRef = useRef();
@@ -13,6 +13,7 @@ const Tabs = ({ children, swipe = true }) => {
     ev.preventDefault();
     swiperRef.current.swiper.slideTo(index);
     setActiveTabId(newActiveTabId);
+    onTabChange(newActiveTabId);
   };
 
   return (
@@ -36,9 +37,10 @@ const Tabs = ({ children, swipe = true }) => {
         slidesPerView={1}
         initialSlide={0}
         watchOverflow={true}
-        onSlideChange={(swiper) =>
-          setActiveTabId(children[swiper.activeIndex].props.id)
-        }
+        onSlideChange={(swiper) => {
+          setActiveTabId(children[swiper.activeIndex].props.id);
+          onTabChange(children[swiper.activeIndex].props.id);
+        }}
       >
         {swipe
           ? children.map((tab) => (

--- a/core/utils/poly-look/src/react-components/tabs/tabs.jsx
+++ b/core/utils/poly-look/src/react-components/tabs/tabs.jsx
@@ -4,7 +4,7 @@ import Tab from "./tab.jsx";
 
 import "./tabs.css";
 
-const Tabs = ({ children, swipe = true, onTabChange = () => {} }) => {
+const Tabs = ({ children, swipe = true, onTabChange }) => {
   const [activeTabId, setActiveTabId] = useState(children[0].props.id);
 
   const swiperRef = useRef();
@@ -13,7 +13,7 @@ const Tabs = ({ children, swipe = true, onTabChange = () => {} }) => {
     ev.preventDefault();
     swiperRef.current.swiper.slideTo(index);
     setActiveTabId(newActiveTabId);
-    onTabChange(newActiveTabId);
+    if (onTabChange) onTabChange(newActiveTabId);
   };
 
   return (
@@ -39,7 +39,7 @@ const Tabs = ({ children, swipe = true, onTabChange = () => {} }) => {
         watchOverflow={true}
         onSlideChange={(swiper) => {
           setActiveTabId(children[swiper.activeIndex].props.id);
-          onTabChange(children[swiper.activeIndex].props.id);
+          if (onTabChange) onTabChange(children[swiper.activeIndex].props.id);
         }}
       >
         {swipe

--- a/features/polyExplorer/src/components/clusterStories/receivingCompanies.jsx
+++ b/features/polyExplorer/src/components/clusterStories/receivingCompanies.jsx
@@ -116,21 +116,12 @@ function Industries({ entities }) {
 }
 
 export default function ReceivingCompanies({ entities }) {
-    const [selectedRecievingCompaniesTab, setSelectedRecievingCompaniesTab] =
+    const [selectedReceivingEntitiesTab, setSelectedReceivingEntitiesTab] =
         useState("companies-bar-chart-info");
     const switchCompany = (tabId) => {
-        switch (tabId) {
-            case "companies":
-                setSelectedRecievingCompaniesTab("companies-bar-chart-info");
-                break;
-            case "industries":
-                setSelectedRecievingCompaniesTab(
-                    "industries-packed-circle-info"
-                );
-                break;
-            default:
-                setSelectedRecievingCompaniesTab("companies-bar-chart-info");
-        }
+        if (tabId === "industries")
+            setSelectedReceivingEntitiesTab("industries-packed-circle-info");
+        else setSelectedReceivingEntitiesTab("companies-bar-chart-info");
     };
     return (
         <div className="receiving-companies">
@@ -153,7 +144,7 @@ export default function ReceivingCompanies({ entities }) {
                 </Tab>
             </Tabs>
             <SourceInfoButton
-                infoScreen={selectedRecievingCompaniesTab}
+                infoScreen={selectedReceivingEntitiesTab}
                 source={i18n.t("common:source.polyPedia")}
             />
         </div>

--- a/features/polyExplorer/src/components/clusterStories/receivingCompanies.jsx
+++ b/features/polyExplorer/src/components/clusterStories/receivingCompanies.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from "react";
+import React, { useState, useContext, useMemo } from "react";
 import { Tabs, Tab, PolyChart } from "@polypoly-eu/poly-look";
 import SourceInfoButton from "../sourceInfoButton/sourceInfoButton.jsx";
 
@@ -116,9 +116,25 @@ function Industries({ entities }) {
 }
 
 export default function ReceivingCompanies({ entities }) {
+    const [selectedRecievingCompaniesTab, setSelectedRecievingCompaniesTab] =
+        useState("companies-bar-chart-info");
+    const switchCompany = (tabId) => {
+        switch (tabId) {
+            case "companies":
+                setSelectedRecievingCompaniesTab("companies-bar-chart-info");
+                break;
+            case "industries":
+                setSelectedRecievingCompaniesTab(
+                    "industries-packed-circle-info"
+                );
+                break;
+            default:
+                setSelectedRecievingCompaniesTab("companies-bar-chart-info");
+        }
+    };
     return (
         <div className="receiving-companies">
-            <Tabs>
+            <Tabs onTabChange={switchCompany}>
                 <Tab
                     id="companies"
                     label={i18n.t(
@@ -126,10 +142,6 @@ export default function ReceivingCompanies({ entities }) {
                     )}
                 >
                     <Companies entities={entities} />
-                    <SourceInfoButton
-                        infoScreen="companies-bar-chart-info"
-                        source={i18n.t("common:source.polyPedia")}
-                    />
                 </Tab>
                 <Tab
                     id="industries"
@@ -138,12 +150,12 @@ export default function ReceivingCompanies({ entities }) {
                     )}
                 >
                     <Industries entities={entities} />
-                    <SourceInfoButton
-                        infoScreen="industries-packed-circle-info"
-                        source={i18n.t("common:source.polyPedia")}
-                    />
                 </Tab>
             </Tabs>
+            <SourceInfoButton
+                infoScreen={selectedRecievingCompaniesTab}
+                source={i18n.t("common:source.polyPedia")}
+            />
         </div>
     );
 }


### PR DESCRIPTION
In order to anchor the info button to the right, the button was removed from the individual tabs and inserted into the parent component. A useState was implemented to keep track of the active tab and now a custom callback can be triggered every time the tab is changed.