### PR TITLE
PROD4POD-1242 - Replace FileUtils.sizeOfDirectory

### DIFF
--- a/android/app/src/main/kotlin/coop/polypoly/polypod/polyOut/PolyOut.kt
+++ b/android/app/src/main/kotlin/coop/polypoly/polypod/polyOut/PolyOut.kt
@@ -97,13 +97,13 @@ open class PolyOut(
         return result
     }
 
-    private fun determineSize(file: File): Long {
-        if (!file.isDirectory) return file.length()
+    private fun determineSize(fileOrDirectory: File): Long {
+        if (!fileOrDirectory.isDirectory) return fileOrDirectory.length()
         // We previously used FileUtils.sizeOfDirectory here, which had some
         // special cases for symbolic links and negative file sizes. It did,
         // however, use java.nio.file.Path.toPath(), which does not exist
         // on API 24, so we replaced it with this simpler implementation.
-        val files = file.listFiles() ?: return 0L
+        val files = fileOrDirectory.listFiles() ?: return 0L
         return files.sumOf { determineSize(it) }
     }
 


### PR DESCRIPTION
Since it doesn't seem to work on API 24. It's probably better this way
anyway, because we don't explicitly have commons-io as a dependency,
it's pulled in through Jena it seems.