### PR TITLE
[Task] Provide information if the AppStore workflow is launched from non-main non-release branches.

### DIFF
--- a/.github/workflows/upload_app_store.yml
+++ b/.github/workflows/upload_app_store.yml
@@ -6,10 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.ref != 'refs/heads/main' && startsWith(github.ref, 'refs/heads/release') != true }}
     steps:
-      name: No go zone
-      env:
-        REF: ${{github.ref}}
-      run: echo "::error::🚫 ${REF} is not a «main» or «release» branch, only ones allowed"
+      - name: No go zone
+        env:
+          REF: ${{github.ref}}
+        run: echo "::error::🚫 ${REF} is not a «main» or «release» branch, only ones allowed"
+
   build_test_upload:
     name: Build, test, and upload to App Store
     runs-on: macos-11

--- a/.github/workflows/upload_app_store.yml
+++ b/.github/workflows/upload_app_store.yml
@@ -1,6 +1,15 @@
 name: Upload IPA to App Store
 on: workflow_dispatch
 jobs:
+  say_something_if_incorrect_branch:
+    name: Bail out with informative error
+    runs-on: ubuntu-latest
+    if: ${{ github.ref != 'refs/heads/main' && startsWith(github.ref, 'refs/heads/release') != true }}
+    steps:
+      name: No go zone
+      env:
+        REF: ${{github.ref}}
+      run: echo "::error::🚫 ${REF} is not a «main» or «release» branch, only ones allowed"
   build_test_upload:
     name: Build, test, and upload to App Store
     runs-on: macos-11


### PR DESCRIPTION
If it fails to meet the conditions, it will simply not run the job. Instead, this one will run and provide an error message.