### PR TITLE
[Spike] Introduce spell checking into the linting process

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,29 +2,27 @@ module.exports = {
     extends: [
         "eslint:recommended",
         "plugin:prettier/recommended",
-        "plugin:react/recommended"
+        "plugin:react/recommended",
     ],
-    "plugins": [
-        "cypress"
-    ],
+    plugins: ["cypress", "spellcheck"],
     parserOptions: {
         ecmaVersion: 2020,
         sourceType: "module",
     },
     env: {
-        browser : true,
+        browser: true,
         es6: true,
         mocha: true,
         jest: true,
         node: true,
-        "cypress/globals": true
+        "cypress/globals": true,
     },
     settings: {
         react: {
             version: "latest",
         },
     },
-    "ignorePatterns": [
+    ignorePatterns: [
         "*.conf.*",
         "*.config.*",
         "*.bundled.*",
@@ -40,11 +38,32 @@ module.exports = {
         "**/storybook-static/*",
         "podApi/",
         "**/build/*",
-        "PolyPodApp/"],
+        "PolyPodApp/",
+    ],
     rules: {
         semi: 2,
         "react/prop-types": "off",
         "react/jsx-key": "off",
+        "spellcheck/spell-checker": [
+            1,
+            {
+                comments: false,
+                strings: true,
+                identifiers: false,
+                templates: false,
+                lang: "en_US",
+                skipWords: [
+                    "dict",
+                    "aff",
+                    "hunspellchecker",
+                    "hunspell",
+                    "utils",
+                ],
+                skipIfMatch: ["http://[^s]*", "^[-\\w]+/[-\\w\\.]+$"],
+                skipWordIfMatch: ["^foobar.*$"],
+                minLength: 3,
+            },
+        ],
     },
     overrides: [
         {
@@ -74,8 +93,8 @@ module.exports = {
             files: ["*.jsx"],
             parserOptions: {
                 ecmaFeatures: {
-                    jsx: true
-                }
+                    jsx: true,
+                },
             },
         },
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-plugin-cypress": "^2.11.3",
         "eslint-plugin-prettier": "^3.4.0",
         "eslint-plugin-react": "^7.28.0",
+        "eslint-plugin-spellcheck": "^0.0.19",
         "eslint-plugin-svelte3": "^3.2.0",
         "jest": "^27.2.5",
         "prettier": "^2.3.0",
@@ -3077,6 +3078,20 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-spellcheck": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-spellcheck/-/eslint-plugin-spellcheck-0.0.19.tgz",
+      "integrity": "sha512-Vau+oCLT3IGx+inJV5rkuKlIwgka9L2is1SkztviIHN3apNnT2OrZoGy9Jt3gbcjjkfkIFMFSZjB+ijHCimbNA==",
+      "dev": true,
+      "dependencies": {
+        "globals": "^13.0.0",
+        "hunspell-spellchecker": "^1.0.2",
+        "lodash": "^4.17.15"
+      },
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
+    },
     "node_modules/eslint-plugin-svelte3": {
       "version": "3.2.0",
       "integrity": "sha512-qdWB1QN21dEozsJFdR8XlEhMnsS6aKHjsXWuNmchYwxoet5I6QdCr1Xcq62++IzRBMCNCeH4waXqSOAdqrZzgA==",
@@ -3925,6 +3940,15 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/hunspell-spellchecker": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hunspell-spellchecker/-/hunspell-spellchecker-1.0.2.tgz",
+      "integrity": "sha1-oQsL0voAplq2Kkxrc0zkltMYkQ4=",
+      "dev": true,
+      "bin": {
+        "hunspell-tojson": "bin/hunspell-tojson.js"
       }
     },
     "node_modules/iconv-lite": {
@@ -9729,6 +9753,17 @@
         }
       }
     },
+    "eslint-plugin-spellcheck": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-spellcheck/-/eslint-plugin-spellcheck-0.0.19.tgz",
+      "integrity": "sha512-Vau+oCLT3IGx+inJV5rkuKlIwgka9L2is1SkztviIHN3apNnT2OrZoGy9Jt3gbcjjkfkIFMFSZjB+ijHCimbNA==",
+      "dev": true,
+      "requires": {
+        "globals": "^13.0.0",
+        "hunspell-spellchecker": "^1.0.2",
+        "lodash": "^4.17.15"
+      }
+    },
     "eslint-plugin-svelte3": {
       "version": "3.2.0",
       "integrity": "sha512-qdWB1QN21dEozsJFdR8XlEhMnsS6aKHjsXWuNmchYwxoet5I6QdCr1Xcq62++IzRBMCNCeH4waXqSOAdqrZzgA==",
@@ -10303,6 +10338,12 @@
     "human-signals": {
       "version": "2.1.0",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true
+    },
+    "hunspell-spellchecker": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hunspell-spellchecker/-/hunspell-spellchecker-1.0.2.tgz",
+      "integrity": "sha1-oQsL0voAplq2Kkxrc0zkltMYkQ4=",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-cypress": "^2.11.3",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.28.0",
+    "eslint-plugin-spellcheck": "^0.0.19",
     "eslint-plugin-svelte3": "^3.2.0",
     "jest": "^27.2.5",
     "prettier": "^2.3.0",


### PR DESCRIPTION
This is just a very initial test, mainly here to see if it's raised any interest at all. It fails a lot, and it's got several drawbacks
* Does not support German (that's a big one, but it can probably be jury-rigged to do so).
* Not clear how to configure it to spell check only JSON
  * In fact, it's so verbose that I'm not sure if it's checking JSON *at all*
* Not clear if it supports local dictionaries. It should.
* Of course, if we decide to go with it, it will take a *long* time until we insert all our local words and it starts to go green.

Anyway, open for comments/suggestions.

> Many changes are explained by the automatic correction superpowers that Code has.