### PR TITLE
Eliminates apparently unused package.json key polypoly → manifest

### DIFF
--- a/features/polyPinion/package.json
+++ b/features/polyPinion/package.json
@@ -17,8 +17,7 @@
         "polypoly": "^0.4.2"
     },
     "polypoly": {
-        "root": "dist",
-        "manifest": ""
+        "root": "dist"
     },
     "dependencies": {
         "@polypoly-eu/silly-i18n": "file:../../core/utils/silly-i18n",


### PR DESCRIPTION
This was the only place it was used, and it was empty. So better eliminate it to avoid confusion.

> The whole `polypoly` section is probably unused either; it's only here and in `example`. But that can wait, I guess.