### PR TITLE
Facebook was substituted for meta

### DIFF
--- a/features/polyExplorer/src/screens/stories/messengerStory.jsx
+++ b/features/polyExplorer/src/screens/stories/messengerStory.jsx
@@ -80,10 +80,10 @@ const MessengerStory = () => {
             ),
         }),
         i18n.t(`${i18nHeader}:summary.bullet.3`, {
-            max_facebook_product_recipients: facebookMessengers.reduce((a, b) =>
+            max_meta_product_recipients: facebookMessengers.reduce((a, b) =>
                 Math.max(a.dataRecipients?.length || a, b.dataRecipients.length)
             ),
-            facebook_recipients:
+            meta_recipients:
                 entityObjectByPpid(mainFacebookCompany).dataRecipients.length,
         }),
     ];


### PR DESCRIPTION
Facebook had been changed to meta in the strings, but not in the code.
![Captura de pantalla de 2022-02-10 10-00-54](https://user-images.githubusercontent.com/500/153373237-baf60266-4361-4026-aac3-6af86fa7d68e.png)
