### PR TITLE
Add doc generation target to FacebookImport

### DIFF
--- a/features/facebookImport/package.json
+++ b/features/facebookImport/package.json
@@ -8,7 +8,8 @@
     "watch": "rollup --watch -c",
     "serve": "rollup --watch --configServe -c",
     "serve-polypedia-stub": "node scripts/serve-polypedia-stub.js",
-    "test": "jest"
+    "test": "jest",
+    "doc": "jsdoc -r src/ -d ./docs"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.14.8",


### PR DESCRIPTION
Although documentation is not generalized, there are few modules that are actually documented. Adding this might encourage documentation of the rest, and notably help devs to check out documentation in a single place (beyond tool tips by VSCode)