### PR TITLE
Hack to fix PROD4POD-1380

### DIFF
--- a/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
+++ b/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
@@ -11,6 +11,7 @@ const margin = {
   left: 0,
 };
 
+let called = 0;
 const barValueMargin = 4;
 const barPaddingProportion = 0.2;
 const groupHeadlineHeight = 14;
@@ -301,6 +302,8 @@ export class HorizontalBarChart extends Chart {
   }
 
   render() {
+    if (called > 0) return;
+    called = 1;
     this._adaptScalesToData();
     const barGroups = this.chart
       .selectAll(".bar-group")

--- a/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
+++ b/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
@@ -292,18 +292,17 @@ export class HorizontalBarChart extends Chart {
 
   _displayBars(barGroups, enteringBarGroups) {
     this._addEnteringBars(enteringBarGroups);
-    this._updateExistingBars(barGroups);
+    if (!called) this._updateExistingBars(barGroups);
   }
 
   _displayValues(barGroups, enteringBarGroups) {
-    this._updateExistingBarValues(barGroups);
+    if (!called) this._updateExistingBarValues(barGroups);
     this._addEnteringBarValues(enteringBarGroups);
     this._addEnteringBarLabels(enteringBarGroups);
   }
 
   render() {
-    if (called > 0) return;
-    called = 1;
+    called = true;
     this._adaptScalesToData();
     const barGroups = this.chart
       .selectAll(".bar-group")


### PR DESCRIPTION
For some reason, the component was rendered twice, which didn't play well with d3.

> This is the result of a monrning-long work session with @mteresa-jimenez and @alefalafel, who've had all the insights that have permitted to come to this (possible) fix.