### PR TITLE
Fix/stop barchart redraw

### DIFF
--- a/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
+++ b/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
@@ -311,9 +311,7 @@ export class HorizontalBarChart extends Chart {
       .attr("class", "bar-group");
 
     barGroups.exit().remove();
-    if (!enteringBarGroups._groups[0][0]) {
-      //do nothing if the new entering bar groups are empty
-    } else {
+    if (enteringBarGroups._groups[0][0]) {
       this._displayBars(barGroups, enteringBarGroups);
       if (this._barValueColor)
         this._displayValues(barGroups, enteringBarGroups);

--- a/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
+++ b/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
@@ -289,13 +289,11 @@ export class HorizontalBarChart extends Chart {
     });
   }
 
-  _displayBars(barGroups, enteringBarGroups) {
+  _displayBars(enteringBarGroups) {
     this._addEnteringBars(enteringBarGroups);
-    this._updateExistingBars(barGroups);
   }
 
-  _displayValues(barGroups, enteringBarGroups) {
-    this._updateExistingBarValues(barGroups);
+  _displayValues(enteringBarGroups) {
     this._addEnteringBarValues(enteringBarGroups);
     this._addEnteringBarLabels(enteringBarGroups);
   }
@@ -311,19 +309,15 @@ export class HorizontalBarChart extends Chart {
       .attr("class", "bar-group");
 
     barGroups.exit().remove();
-    if (enteringBarGroups._groups[0][0]) {
-      this._displayBars(barGroups, enteringBarGroups);
-      if (this._barValueColor)
-        this._displayValues(barGroups, enteringBarGroups);
-      else this.chart.selectAll(".bar-value").remove();
-      if (this._groups) {
-        const groupLabels = this.chart
-          .selectAll(".bar-group")
-          .data(this._groups, (g) => g.id);
-        const enteringGroupLabels = groupLabels.enter();
-        this._addEnteringGroupLabels(enteringGroupLabels);
-      }
-      this._alignBarText(barGroups);
+    this._displayBars(enteringBarGroups);
+    if (this._barValueColor) this._displayValues(enteringBarGroups);
+    else this.chart.selectAll(".bar-value").remove();
+    if (this._groups) {
+      const groupLabels = this.chart
+        .selectAll(".bar-group")
+        .data(this._groups, (g) => g.id);
+      const enteringGroupLabels = groupLabels.enter();
+      this._addEnteringGroupLabels(enteringGroupLabels);
     }
   }
 }

--- a/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
+++ b/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
@@ -311,16 +311,21 @@ export class HorizontalBarChart extends Chart {
       .attr("class", "bar-group");
 
     barGroups.exit().remove();
-    this._displayBars(barGroups, enteringBarGroups);
-    if (this._barValueColor) this._displayValues(barGroups, enteringBarGroups);
-    else this.chart.selectAll(".bar-value").remove();
-    if (this._groups) {
-      const groupLabels = this.chart
-        .selectAll(".bar-group")
-        .data(this._groups, (g) => g.id);
-      const enteringGroupLabels = groupLabels.enter();
-      this._addEnteringGroupLabels(enteringGroupLabels);
+    if (!enteringBarGroups._groups[0][0]) {
+      //do nothing if the new entering bar groups are empty
+    } else {
+      this._displayBars(barGroups, enteringBarGroups);
+      if (this._barValueColor)
+        this._displayValues(barGroups, enteringBarGroups);
+      else this.chart.selectAll(".bar-value").remove();
+      if (this._groups) {
+        const groupLabels = this.chart
+          .selectAll(".bar-group")
+          .data(this._groups, (g) => g.id);
+        const enteringGroupLabels = groupLabels.enter();
+        this._addEnteringGroupLabels(enteringGroupLabels);
+      }
+      this._alignBarText(barGroups);
     }
-    this._alignBarText(barGroups);
   }
 }

--- a/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
+++ b/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
@@ -158,22 +158,6 @@ export class HorizontalBarChart extends Chart {
       .attr("width", (d) => this._xScale(d.value));
   }
 
-  _updateExistingBars(bars) {
-    bars
-      .transition()
-      .duration(750)
-      .attr("x", 0)
-      .attr("width", initializingBarHeight)
-      .attr("y", (d) => this._setBarYAttribute(d))
-      .attr("height", this._barWidth)
-      .attr("fill", this._barColor)
-      .attr("class", "bar")
-      .transition()
-      .duration(750)
-      .attr("x", 0)
-      .attr("width", (d) => this._xScale(d.value));
-  }
-
   _addEnteringBarLabels(barLabels) {
     barLabels
       .append("text")
@@ -233,20 +217,6 @@ export class HorizontalBarChart extends Chart {
       .style("font-size", fontSizeInBar)
       .transition()
       .delay(1000)
-      .duration(500)
-      .attr("fill", this._barValueColor);
-  }
-
-  _updateExistingBarValues(barValues) {
-    barValues
-      .attr("y", (d) => this._setValueYAttribute(d))
-      .attr("class", "bar-value")
-      .attr("text-anchor", "end")
-      .attr("x", (d) => this._xScale(d.value) - barValueMargin)
-      .text((d) => d.value)
-      .raise()
-      .transition()
-      .delay(1500)
       .duration(500)
       .attr("fill", this._barValueColor);
   }

--- a/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
+++ b/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
@@ -319,5 +319,6 @@ export class HorizontalBarChart extends Chart {
       const enteringGroupLabels = groupLabels.enter();
       this._addEnteringGroupLabels(enteringGroupLabels);
     }
+    this._alignBarText(barGroups);
   }
 }

--- a/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
+++ b/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
@@ -318,6 +318,7 @@ export class HorizontalBarChart extends Chart {
     if (this._barValueColor) this._displayValues(barGroups, enteringBarGroups);
     else this.chart.selectAll(".bar-value").remove();
     if (this._groups) {
+      this.chart.selectAll(".group-label").remove();
       const groupLabels = this.chart
         .selectAll(".bar-group")
         .data(this._groups, (g) => g.id);

--- a/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
+++ b/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
@@ -158,6 +158,22 @@ export class HorizontalBarChart extends Chart {
       .attr("width", (d) => this._xScale(d.value));
   }
 
+  _updateExistingBars(bars) {
+    bars
+      .transition()
+      .duration(750)
+      .attr("x", 0)
+      .attr("width", initializingBarHeight)
+      .attr("y", (d) => this._setBarYAttribute(d))
+      .attr("height", this._barWidth)
+      .attr("fill", this._barColor)
+      .attr("class", "bar")
+      .transition()
+      .duration(750)
+      .attr("x", 0)
+      .attr("width", (d) => this._xScale(d.value));
+  }
+
   _addEnteringBarLabels(barLabels) {
     barLabels
       .append("text")
@@ -221,6 +237,23 @@ export class HorizontalBarChart extends Chart {
       .attr("fill", this._barValueColor);
   }
 
+  _updateExistingBarValues(barGroups) {
+    barGroups
+      .selectAll("bar-value")
+      .attr("y", (d) => this._setValueYAttribute(d))
+      .attr("class", "bar-value")
+      .attr("text-anchor", "end")
+      .attr("x", (d) => this._xScale(d.value) - barValueMargin)
+      .text((d) => d.value)
+      .attr("fill", "transparent")
+      .style("font-size", fontSizeInBar)
+      .raise()
+      .transition()
+      .delay(1500)
+      .duration(500)
+      .attr("fill", this._barValueColor);
+  }
+
   _alignBarText() {
     const xScale = this._xScale;
     const groups = this._groups;
@@ -259,13 +292,15 @@ export class HorizontalBarChart extends Chart {
     });
   }
 
-  _displayBars(enteringBarGroups) {
+  _displayBars(barGroups, enteringBarGroups) {
     this._addEnteringBars(enteringBarGroups);
+    this._updateExistingBars(barGroups);
   }
 
-  _displayValues(enteringBarGroups) {
+  _displayValues(barGroups, enteringBarGroups) {
     this._addEnteringBarValues(enteringBarGroups);
     this._addEnteringBarLabels(enteringBarGroups);
+    this._updateExistingBarValues(barGroups);
   }
 
   render() {
@@ -279,8 +314,8 @@ export class HorizontalBarChart extends Chart {
       .attr("class", "bar-group");
 
     barGroups.exit().remove();
-    this._displayBars(enteringBarGroups);
-    if (this._barValueColor) this._displayValues(enteringBarGroups);
+    this._displayBars(barGroups, enteringBarGroups);
+    if (this._barValueColor) this._displayValues(barGroups, enteringBarGroups);
     else this.chart.selectAll(".bar-value").remove();
     if (this._groups) {
       const groupLabels = this.chart


### PR DESCRIPTION
When returning to the messenger story the screen is rerendered and triggers the barchart to draw twice, the entering data is now an empty array, and the newly-drawn bars are nonexistant. An if statement prevents this from happening.