### PR TITLE
fixes to some components and changed scroll reference usage to fix in…

### DIFF
--- a/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
+++ b/core/utils/poly-look/src/visualisations/charts/bar-charts/horizontalBarChart/horizontalBarChart.js
@@ -311,16 +311,20 @@ export class HorizontalBarChart extends Chart {
       .attr("class", "bar-group");
 
     barGroups.exit().remove();
-    this._displayBars(barGroups, enteringBarGroups);
-    if (this._barValueColor) this._displayValues(barGroups, enteringBarGroups);
-    else this.chart.selectAll(".bar-value").remove();
-    if (this._groups) {
-      const groupLabels = this.chart
-        .selectAll(".bar-group")
-        .data(this._groups, (g) => g.id);
-      const enteringGroupLabels = groupLabels.enter();
-      this._addEnteringGroupLabels(enteringGroupLabels);
+    //check if entering bars are empty or not
+    if (enteringBarGroups._groups[0][0]) {
+      this._displayBars(barGroups, enteringBarGroups);
+      if (this._barValueColor)
+        this._displayValues(barGroups, enteringBarGroups);
+      else this.chart.selectAll(".bar-value").remove();
+      if (this._groups) {
+        const groupLabels = this.chart
+          .selectAll(".bar-group")
+          .data(this._groups, (g) => g.id);
+        const enteringGroupLabels = groupLabels.enter();
+        this._addEnteringGroupLabels(enteringGroupLabels);
+      }
+      this._alignBarText(barGroups);
     }
-    this._alignBarText(barGroups);
   }
 }

--- a/features/polyExplorer/src/components/clusterStories/purposes.jsx
+++ b/features/polyExplorer/src/components/clusterStories/purposes.jsx
@@ -1,10 +1,11 @@
-import React from "react";
-
+import React, { useContext } from "react";
+import { ExplorerContext } from "../../context/explorer-context.jsx";
 import i18n from "../../i18n.js";
 import PurposesBarChart from "../dataViz/purposesBarChart.jsx";
 import SourceInfoButton from "../sourceInfoButton/sourceInfoButton.jsx";
 
-export default function Purposes({ companies, createPopUp }) {
+export default function Purposes({ companies }) {
+    const { createPopUp } = useContext(ExplorerContext);
     const purposes = {};
 
     for (let company of companies) {

--- a/features/polyExplorer/src/components/clusterStory/clusterStory.jsx
+++ b/features/polyExplorer/src/components/clusterStory/clusterStory.jsx
@@ -23,13 +23,13 @@ const ClusterStory = ({
     className,
     primaryColor,
     fadingTopBackground,
-    setScrollingRef,
+    scrollingRef,
 }) => {
     return (
         <Screen
             className={`cluster-story ${className}`}
             theme={"poly-theme-light"}
-            setScrollingRef={setScrollingRef}
+            scrollingRef={scrollingRef}
         >
             <div
                 className="content"

--- a/features/polyExplorer/src/components/screen/screen.jsx
+++ b/features/polyExplorer/src/components/screen/screen.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React from "react";
 
 import "./screen.css";
 
@@ -8,14 +8,8 @@ const Screen = ({
     topShadow = true,
     children,
     noScroll = false,
-    setScrollingRef,
+    scrollingRef,
 }) => {
-    const scrollingRef = useRef();
-
-    useEffect(() => {
-        setScrollingRef && setScrollingRef(scrollingRef.current);
-    }, []);
-
     return (
         <div className={`${theme || ""} explorer-container`}>
             {topShadow && <div className="poly-nav-bar-separator-overlay" />}

--- a/features/polyExplorer/src/components/scrollingProgressTracker/scrollingProgressTracker.jsx
+++ b/features/polyExplorer/src/components/scrollingProgressTracker/scrollingProgressTracker.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from "react";
-
 import { useHistory } from "react-router-dom";
 
 /*
@@ -9,19 +8,18 @@ import { useHistory } from "react-router-dom";
  */
 const ScrollingProgressTracker = ({ children, scrollingRef }) => {
     const history = useHistory();
-
     const handleExitStory = () => {
         history.entries[
             history.entries.length - 2
-        ].state.storyScrollingProgress = scrollingRef.scrollTop;
+        ].state.storyScrollingProgress = scrollingRef.current?.scrollTop || 0;
     };
 
     useEffect(() => {
-        scrollingRef?.scrollTo(
+        scrollingRef?.current?.scrollTo(
             0,
             history.location.state.storyScrollingProgress || 0
         );
-    });
+    }, []);
 
     return (
         <div className="scrolling-progress-tracker" onClick={handleExitStory}>

--- a/features/polyExplorer/src/polyExplorer.jsx
+++ b/features/polyExplorer/src/polyExplorer.jsx
@@ -23,15 +23,11 @@ import ExampleStory from "./screens/stories/exampleStory.jsx";
 import DigitalGiantsStory from "./screens/stories/digitalGiantsStory.jsx";
 
 const PolyExplorerApp = () => {
-    const { navigationState, popUp } = useContext(ExplorerContext);
-
     return (
         <div className="poly-explorer poly-theme poly-theme-dark">
             <Switch>
                 <Route exact path="/">
-                    <Redirect
-                        to={{ pathname: "/main", state: navigationState }}
-                    />
+                    <RedirectToMain />
                 </Route>
                 <Route exact path="/main">
                     <MainScreen />
@@ -58,14 +54,28 @@ const PolyExplorerApp = () => {
                     <ExampleStory />
                 </Route>
             </Switch>
-            {popUp &&
-                popUp.component({
-                    onClose: popUp.onClose,
-                    content: popUp.content,
-                    ...popUp.props,
-                })}
+            <Popup />
         </div>
     );
+};
+
+const RedirectToMain = () => {
+    const { navigationState } = useContext(ExplorerContext);
+    return <Redirect to={{ pathname: "/main", state: navigationState }} />;
+};
+
+const Popup = () => {
+    const { popUp } = useContext(ExplorerContext);
+
+    if (!popUp) {
+        return null;
+    }
+
+    return popUp.component({
+        onClose: popUp.onClose,
+        content: popUp.content,
+        ...popUp.props,
+    });
 };
 
 const PolyExplorer = () => {

--- a/features/polyExplorer/src/screens/stories/digitalGiantsStory.jsx
+++ b/features/polyExplorer/src/screens/stories/digitalGiantsStory.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { createRef, useContext, useRef } from "react";
 
 import ClusterStory from "../../components/clusterStory/clusterStory.jsx";
 import GradientCircleList from "../../components/gradientCircleList/gradientCircleList.jsx";
@@ -25,7 +25,9 @@ const DigitalGiantsStory = () => {
     const { featuredEntities, entityJurisdictionByPpid, createPopUp } =
         useContext(ExplorerContext);
 
-    const [scrollingRef, setScrollingRef] = useState(null);
+    const storyRefs = useRef({
+        scrollingRef: createRef(),
+    });
 
     const bigSix = bigSixNames.map((n) => {
         const entity = featuredEntities
@@ -58,7 +60,7 @@ const DigitalGiantsStory = () => {
             fadingTopBackground={{
                 distance: "600px",
             }}
-            setScrollingRef={setScrollingRef}
+            scrollingRef={storyRefs.current.scrollingRef}
         >
             <h1 className="cluster-story-main-title">
                 {i18n.t(`${i18nHeader}:title`)}
@@ -133,7 +135,11 @@ const DigitalGiantsStory = () => {
             <p className="big-first-letter">
                 {i18n.t(`${i18nHeader}:explore.further.p.1`)}
             </p>
-            <ScrollingProgressTracker scrollingRef={scrollingRef}>
+            <ScrollingProgressTracker
+                key="messenger"
+                scrollingRef={storyRefs.current.scrollingRef}
+                history={history}
+            >
                 <EntityList entities={bigSix} expand={true} />
             </ScrollingProgressTracker>
             <LinkButton route={"back"} className="poly-button margin-top">


### PR DESCRIPTION
Some changes to how the scrolling state is saved, some changes in the messenger story to make components a bit more concise (might need to be on a separate PR), the horizontal barchart fix/hack to not redraw the horizontal bar chart. 

A small offset in the scroll recovery occurs even thought the correct scroll level is stored. This is due to the order in which the components within the story populate and resize, which happens after the scroll is finished which leads to a scenario in which the scroll tracker tries to reach a scroll level that is not available yet.