### PR TITLE
Adding a wait state to avoid timeouts

### DIFF
--- a/ios/PolyPodApp/PolyPodUITests/UpdateNotificationTest.swift
+++ b/ios/PolyPodApp/PolyPodUITests/UpdateNotificationTest.swift
@@ -61,7 +61,7 @@ class UpdateNotificationTest: XCTestCase {
         }
         app.launch()
         let background = app.wait(for: .runningForeground, timeout: 30)
-        XCTAssertTrue( background )
+        XCTAssertTrue(background)
     }
 
     private func assertInAppNotificationShown() {

--- a/ios/PolyPodApp/PolyPodUITests/UpdateNotificationTest.swift
+++ b/ios/PolyPodApp/PolyPodUITests/UpdateNotificationTest.swift
@@ -60,6 +60,8 @@ class UpdateNotificationTest: XCTestCase {
             ]
         }
         app.launch()
+        let background = app.wait(for: .runningForeground, timeout: 30)
+        XCTAssertTrue( background )
     }
 
     private func assertInAppNotificationShown() {


### PR DESCRIPTION
There were some flapping errors in the iOS workflow, such as [this one](https://github.com/polypoly-eu/polyPod/runs/5212584962?check_suite_focus=true). These looked like timeouts, so I added this wait state to try and avoid them. Main idea is the timeout, which can be extended I guess if it keeps failing.
Also my first actual Swift code PR, so please be lenient with me here.