### PR TITLE
PROD4POD-1336: Add test CI for Rust

### DIFF
--- a/.github/workflows/rust_kernel_tests.yml
+++ b/.github/workflows/rust_kernel_tests.yml
@@ -19,28 +19,16 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
       - name: Lint -- Run cargo fmt
         working-directory: ./core/kernel
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Lint -- Run cargo clippy
         working-directory: ./core/kernel
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings
 
       - name: Run cargo test
         working-directory: ./core/kernel
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test

--- a/.github/workflows/rust_kernel_tests.yml
+++ b/.github/workflows/rust_kernel_tests.yml
@@ -1,0 +1,46 @@
+# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
+on:
+  push:
+    paths:
+      - core/kernel/**
+  pull_request:
+    types: [assigned, opened, ready_for_review]
+    paths:
+      - core/kernel/**
+
+name: Lint and Test Rust code
+
+jobs:
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Lint -- Run cargo fmt
+        working-directory: ./core/kernel
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Lint -- Run cargo clippy
+        working-directory: ./core/kernel
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+
+      - name: Run cargo test
+        working-directory: ./core/kernel
+        uses: actions-rs/cargo@v1
+        with:
+          command: test


### PR DESCRIPTION
Add CI to test and lint the Rust kernel.

Kudos to @JJ for original implementation [here](https://github.com/polypoly-eu/polyPod-platform-core-experiments/blob/main/.github/workflows/rust-test.yml)