### PR TITLE
PROD4POD-1363: Kernel - feature manifest parsing

### DIFF
--- a/3rd-party-licenses/rust-licenses.txt
+++ b/3rd-party-licenses/rust-licenses.txt
@@ -1,0 +1,55 @@
+--------------------------------------------------------------------------------
+serde
+--------------------------------------------------------------------------------
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+serde_json
+--------------------------------------------------------------------------------
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/core/kernel/Cargo.lock
+++ b/core/kernel/Cargo.lock
@@ -3,5 +3,87 @@
 version = 3
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "serde"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"

--- a/core/kernel/Cargo.toml
+++ b/core/kernel/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/core/kernel/src/feature_manifest.rs
+++ b/core/kernel/src/feature_manifest.rs
@@ -1,0 +1,12 @@
+use std::collections::HashMap;
+
+pub struct FeatureManifest {
+    name: Option<String>,
+    author: Option<String>,
+    version: Option<String>,
+    description: Option<String>,
+    thumbnail: Option<String>,
+    thumbnail_color: Option<String>,
+    primary_color: Option<String>,
+    links: Option<HashMap<String, String>>
+}

--- a/core/kernel/src/feature_manifest.rs
+++ b/core/kernel/src/feature_manifest.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use serde::{Deserialize};
+use std::{collections::HashMap};
 
 #[derive(Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -12,7 +12,66 @@ pub struct FeatureManifest {
     thumbnail: Option<String>,
     thumbnail_color: Option<String>,
     primary_color: Option<String>,
-    links: Option<HashMap<String, String>>
+    links: Option<HashMap<String, String>>,
+}
+
+// Alias for str, probably will be moved to a centralized place to be reused
+pub type JSONString = str;
+
+impl FeatureManifest {
+    fn parse(json: &JSONString, locale: &str) -> FeatureManifest {
+        FullFeatureManifest::try_from(json)
+            .map(|manifest| FeatureManifest::build_feature_manifest(manifest, locale))
+            .unwrap_or(FeatureManifest::default()) // TODO: Log error when logging is added
+    }
+
+    fn default() -> FeatureManifest {
+        FeatureManifest {
+            name: None,
+            author: None,
+            version: None,
+            description: None,
+            thumbnail: None,
+            thumbnail_color: None,
+            primary_color: None,
+            links: None,
+        }
+    }
+
+    fn build_feature_manifest(full_manifest: FullFeatureManifest, locale: &str) -> FeatureManifest {
+        let translation = full_manifest
+            .translations
+            .as_ref()
+            .and_then(|unwrapped| unwrapped.get(locale));
+        match translation {
+            Some(translation) => {
+                let mut links = full_manifest.links.unwrap_or(HashMap::new());
+                if let Some(translated_links) = translation.links.clone() {
+                    links.extend(translated_links.into_iter());
+                }
+                FeatureManifest {
+                    name: translation.name.clone().or(full_manifest.name),
+                    author: translation.author.clone().or(full_manifest.author),
+                    version: translation.version.clone().or(full_manifest.version),
+                    description: translation.description.clone().or(full_manifest.description),
+                    thumbnail: translation.thumbnail.clone().or(full_manifest.thumbnail),
+                    thumbnail_color: translation.thumbnail_color.clone().or(full_manifest.thumbnail_color),
+                    primary_color: translation.primary_color.clone().or(full_manifest.primary_color),
+                    links: Some(links),
+                }
+            },
+            None => FeatureManifest {
+                name: full_manifest.name,
+                author: full_manifest.author,
+                version: full_manifest.version,
+                description: full_manifest.description,
+                thumbnail: full_manifest.thumbnail,
+                thumbnail_color: full_manifest.thumbnail_color,
+                primary_color: full_manifest.primary_color,
+                links: full_manifest.links,
+            }
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -26,47 +85,8 @@ struct FullFeatureManifest {
     thumbnail_color: Option<String>,
     primary_color: Option<String>,
     links: Option<HashMap<String, String>>,
-    translations: Option<HashMap<String, FeatureManifest>>
+    translations: Option<HashMap<String, FeatureManifest>>,
 }
-
-// Alias for str, probably will be moved to a centralized place to be reused
-pub type JSONString = str;
-
-impl FeatureManifest {
-    // Hmm, maybe add typed error so the caler can decide based on error. 
-    fn parse(json: &JSONString, locale: &str) -> FeatureManifest {
-        FullFeatureManifest::try_from(json)
-        .map(FeatureManifest::build_feature_manifest)
-        .unwrap_or(FeatureManifest::default())
-    }
-
-    fn default() -> FeatureManifest {
-        FeatureManifest {
-            name: None,
-            author: None,
-            version: None,
-            description: None,
-            thumbnail: None,
-            thumbnail_color: None,
-            primary_color: None,
-            links: None
-        }
-    }
-
-    fn build_feature_manifest(full_manifest: FullFeatureManifest) -> FeatureManifest {
-        FeatureManifest {
-            name: full_manifest.name,
-            author: full_manifest.author,
-            version: full_manifest.version,
-            description: full_manifest.description,
-            thumbnail: full_manifest.thumbnail,
-            thumbnail_color: full_manifest.thumbnail_color,
-            primary_color: full_manifest.primary_color,
-            links: full_manifest.links
-        }
-    }
-}
-
 
 impl TryFrom<&JSONString> for FullFeatureManifest {
     type Error = String;
@@ -84,7 +104,7 @@ mod tests {
     fn test_empty_json() {
         let parsed = FeatureManifest::parse("", "");
 
-        assert_eq!(parsed, FeatureManifest::default(), "Expected to return default manifest if json is empty")
+        assert_eq!(parsed, FeatureManifest::default())
     }
 
     #[test]
@@ -136,8 +156,7 @@ mod tests {
             }
         }"##;
 
-        let parsed = FeatureManifest::parse(json, "");
-        let links = HashMap::from([
+        let expected_links = HashMap::from([
             ("link1".to_string(), "https://example.com/1".to_string()),
             ("link2".to_string(), "https://example.com/2".to_string()),
         ]);
@@ -149,8 +168,63 @@ mod tests {
             thumbnail: Some("assets/thumbnail.png".to_string()),
             thumbnail_color: Some("#FFFFFF".to_string()),
             primary_color: Some("#000000".to_string()),
-            links: Some(links)
+            links: Some(expected_links),
         };
+
+        let parsed = FeatureManifest::parse(json, "");
+
+        assert_eq!(parsed.name, expected_manifest.name);
+        assert_eq!(parsed.author, expected_manifest.author);
+        assert_eq!(parsed.version, expected_manifest.version);
+        assert_eq!(parsed.description, expected_manifest.description);
+        assert_eq!(parsed.thumbnail, expected_manifest.thumbnail);
+        assert_eq!(parsed.thumbnail_color, expected_manifest.thumbnail_color);
+        assert_eq!(parsed.primary_color, expected_manifest.primary_color);
+        assert_eq!(parsed.links, expected_manifest.links);
+    }
+
+    #[test]
+    fn test_has_translations() {
+        let json = r##"
+        {
+            "name": "testManifest",
+            "author": "testAuthor",
+            "version": "0.1.2",
+            "description": "testDescription",
+            "thumbnail": "assets/thumbnail.png",
+            "thumbnailColor": "#FFFFFF",
+            "primaryColor": "#000000",
+            "links": {
+                "link1": "https://example.com/1",
+                "link2": "https://example.com/2"
+            },
+            "translations": {
+                "de": {
+                    "name": "testManifest_de",
+                    "description": "testDescription_de",
+                    "links": {
+                        "link1": "https://example.de/1"
+                    }
+                }
+            }
+        }"##;
+
+        let expected_links = HashMap::from([
+            ("link1".to_string(), "https://example.de/1".to_string()),
+            ("link2".to_string(), "https://example.com/2".to_string()),
+        ]);
+        let expected_manifest = FeatureManifest {
+            name: Some("testManifest_de".to_string()),
+            author: Some("testAuthor".to_string()),
+            version: Some("0.1.2".to_string()),
+            description: Some("testDescription_de".to_string()),
+            thumbnail: Some("assets/thumbnail.png".to_string()),
+            thumbnail_color: Some("#FFFFFF".to_string()),
+            primary_color: Some("#000000".to_string()),
+            links: Some(expected_links)
+        };
+
+        let parsed = FeatureManifest::parse(json, "de");
 
         assert_eq!(parsed.name, expected_manifest.name);
         assert_eq!(parsed.author, expected_manifest.author);

--- a/core/kernel/src/feature_manifest.rs
+++ b/core/kernel/src/feature_manifest.rs
@@ -20,10 +20,10 @@ pub struct FeatureManifestParsingError {
 }
 
 // Alias for str, probably will be moved to a centralized place to be reused
-pub type JSONString = str;
+pub type JSONStr = str;
 
 impl FeatureManifest {
-    pub fn parse(json: &JSONString, locale: &str) -> Result<FeatureManifest, FeatureManifestParsingError> {
+    pub fn parse(json: &JSONStr, locale: &str) -> Result<FeatureManifest, FeatureManifestParsingError> {
         FullFeatureManifest::try_from(json)
             .map(|manifest| FeatureManifest::build_feature_manifest(manifest, locale))
     }
@@ -92,10 +92,10 @@ struct FullFeatureManifest {
     translations: Option<HashMap<String, FeatureManifest>>,
 }
 
-impl TryFrom<&JSONString> for FullFeatureManifest {
+impl TryFrom<&JSONStr> for FullFeatureManifest {
     type Error = FeatureManifestParsingError;
 
-    fn try_from(value: &JSONString) -> Result<Self, Self::Error> {
+    fn try_from(value: &JSONStr) -> Result<Self, Self::Error> {
         serde_json::from_str(value).map_err(|err| FeatureManifestParsingError { description: err.to_string() })
     }
 }

--- a/core/kernel/src/feature_manifest.rs
+++ b/core/kernel/src/feature_manifest.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use serde::{Deserialize};
 
-#[derive(Deserialize)]
+#[derive(Deserialize, PartialEq, Debug)]
 pub struct FeatureManifest {
     // Everything is Option? interesting
     name: Option<String>,
@@ -27,12 +27,52 @@ struct FullFeatureManifest {
     translations: Option<HashMap<String, FeatureManifest>>
 }
 
-type JSONString = str;
+// Alias for str, probably will be moved to a centralized place to be reused
+pub type JSONString = str;
+
+impl FeatureManifest {
+    // Hmm, maybe add typed error so the caler can decide based on error. 
+    fn parse(json: &JSONString, locale: &str) -> FeatureManifest {
+        FullFeatureManifest::try_from(json)
+        .map(FeatureManifest::build_feature_manifest)
+        .unwrap_or(FeatureManifest::default())
+    }
+
+    fn default() -> FeatureManifest {
+        FeatureManifest {
+            name: None,
+            author: None,
+            version: None,
+            description: None,
+            thumbnail: None,
+            thumbnail_color: None,
+            primary_color: None,
+            links: None
+        }
+    }
+
+    fn build_feature_manifest(full_manifest: FullFeatureManifest) -> FeatureManifest {
+        FeatureManifest::default()
+    }
+}
+
 
 impl TryFrom<&JSONString> for FullFeatureManifest {
     type Error = String;
 
     fn try_from(value: &JSONString) -> Result<Self, Self::Error> {
         serde_json::from_str(value).map_err(|err| err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_json() {
+        let parsed = FeatureManifest::parse("", "");
+
+        assert_eq!(parsed, FeatureManifest::default(), "Expected to return default manifest if json is empty")
     }
 }

--- a/core/kernel/src/feature_manifest.rs
+++ b/core/kernel/src/feature_manifest.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use serde::{Deserialize};
 
 #[derive(Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct FeatureManifest {
     // Everything is Option? interesting
     name: Option<String>,
@@ -15,6 +16,7 @@ pub struct FeatureManifest {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct FullFeatureManifest {
     name: Option<String>,
     author: Option<String>,
@@ -115,5 +117,48 @@ mod tests {
         assert_eq!(parsed.description.unwrap(), "testDescription");
         assert_eq!(parsed.author.unwrap(), "testAuthor");
         assert_eq!(parsed.thumbnail.unwrap(), "assets/thumbnail.png");
+    }
+
+    #[test]
+    fn test_no_translations() {
+        let json = r##"
+        {
+            "name": "testManifest",
+            "author": "testAuthor",
+            "version": "0.1.2",
+            "description": "testDescription",
+            "thumbnail": "assets/thumbnail.png",
+            "thumbnailColor": "#FFFFFF",
+            "primaryColor": "#000000",
+            "links": {
+                "link1": "https://example.com/1",
+                "link2": "https://example.com/2"
+            }
+        }"##;
+
+        let parsed = FeatureManifest::parse(json, "");
+        let links = HashMap::from([
+            ("link1".to_string(), "https://example.com/1".to_string()),
+            ("link2".to_string(), "https://example.com/2".to_string()),
+        ]);
+        let expected_manifest = FeatureManifest {
+            name: Some("testManifest".to_string()),
+            author: Some("testAuthor".to_string()),
+            version: Some("0.1.2".to_string()),
+            description: Some("testDescription".to_string()),
+            thumbnail: Some("assets/thumbnail.png".to_string()),
+            thumbnail_color: Some("#FFFFFF".to_string()),
+            primary_color: Some("#000000".to_string()),
+            links: Some(links)
+        };
+
+        assert_eq!(parsed.name, expected_manifest.name);
+        assert_eq!(parsed.author, expected_manifest.author);
+        assert_eq!(parsed.version, expected_manifest.version);
+        assert_eq!(parsed.description, expected_manifest.description);
+        assert_eq!(parsed.thumbnail, expected_manifest.thumbnail);
+        assert_eq!(parsed.thumbnail_color, expected_manifest.thumbnail_color);
+        assert_eq!(parsed.primary_color, expected_manifest.primary_color);
+        assert_eq!(parsed.links, expected_manifest.links);
     }
 }

--- a/core/kernel/src/feature_manifest.rs
+++ b/core/kernel/src/feature_manifest.rs
@@ -46,14 +46,26 @@ impl FeatureManifest {
                     links.extend(translated_links.into_iter());
                 }
                 FeatureManifest {
-                    name: translation.name.clone().or(full_manifest.name),
-                    author: translation.author.clone().or(full_manifest.author),
-                    version: translation.version.clone().or(full_manifest.version),
+                    name: translation
+                        .name
+                        .clone()
+                        .or(full_manifest.name),
+                    author: translation
+                        .author
+                        .clone()
+                        .or(full_manifest.author),
+                    version: translation
+                        .version
+                        .clone()
+                        .or(full_manifest.version),
                     description: translation
                         .description
                         .clone()
                         .or(full_manifest.description),
-                    thumbnail: translation.thumbnail.clone().or(full_manifest.thumbnail),
+                    thumbnail: translation
+                        .thumbnail
+                        .clone()
+                        .or(full_manifest.thumbnail),
                     thumbnail_color: translation
                         .thumbnail_color
                         .clone()

--- a/core/kernel/src/feature_manifest.rs
+++ b/core/kernel/src/feature_manifest.rs
@@ -27,17 +27,17 @@ pub type JSONStr = str;
 impl FeatureManifest {
     pub fn parse(
         json: &JSONStr,
-        locale: &str,
+        language_code: &str,
     ) -> Result<FeatureManifest, FeatureManifestParsingError> {
         FullFeatureManifest::try_from(json)
-            .map(|manifest| FeatureManifest::build_feature_manifest(manifest, locale))
+            .map(|manifest| FeatureManifest::build_feature_manifest(manifest, language_code))
     }
 
-    fn build_feature_manifest(full_manifest: FullFeatureManifest, locale: &str) -> FeatureManifest {
+    fn build_feature_manifest(full_manifest: FullFeatureManifest, language_code: &str) -> FeatureManifest {
         let translation = full_manifest
             .translations
             .as_ref()
-            .and_then(|unwrapped| unwrapped.get(locale));
+            .and_then(|unwrapped| unwrapped.get(language_code));
 
         match translation {
             Some(translation) => {

--- a/core/kernel/src/feature_manifest.rs
+++ b/core/kernel/src/feature_manifest.rs
@@ -75,4 +75,18 @@ mod tests {
 
         assert_eq!(parsed, FeatureManifest::default(), "Expected to return default manifest if json is empty")
     }
+
+    #[test]
+    fn test_empty_json_object() {
+        let parsed = FeatureManifest::parse("{}", "");
+
+        assert_eq!(parsed, FeatureManifest::default())
+    }
+
+    #[test]
+    fn test_wrong_json() {
+        let parsed = FeatureManifest::parse(r#"{ "somethingElse": true }"#, "");
+
+        assert_eq!(parsed, FeatureManifest::default())
+    }
 }

--- a/core/kernel/src/feature_manifest.rs
+++ b/core/kernel/src/feature_manifest.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
+use serde::{Deserialize};
 
+#[derive(Deserialize)]
 pub struct FeatureManifest {
+    // Everything is Option? interesting
     name: Option<String>,
     author: Option<String>,
     version: Option<String>,
@@ -9,4 +12,27 @@ pub struct FeatureManifest {
     thumbnail_color: Option<String>,
     primary_color: Option<String>,
     links: Option<HashMap<String, String>>
+}
+
+#[derive(Deserialize)]
+struct FullFeatureManifest {
+    name: Option<String>,
+    author: Option<String>,
+    version: Option<String>,
+    description: Option<String>,
+    thumbnail: Option<String>,
+    thumbnail_color: Option<String>,
+    primary_color: Option<String>,
+    links: Option<HashMap<String, String>>,
+    translations: Option<HashMap<String, FeatureManifest>>
+}
+
+type JSONString = str;
+
+impl TryFrom<&JSONString> for FullFeatureManifest {
+    type Error = String;
+
+    fn try_from(value: &JSONString) -> Result<Self, Self::Error> {
+        serde_json::from_str(value).map_err(|err| err.to_string())
+    }
 }

--- a/core/kernel/src/feature_manifest.rs
+++ b/core/kernel/src/feature_manifest.rs
@@ -52,7 +52,16 @@ impl FeatureManifest {
     }
 
     fn build_feature_manifest(full_manifest: FullFeatureManifest) -> FeatureManifest {
-        FeatureManifest::default()
+        FeatureManifest {
+            name: full_manifest.name,
+            author: full_manifest.author,
+            version: full_manifest.version,
+            description: full_manifest.description,
+            thumbnail: full_manifest.thumbnail,
+            thumbnail_color: full_manifest.thumbnail_color,
+            primary_color: full_manifest.primary_color,
+            links: full_manifest.links
+        }
     }
 }
 
@@ -88,5 +97,23 @@ mod tests {
         let parsed = FeatureManifest::parse(r#"{ "somethingElse": true }"#, "");
 
         assert_eq!(parsed, FeatureManifest::default())
+    }
+
+    #[test]
+    fn test_partial_json() {
+        let json = r#"
+        { 
+            "name": "testManifest",
+            "description": "testDescription",
+            "author": "testAuthor",
+            "thumbnail": "assets/thumbnail.png"
+        }"#;
+
+        let parsed = FeatureManifest::parse(json, "");
+
+        assert_eq!(parsed.name.unwrap(), "testManifest");
+        assert_eq!(parsed.description.unwrap(), "testDescription");
+        assert_eq!(parsed.author.unwrap(), "testAuthor");
+        assert_eq!(parsed.thumbnail.unwrap(), "assets/thumbnail.png");
     }
 }

--- a/core/kernel/src/lib.rs
+++ b/core/kernel/src/lib.rs
@@ -1,1 +1,1 @@
-// TBA
+mod feature_manifest;


### PR DESCRIPTION
- Added feature manifest parsing:
  - Parsing from JSON.
  - Locale handling.
  - Tests. 
- Used [serde_json](https://docs.serde.rs/serde_json/) for parsing, the "go to" solution in Rust, as it does not have native json parsing capabilities.
- Added the required licenses.