### PR TITLE
[Fix] Log sanitization to avoid CodeQL warnings

### DIFF
--- a/features/facebookImport/scripts/serve-polypedia-stub.js
+++ b/features/facebookImport/scripts/serve-polypedia-stub.js
@@ -27,7 +27,7 @@ function logRequest(request, body) {
     console.log("Timestamp: ", new Date());
     console.log("Authorization: ", request.headers?.authorization);
     console.log("[body start]");
-    console.log(body);
+    console.log(body.replace(/\s*\n\s*/, "→|←"));
     console.log("[body end]\n");
 }
 

--- a/features/facebookImport/scripts/serve-polypedia-stub.js
+++ b/features/facebookImport/scripts/serve-polypedia-stub.js
@@ -25,7 +25,10 @@ function logRequest(request, body) {
     if (!body) return;
     console.log("----- Received request -----");
     console.log("Timestamp: ", new Date());
-    console.log("Authorization: ", request.headers?.authorization);
+    console.log(
+        "Authorization: ",
+        request.headers?.authorization.replace("\n", "-")
+    );
     console.log("[body start]");
     console.log(body.replace(/\s*\n\s*/, "→|←"));
     console.log("[body end]\n");

--- a/features/facebookImport/scripts/serve-polypedia-stub.js
+++ b/features/facebookImport/scripts/serve-polypedia-stub.js
@@ -25,7 +25,7 @@ function logRequest(request, body) {
     if (!body) return;
     console.log("----- Received request -----");
     console.log("Timestamp: ", new Date());
-    console.log("Authorizaton: ", request.headers?.authorization);
+    console.log("Authorization: ", request.headers?.authorization);
     console.log("[body start]");
     console.log(body);
     console.log("[body end]\n");

--- a/features/facebookImport/scripts/serve-polypedia-stub.js
+++ b/features/facebookImport/scripts/serve-polypedia-stub.js
@@ -27,10 +27,10 @@ function logRequest(request, body) {
     console.log("Timestamp: ", new Date());
     console.log(
         "Authorization: ",
-        request.headers?.authorization.replace("\n", "-")
+        request.headers?.authorization.replaceAll("\n", "-")
     );
     console.log("[body start]");
-    console.log(body.replace(/\s*\n\s*/, "→|←"));
+    console.log(body.replaceAll(/\s*\n\s*/, "→|←"));
     console.log("[body end]\n");
 }
 


### PR DESCRIPTION
This is admittedly a very low impact vulnerability, since it's not even invoked from tests; however, it's a good practice at the end of the day to sanitize user input before committing it anywhere, which is what I'm doing here, fixing a typo along the way.