### PR TITLE
[Task] {PROD4POD-122} Add a real l12n module

### DIFF
--- a/feature-utils/silly-i18n/cypress/integration/browser_spec.js
+++ b/feature-utils/silly-i18n/cypress/integration/browser_spec.js
@@ -2,14 +2,10 @@ import { determineLanguage, determineLocale } from "../../src/locale.js";
 import { I18n } from "../../src/index.js";
 import { L12n } from "../../src/l12n.js";
 
+import { bigNumber, localePairs } from "../../test/test-utils.js";
+
 const LANGUAGE = "foo";
 let i18n;
-const bigNumber = "1000000.33";
-const localePairs = {
-    "de-DE": "1.000.000,33",
-    "es-ES": "1.000.000,33",
-    "en-GB": "1,000,000.33",
-};
 
 beforeEach(() => {
     i18n = new I18n(LANGUAGE, {

--- a/feature-utils/silly-i18n/cypress/integration/browser_spec.js
+++ b/feature-utils/silly-i18n/cypress/integration/browser_spec.js
@@ -20,7 +20,7 @@ describe("Test language determination", () => {
     });
 
     it("is able to create the object in a web environment", () => {
-        expect(i18n).to.have.keys(["_locale", "language", "_translations"]);
+        expect(i18n).to.have.keys(["_l12n", "language", "_translations"]);
         expect(i18n.language).to.equal(LANGUAGE);
     });
 });
@@ -38,7 +38,7 @@ describe("Test locale numeric options correctly in its module", () => {
 describe("Test locale numeric options correctly", () => {
     it("Converts big numbers to locale format", () => {
         for (const [locale, l8nString] of Object.entries(localePairs)) {
-            i18n._locale = locale;
+            i18n._l12n = new L12n(locale);
             expect(i18n.locale).to.equal(locale);
             expect(i18n.t("options:opt", { opt: bigNumber })).to.equal(
                 l8nString

--- a/feature-utils/silly-i18n/cypress/integration/browser_spec.js
+++ b/feature-utils/silly-i18n/cypress/integration/browser_spec.js
@@ -2,7 +2,7 @@ import { determineLanguage, determineLocale } from "../../src/locale.js";
 import { I18n } from "../../src/index.js";
 import { L12n } from "../../src/l12n.js";
 
-import { bigNumber, localePairs } from "../../test/test-utils.js";
+import { bigNumber, numberPairs } from "../../test/test-utils.js";
 
 const LANGUAGE = "foo";
 let i18n;
@@ -27,7 +27,7 @@ describe("Test language determination", () => {
 
 describe("Test locale numeric options correctly in its module", () => {
     it("Converts big numbers to locale format", () => {
-        for (const [locale, l8nString] of Object.entries(localePairs)) {
+        for (const [locale, l8nString] of Object.entries(numberPairs)) {
             const localeHere = new L12n(locale);
             expect(localeHere.locale).to.equal(locale);
             expect(localeHere.t(bigNumber)).to.equal(l8nString);
@@ -37,7 +37,7 @@ describe("Test locale numeric options correctly in its module", () => {
 
 describe("Test locale numeric options correctly", () => {
     it("Converts big numbers to locale format", () => {
-        for (const [locale, l8nString] of Object.entries(localePairs)) {
+        for (const [locale, l8nString] of Object.entries(numberPairs)) {
             i18n._l12n = new L12n(locale);
             expect(i18n.locale).to.equal(locale);
             expect(i18n.t("options:opt", { opt: bigNumber })).to.equal(

--- a/feature-utils/silly-i18n/cypress/integration/browser_spec.js
+++ b/feature-utils/silly-i18n/cypress/integration/browser_spec.js
@@ -2,7 +2,12 @@ import { determineLanguage, determineLocale } from "../../src/locale.js";
 import { I18n } from "../../src/index.js";
 import { L12n } from "../../src/l12n.js";
 
-import { bigNumber, numberPairs } from "../../test/test-utils.js";
+import {
+    bigNumber,
+    numberPairs,
+    date,
+    datePairs,
+} from "../../test/test-utils.js";
 
 const LANGUAGE = "foo";
 let i18n;
@@ -25,12 +30,19 @@ describe("Test language determination", () => {
     });
 });
 
-describe("Test locale numeric options correctly in its module", () => {
+describe("Test locale options correctly in its module", () => {
     it("Converts big numbers to locale format", () => {
-        for (const [locale, l8nString] of Object.entries(numberPairs)) {
+        for (const [locale, l12nString] of Object.entries(numberPairs)) {
             const localeHere = new L12n(locale);
             expect(localeHere.locale).to.equal(locale);
-            expect(localeHere.t(bigNumber)).to.equal(l8nString);
+            expect(localeHere.t(bigNumber)).to.equal(l12nString);
+        }
+    });
+
+    it("Converts dates to locale format", () => {
+        for (const [locale, l12nDate] of Object.entries(datePairs)) {
+            const localeHere = new L12n(locale);
+            expect(localeHere.t(date)).to.equal(l12nDate);
         }
     });
 });

--- a/feature-utils/silly-i18n/cypress/integration/browser_spec.js
+++ b/feature-utils/silly-i18n/cypress/integration/browser_spec.js
@@ -1,8 +1,15 @@
 import { determineLanguage, determineLocale } from "../../src/locale.js";
 import { I18n } from "../../src/index.js";
+import { L12n } from "../../src/l12n.js";
 
 const LANGUAGE = "foo";
 let i18n;
+const bigNumber = "1000000.33";
+const localePairs = {
+    "de-DE": "1.000.000,33",
+    "es-ES": "1.000.000,33",
+    "en-GB": "1,000,000.33",
+};
 
 beforeEach(() => {
     i18n = new I18n(LANGUAGE, {
@@ -22,14 +29,18 @@ describe("Test language determination", () => {
     });
 });
 
+describe("Test locale numeric options correctly in its module", () => {
+    it("Converts big numbers to locale format", () => {
+        for (const [locale, l8nString] of Object.entries(localePairs)) {
+            const localeHere = new L12n(locale);
+            expect(localeHere.locale).to.equal(locale);
+            expect(localeHere.t(bigNumber)).to.equal(l8nString);
+        }
+    });
+});
+
 describe("Test locale numeric options correctly", () => {
     it("Converts big numbers to locale format", () => {
-        const bigNumber = "1000000.33";
-        const localePairs = {
-            "de-DE": "1.000.000,33",
-            "es-ES": "1.000.000,33",
-            "en-GB": "1,000,000.33",
-        };
         for (const [locale, l8nString] of Object.entries(localePairs)) {
             i18n._locale = locale;
             expect(i18n.locale).to.equal(locale);

--- a/feature-utils/silly-i18n/src/index.js
+++ b/feature-utils/silly-i18n/src/index.js
@@ -5,6 +5,7 @@ import {
 } from "./errors.js";
 
 import { determineLocale, determineLanguage } from "./locale.js";
+import { L12n } from "./l12n.js";
 
 /**
  * Simple class for performing string translations, with simple templating capabilities
@@ -33,7 +34,7 @@ export class I18n {
         language,
         translations,
         fallbackLanguage = Object.keys(translations)[0],
-        locale = determineLocale()
+        l12n = new L12n()
     ) {
         if (!(fallbackLanguage in translations)) {
             throw new LanguageError(
@@ -41,7 +42,7 @@ export class I18n {
                     " is not a key in the translations hash provided"
             );
         }
-        this._locale = locale;
+        this._l12n = l12n;
         this.language = language in translations ? language : fallbackLanguage;
         this._translations = translations[this.language];
     }
@@ -55,12 +56,21 @@ export class I18n {
     }
 
     /**
-     * Returns the locale string.
+     * Returns the locale string
      *
-     * @returns locale string in the usual `xx-XX` format.
+     * @returns the locale string in the usual format
      */
     get locale() {
-        return this._locale;
+        return this._l12n.locale;
+    }
+
+    /**
+     * Returns the localization object
+     *
+     * @returns the localization object.
+     */
+    get l12n() {
+        return this._l12n;
     }
 
     /**
@@ -94,13 +104,10 @@ export class I18n {
         }
 
         for (let [key, value] of Object.entries(options)) {
-            let convertedValue = value;
-            if (!isNaN(parseFloat(value))) {
-                convertedValue = Intl.NumberFormat(this._locale).format(
-                    parseFloat(value)
-                );
-            }
-            translation = translation.replace(`{{${key}}}`, convertedValue);
+            translation = translation.replace(
+                `{{${key}}}`,
+                this._l12n.t(value)
+            );
         }
         return translation;
     }

--- a/feature-utils/silly-i18n/src/index.js
+++ b/feature-utils/silly-i18n/src/index.js
@@ -26,8 +26,8 @@ export class I18n {
      *     It's an optional parameter, that defaults to the first key
      *     in the `translations` hash, so you might want to use arrange it
      *     bearing this in mind.
-     * @param {string} [ locale = determineLocale() ] - locale string, in the usual format xx[_YY],
-     *     by default locale determined using that function
+     * @param {string} [ l12n = new L12n() ] - localization object, by default it will use the current locale string
+     *     as determined by the [[L12n]] function
      * @throws LanguageError - if the `fallbackLanguage` key is not included in the translations hash
      */
     constructor(

--- a/feature-utils/silly-i18n/src/l12n.js
+++ b/feature-utils/silly-i18n/src/l12n.js
@@ -56,19 +56,13 @@ export class L12n {
     /**
      * Obtains the (translated) string for a `namespace:key` defined in the translations hash.
      *
-     * @param object - What needs to be translated
+     * @param object - What needs to be translated. For the time being, only translates numbers
      * @returns The locale-formatted string.
      */
     t(object) {
-        for (let [key, value] of Object.entries(options)) {
-            let convertedValue = value;
-            if (!isNaN(parseFloat(value))) {
-                convertedValue = Intl.NumberFormat(this._locale).format(
-                    parseFloat(value)
-                );
-            }
-            translation = translation.replace(`{{${key}}}`, convertedValue);
+        if (!isNaN(parseFloat(object))) {
+            return Intl.NumberFormat(this._locale).format(parseFloat(object));
         }
-        return translation;
+        return object;
     }
 }

--- a/feature-utils/silly-i18n/src/l12n.js
+++ b/feature-utils/silly-i18n/src/l12n.js
@@ -17,13 +17,31 @@ export class L12n {
      * @throws LanguageError - if the provided language is incorrect in some way (inexistent, or incorrect string format)
      */
     constructor(locale = determineLocale()) {
-        const canonicalLocale = Intl.getCanonicalLocales(locale)[0];
+        let canonicalLocale;
+        try {
+            canonicalLocale = Intl.getCanonicalLocales(locale)[0];
+        } catch (error) {
+            if (error.name == "RangeError") {
+                throw new LanguageError(
+                    canonicalLocale + " is not a supported locale"
+                );
+            }
+        }
         if (!canonicalLocale.match(/^[a-z]{2}\b(_[A-Z]{2}\b)?/)) {
             throw new LanguageError(
                 canonicalLocale + " does not follow the usual locale format"
             );
         }
-        this._locale = locale;
+
+        if (
+            Intl.NumberFormat.supportedLocalesOf([canonicalLocale]).length == 0
+        ) {
+            throw new LanguageError(
+                canonicalLocale + " does not support numeric formats"
+            );
+        }
+
+        this._locale = canonicalLocale;
     }
 
     /**

--- a/feature-utils/silly-i18n/src/l12n.js
+++ b/feature-utils/silly-i18n/src/l12n.js
@@ -27,7 +27,7 @@ export class L12n {
                 );
             }
         }
-        if (!canonicalLocale.match(/^[a-z]{2}\b(_[A-Z]{2}\b)?/)) {
+        if (!canonicalLocale.match(/^[a-z]{2,3}\b(_[A-Z]{2,4}\b)?/)) {
             throw new LanguageError(
                 canonicalLocale + " does not follow the usual locale format"
             );
@@ -55,7 +55,7 @@ export class L12n {
 
     /**
      * Obtains the (translated) string for a `namespace:key` defined in the translations hash.
-     *
+     *cd .
      * @param object - What needs to be translated. For the time being, only translates numbers
      * @returns The locale-formatted string.
      */

--- a/feature-utils/silly-i18n/src/l12n.js
+++ b/feature-utils/silly-i18n/src/l12n.js
@@ -1,0 +1,56 @@
+import { LanguageError } from "./errors.js";
+import { determineLocale } from "./locale.js";
+
+/**
+ * Simple class for performing string translations, with simple templating capabilities
+ *
+ * @class
+ */
+export class L12n {
+    /**
+     * Class constructor for the localization class. The locale used will be auto-detected (by default)
+     * and stored as a private, read-only attribute. This is going to essentially be an encapsulation of
+     * the existing localle, deferring all actual processing to the `Intl` standard library.
+     *
+     * @param {string} [ locale = determineLocale() ] - locale string, in the usual format xx[_YY],
+     *     by default locale determined using that function
+     * @throws LanguageError - if the provided language is incorrect in some way (inexistent, or incorrect string format)
+     */
+    constructor(locale = determineLocale()) {
+        const canonicalLocale = Intl.getCanonicalLocales(locale)[0];
+        if (!canonicalLocale.match(/^[a-z]{2}\b(_[A-Z]{2}\b)?/)) {
+            throw new LanguageError(
+                canonicalLocale + " does not follow the usual locale format"
+            );
+        }
+        this._locale = locale;
+    }
+
+    /**
+     * Returns the locale string.
+     *
+     * @returns locale string in the usual `xx-XX` format.
+     */
+    get locale() {
+        return this._locale;
+    }
+
+    /**
+     * Obtains the (translated) string for a `namespace:key` defined in the translations hash.
+     *
+     * @param object - What needs to be translated
+     * @returns The locale-formatted string.
+     */
+    t(object) {
+        for (let [key, value] of Object.entries(options)) {
+            let convertedValue = value;
+            if (!isNaN(parseFloat(value))) {
+                convertedValue = Intl.NumberFormat(this._locale).format(
+                    parseFloat(value)
+                );
+            }
+            translation = translation.replace(`{{${key}}}`, convertedValue);
+        }
+        return translation;
+    }
+}

--- a/feature-utils/silly-i18n/src/l12n.js
+++ b/feature-utils/silly-i18n/src/l12n.js
@@ -60,6 +60,9 @@ export class L12n {
      * @returns The locale-formatted string.
      */
     t(object) {
+        if (object instanceof Date) {
+            return Intl.DateTimeFormat(this._locale).format(object);
+        }
         if (!isNaN(parseFloat(object))) {
             return Intl.NumberFormat(this._locale).format(parseFloat(object));
         }

--- a/feature-utils/silly-i18n/test/basic.test.js
+++ b/feature-utils/silly-i18n/test/basic.test.js
@@ -24,6 +24,7 @@ beforeAll(() => {
 describe("Test basic configuration", () => {
     it("is created correctly", () => {
         expect(i18n).toBeInstanceOf(I18n);
+        expect(i18n.l12n).toBeDefined();
     });
     it("Includes all attributes", () => {
         expect(i18n.sections).toStrictEqual(Object.keys(translationData));

--- a/feature-utils/silly-i18n/test/basic.test.js
+++ b/feature-utils/silly-i18n/test/basic.test.js
@@ -6,7 +6,7 @@ import {
     TranslationKeyError,
 } from "../src/errors";
 
-import { bigNumber, localePairs } from "./test-utils.js";
+import { bigNumber, numberPairs } from "./test-utils.js";
 import { L12n } from "../src/l12n.js";
 
 const LANGUAGE = "foo";
@@ -75,7 +75,7 @@ describe("Test basic configuration", () => {
 
 describe("Test locale numeric options correctly", () => {
     it("Converts big numbers to locale format", () => {
-        for (const [locale, l8nString] of Object.entries(localePairs)) {
+        for (const [locale, l8nString] of Object.entries(numberPairs)) {
             i18n._l12n = new L12n(locale);
             expect(i18n.t("template:opt", { opt: bigNumber })).toBe(l8nString);
         }

--- a/feature-utils/silly-i18n/test/basic.test.js
+++ b/feature-utils/silly-i18n/test/basic.test.js
@@ -6,6 +6,9 @@ import {
     TranslationKeyError,
 } from "../src/errors";
 
+import { bigNumber, localePairs } from "./test-utils.js";
+import { L12n } from "../src/l12n.js";
+
 const LANGUAGE = "foo";
 const FALLBACK_LANGUAGE = "en";
 let i18n;
@@ -71,14 +74,8 @@ describe("Test basic configuration", () => {
 
 describe("Test locale numeric options correctly", () => {
     it("Converts big numbers to locale format", () => {
-        const bigNumber = "1000000.33";
-        const localePairs = {
-            "de-DE": "1.000.000,33",
-            "es-ES": "1.000.000,33",
-            "en-GB": "1,000,000.33",
-        };
         for (const [locale, l8nString] of Object.entries(localePairs)) {
-            i18n._locale = locale;
+            i18n._l12n = new L12n(locale);
             expect(i18n.t("template:opt", { opt: bigNumber })).toBe(l8nString);
         }
     });

--- a/feature-utils/silly-i18n/test/l12n.test.js
+++ b/feature-utils/silly-i18n/test/l12n.test.js
@@ -44,4 +44,12 @@ describe("It's able to translate numbers correctly", () => {
             expect(localeHere.t(bigNumber)).toEqual(l12nString);
         }
     });
+
+    it("passes through non-number objects without a glitch", () => {
+        const foobar = "foobar";
+        for (const locale in localePairs) {
+            const localeHere = new L12n(locale);
+            expect(localeHere.t(foobar)).toEqual(foobar);
+        }
+    });
 });

--- a/feature-utils/silly-i18n/test/l12n.test.js
+++ b/feature-utils/silly-i18n/test/l12n.test.js
@@ -1,13 +1,8 @@
 import { LanguageError } from "../src/errors";
 import { L12n } from "../src/l12n";
+import { bigNumber, localePairs } from "./test-utils.js";
 
 let l12n;
-const bigNumber = "1000000.33";
-const localePairs = {
-    "de-DE": "1.000.000,33",
-    "es-ES": "1.000.000,33",
-    "en-GB": "1,000,000.33",
-};
 
 beforeAll(() => {
     l12n = new L12n();

--- a/feature-utils/silly-i18n/test/l12n.test.js
+++ b/feature-utils/silly-i18n/test/l12n.test.js
@@ -11,15 +11,27 @@ describe("Test correct and incorrect locales", () => {
     it("has a reasonable locale", () => {
         expect(l12n.locale).toMatch(/^\w{2}/);
     });
-    it("throws correctly if locale is incorrect ", () => {
+    it("throws correctly if locale has incorrect format ", () => {
         let thrownError;
         try {
             new L12n("WAT");
         } catch (error) {
             thrownError = error;
         }
-        console.log(thrownError);
         expect(thrownError).toBeInstanceOf(LanguageError);
         expect(thrownError.message).toEqual(expect.stringMatching(/format/));
+    });
+    it("throws correctly if locale does not support numeric format ", () => {
+        let thrownError;
+        try {
+            new L12n("wa_WA");
+        } catch (error) {
+            thrownError = error;
+        }
+        console.log(thrownError);
+        expect(thrownError).toBeInstanceOf(LanguageError);
+        expect(thrownError.message).toEqual(
+            expect.stringMatching(/supported locale/)
+        );
     });
 });

--- a/feature-utils/silly-i18n/test/l12n.test.js
+++ b/feature-utils/silly-i18n/test/l12n.test.js
@@ -1,6 +1,6 @@
 import { LanguageError } from "../src/errors";
 import { L12n } from "../src/l12n";
-import { bigNumber, localePairs } from "./test-utils.js";
+import { bigNumber, numberPairs, date, datePairs } from "./test-utils.js";
 
 let l12n;
 
@@ -36,18 +36,21 @@ describe("Test correct and incorrect locales", () => {
     });
 });
 
-describe("It's able to translate numbers correctly", () => {
-    it("is able to convert number to a known format", () => {
-        for (const [locale, l12nString] of Object.entries(localePairs)) {
+describe("It's able to translate objects correctly", () => {
+    it("is able to convert numbers and dates to a known format", () => {
+        for (const locale in numberPairs) {
             const localeHere = new L12n(locale);
             expect(localeHere.locale).toEqual(locale);
+            const l12nString = numberPairs[locale];
             expect(localeHere.t(bigNumber)).toEqual(l12nString);
+            const l12nDate = datePairs[locale];
+            expect(localeHere.t(date)).toEqual(l12nDate);
         }
     });
 
     it("passes through non-number objects without a glitch", () => {
         const foobar = "foobar";
-        for (const locale in localePairs) {
+        for (const locale in numberPairs) {
             const localeHere = new L12n(locale);
             expect(localeHere.t(foobar)).toEqual(foobar);
         }

--- a/feature-utils/silly-i18n/test/l12n.test.js
+++ b/feature-utils/silly-i18n/test/l12n.test.js
@@ -28,10 +28,18 @@ describe("Test correct and incorrect locales", () => {
         } catch (error) {
             thrownError = error;
         }
-        console.log(thrownError);
         expect(thrownError).toBeInstanceOf(LanguageError);
         expect(thrownError.message).toEqual(
             expect.stringMatching(/supported locale/)
         );
+    });
+});
+
+describe("It's able to translate numbers correctly", () => {
+    it("is able to convert number to a known format", () => {
+        const enLocale = "en";
+        const enL12n = new L12n(enLocale);
+        expect(enL12n.locale).toBe(enLocale);
+        expect(enL12n.t(33333)).toBe("33,333");
     });
 });

--- a/feature-utils/silly-i18n/test/l12n.test.js
+++ b/feature-utils/silly-i18n/test/l12n.test.js
@@ -1,0 +1,25 @@
+import { LanguageError } from "../src/errors";
+import { L12n } from "../src/l12n";
+
+let l12n;
+
+beforeAll(() => {
+    l12n = new L12n();
+});
+
+describe("Test correct and incorrect locales", () => {
+    it("has a reasonable locale", () => {
+        expect(l12n.locale).toMatch(/^\w{2}/);
+    });
+    it("throws correctly if locale is incorrect ", () => {
+        let thrownError;
+        try {
+            new L12n("WAT");
+        } catch (error) {
+            thrownError = error;
+        }
+        console.log(thrownError);
+        expect(thrownError).toBeInstanceOf(LanguageError);
+        expect(thrownError.message).toEqual(expect.stringMatching(/format/));
+    });
+});

--- a/feature-utils/silly-i18n/test/l12n.test.js
+++ b/feature-utils/silly-i18n/test/l12n.test.js
@@ -2,6 +2,12 @@ import { LanguageError } from "../src/errors";
 import { L12n } from "../src/l12n";
 
 let l12n;
+const bigNumber = "1000000.33";
+const localePairs = {
+    "de-DE": "1.000.000,33",
+    "es-ES": "1.000.000,33",
+    "en-GB": "1,000,000.33",
+};
 
 beforeAll(() => {
     l12n = new L12n();
@@ -37,9 +43,10 @@ describe("Test correct and incorrect locales", () => {
 
 describe("It's able to translate numbers correctly", () => {
     it("is able to convert number to a known format", () => {
-        const enLocale = "en";
-        const enL12n = new L12n(enLocale);
-        expect(enL12n.locale).toBe(enLocale);
-        expect(enL12n.t(33333)).toBe("33,333");
+        for (const [locale, l12nString] of Object.entries(localePairs)) {
+            const localeHere = new L12n(locale);
+            expect(localeHere.locale).toEqual(locale);
+            expect(localeHere.t(bigNumber)).toEqual(l12nString);
+        }
     });
 });

--- a/feature-utils/silly-i18n/test/test-utils.js
+++ b/feature-utils/silly-i18n/test/test-utils.js
@@ -1,6 +1,13 @@
 export const bigNumber = "1000000.33";
-export const localePairs = {
+export const numberPairs = {
     "de-DE": "1.000.000,33",
     "es-ES": "1.000.000,33",
     "en-GB": "1,000,000.33",
+};
+
+export const date = new Date(2022, 2, 2);
+export const datePairs = {
+    "de-DE": "2.3.2022",
+    "es-ES": "2/3/2022",
+    "en-GB": "02/03/2022",
 };

--- a/feature-utils/silly-i18n/test/test-utils.js
+++ b/feature-utils/silly-i18n/test/test-utils.js
@@ -1,0 +1,6 @@
+export const bigNumber = "1000000.33";
+export const localePairs = {
+    "de-DE": "1.000.000,33",
+    "es-ES": "1.000.000,33",
+    "en-GB": "1,000,000.33",
+};


### PR DESCRIPTION
We had some localization (l12n) capabilities in `silly-i18n`, but now I'm spinning them off to its new module and extending capabilities. At least, I'll try to account for numbers and dates, these being the ones that can be easily identified (more or less)

To do:
- [x] Document to the tune of the rest of the module.
- [x] Make the rest of the module use this.
- [x] Add date-formatting capabilities for `Date` objects.
