### PR TITLE
Cache Java

### DIFF
--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -49,7 +49,7 @@ jobs:
             - name: Test core and features
               if: steps.changes.outputs.apiAndFeatures == 'true'
               run: xvfb-run --auto-servernum ./build.js test
-            - uses: actions/setup-java@v1
+            - uses: actions/setup-java@v2
               if: steps.changes.outputs.android == 'true'
               with:
                   java-version: 11

--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -53,6 +53,7 @@ jobs:
               if: steps.changes.outputs.android == 'true'
               with:
                   java-version: 11
+                  distribution: 'temurin'
                   cache: 'gradle'
             - name: Test android
               if: steps.changes.outputs.android == 'true'

--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -53,6 +53,7 @@ jobs:
               if: steps.changes.outputs.android == 'true'
               with:
                   java-version: 11
+                  cache: 'gradle'
             - name: Test android
               if: steps.changes.outputs.android == 'true'
               working-directory: platform/android

--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -32,7 +32,7 @@ task.
 
 ### Linting
 
-We use [ktlint](https://github.com/pinterest/ktlint) for testing the source, and
+We use [ktlint](https://github.com/pinterest/ktlint) for linting sources, and
 that it conforms to the usual standards. It will be run automatically when
 you push or create a pull request, but you can download, put it somewhere in the
 path,  and then run it with

--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -5,7 +5,7 @@ This directory contains the source for the polyPod app for Android devices.
 ## Building
 
 Before you do anything else, ensure you've built the core code and features: See
-the [`README` file](../README.md) above.
+the [`README` file](../../README.md) above.
 
 ### Android Studio
 

--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -19,7 +19,7 @@ If you merely want to build the code, get:
 1. [OpenJDK 11]
 2. [Android SDK command line tools]
 
-Then set `sdk.dir` in `local.properties` and finally run:
+Then set `sdk.dir` in your local `local.properties` and finally run:
 
 ```
 ./gradlew assemble

--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -16,7 +16,7 @@ and open this directory as an existing project.
 
 If you merely want to build the code, get:
 
-1. [OpenJDK 8]
+1. [OpenJDK 11]
 2. [Android SDK command line tools]
 
 Then set `sdk.dir` in `local.properties` and finally run:
@@ -63,4 +63,4 @@ uninstalled.
 
 [Android Studio]: https://developer.android.com/studio
 [Android SDK command line tools]: https://developer.android.com/studio/index.html#command-tools
-[OpenJDK 8]: https://openjdk.java.net
+[OpenJDK 11]: https://openjdk.java.net


### PR DESCRIPTION

![mejora-cache](https://user-images.githubusercontent.com/500/157001225-9486586e-37b1-42d6-b240-02ea6adfa612.png)
Java can be cached, so why not. Might not work due to the fact that we have our files elsewhere, but wanted to check just in case. It needed an upgrade of the GitHub action, and a (mostly random) selection of the Java distribution (previously Zulu was used, can be used too). As can be seen above, 2 minutes saved!