### PR TITLE
Dispatch archive unzipping to IO context

### DIFF
--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/polyOut/PolyOut.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/polyOut/PolyOut.kt
@@ -8,6 +8,7 @@ import coop.polypoly.polypod.Preferences
 import coop.polypoly.polypod.features.FeatureStorage
 import coop.polypoly.polypod.polyNav.ZipTools
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.supervisorScope
 import java.io.File
@@ -157,7 +158,7 @@ open class PolyOut(
             }
         }
         val retVal = supervisorScope {
-            this.async {
+            this.async(Dispatchers.IO) {
                 contentResolver?.openInputStream(uri).use { inputStream ->
                     if (inputStream == null) {
                         throw Error("File import error")


### PR DESCRIPTION
A coroutine can block the main thread if it performs a heavy job, thus this change dispatches the archive unzipping to IO thread so that main thread(which is used for UI) is unblocked. This way the app is usable while the archive is imported, and this should fix the ANR.

This fix is similar to -> https://github.com/polypoly-eu/polyPod/pull/595. It seems that Android and iOS apps are running everything(or almost) on the main thread. While for simple operations this is acceptable; heavier operations need to be offloaded to other threads to free the main thread for UI jobs triggered by the OS, for example screen refresh. Executing lots of operations on the main thread will decrease the application's frame rate down to being unresponsive. We may need to investigate the apps for other cases, when a heavy operation is done on the main thread.