### PR TITLE
[Fix] Rollup ⚠ in two modules

### DIFF
--- a/features/polyPinion/rollup.config.js
+++ b/features/polyPinion/rollup.config.js
@@ -15,6 +15,7 @@ export default {
             react: "React",
             "react-dom": "ReactDOM",
             uuid: "uuid",
+            "@polypoly-eu/silly-i18n": "@polypoly-eu/silly-i18n",
         },
     },
     plugins: [
@@ -46,5 +47,5 @@ export default {
             preventAssignment: true,
         }),
     ],
-    external: ["react", "react-dom", "uuid"],
+    external: ["react", "react-dom", "uuid", "@polypoly-eu/silly-i18n"],
 };

--- a/platform/podjs/rollup.config.js
+++ b/platform/podjs/rollup.config.js
@@ -21,7 +21,7 @@ export default [
                 transforms: ["typescript"],
             }),
         ],
-        external: ["@polypoly-eu/rdf", "@zip.js/zip.js"],
+        external: ["@polypoly-eu/rdf","@polypoly-eu/manifest-parser", "@zip.js/zip.js"],
     },
     {
         input: "src/pod.ts",


### PR DESCRIPTION
Mainly configures them as external dependencies to avoid the warning. There's still a circular dependency warning in pod.js, but it's not our code, but `semver`