### PR TITLE
[Task] Rollup-plugin-copy-watch CI workflow and actual test ✅

### DIFF
--- a/.github/workflows/rollup-copy-test.yml
+++ b/.github/workflows/rollup-copy-test.yml
@@ -1,0 +1,42 @@
+name: Test Rollup plugin
+on:
+    push:
+        paths:
+          - "dev-utils/rollup-plugin-copy-watch/**"
+          - ".github/workflows/rollup-copy-test.yml"
+    pull_request:
+        types: [assigned, opened, ready_for_review]
+        paths:
+          - "dev-utils/rollup-plugin-copy-watch/**"
+
+jobs:
+    test:
+        name: Run tests.
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 16
+                  cache: "npm"
+                  cache-dependency-path: "package-lock.json"
+            - name: Cache root
+              uses: actions/cache@v2
+              id: root-cache
+              with:
+                  path: "**/node_modules"
+                  key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+            - name: Install root
+              if: steps.root-cache.outputs.cache-hit != 'true'
+              run: npm --no-audit --prefer-offline ci
+            - name: Cache this
+              uses: actions/cache@v2
+              id: this-cache
+              with:
+                  path: "dev-utils/rollup-plugin-copy-watch/node_modules"
+                  key: ${{ runner.os }}-${{ hashFiles('dev-utils/rollup-plugin-copy-watch/package-lock.json') }}
+
+            - name: Test core and features
+              if: steps.this-cache.outputs.cache-hit != 'true'
+              working-directory: dev-utils/rollup-plugin-copy-watch
+              run: npm ci && npm run test

--- a/.github/workflows/rollup-copy-test.yml
+++ b/.github/workflows/rollup-copy-test.yml
@@ -36,7 +36,9 @@ jobs:
                   path: "dev-utils/rollup-plugin-copy-watch/node_modules"
                   key: ${{ runner.os }}-${{ hashFiles('dev-utils/rollup-plugin-copy-watch/package-lock.json') }}
 
-            - name: Test core and features
+            - name: Install modules
               if: steps.this-cache.outputs.cache-hit != 'true'
               working-directory: dev-utils/rollup-plugin-copy-watch
-              run: npm ci && npm run test
+              run: npm ci
+            - name: Actually run tests
+              run: npm run test

--- a/.github/workflows/rollup-copy-test.yml
+++ b/.github/workflows/rollup-copy-test.yml
@@ -24,7 +24,7 @@ jobs:
               uses: actions/cache@v2
               id: root-cache
               with:
-                  path: "**/node_modules"
+                  path: "./node_modules"
                   key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
             - name: Install root
               if: steps.root-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/rollup-copy-test.yml
+++ b/.github/workflows/rollup-copy-test.yml
@@ -41,4 +41,5 @@ jobs:
               working-directory: dev-utils/rollup-plugin-copy-watch
               run: npm ci
             - name: Actually run tests
+              working-directory: dev-utils/rollup-plugin-copy-watch
               run: npm run test

--- a/dev-utils/rollup-plugin-copy-watch/README.md
+++ b/dev-utils/rollup-plugin-copy-watch/README.md
@@ -5,7 +5,7 @@ files.
 
 There's already a [rollup-plugin-copy-watch] out there that should do this, but
 when we tried to use it it actually triggered watch mode for regular builds for
-some reason. Ideally we get rid of this self written plugin in favour of
+some reason. Ideally we should get rid of this self written plugin in favour of
 something maintained by somebody else, but for now writing a few lines of code
 ourselves was the easiest thing to do.
 

--- a/dev-utils/rollup-plugin-copy-watch/copy.test.js
+++ b/dev-utils/rollup-plugin-copy-watch/copy.test.js
@@ -1,0 +1,12 @@
+const copy = require("./index");
+const fs = require("fs");
+
+beforeAll(() => {
+    copy({
+        targets: [{ src: "index.js", dest: "/tmp" }],
+    });
+});
+
+test("copy has worked", () => {
+    expect(fs.existsSync("/tmp/index.js")).toBeTruthy;
+});

--- a/dev-utils/rollup-plugin-copy-watch/package.json
+++ b/dev-utils/rollup-plugin-copy-watch/package.json
@@ -2,6 +2,7 @@
   "name": "@polypoly-eu/rollup-plugin-copy-watch",
   "main": "index.js",
   "private": true,
+  "scripts":{ "test": "jest"},
   "dependencies": {
     "rollup-plugin-copy": "^3.4.0"
   }


### PR DESCRIPTION
Along with #736, this is a new workflow to actually test `rollup-plugin-copy-watch`, which wasn't tested originally. Everything is cached, and it's actually creating a global cache for root, so it would be reusable for other workflows (as soon as we change them to do so, of course).
Changes in README are basically to check that the cache is working. It is, and if package.json is not changed, it takes 10 seconds to test this.