### PR TITLE
Set indent for GA workflow files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ indent_size = 4
 # code alone for now, we overwrite max_line_length for TypeScript code.
 max_line_length = 100
 
+[.github/**.yml]
+indent_size = 2
+
 [COMMIT_EDITMSG]
 trim_trailing_whitespace = false
 max_line_length = 72

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ indent_size = 4
 # code alone for now, we overwrite max_line_length for TypeScript code.
 max_line_length = 100
 
-[.github/**.yml]
+[.github/**.y{,a}ml]
 indent_size = 2
 
 [COMMIT_EDITMSG]


### PR DESCRIPTION
Was starting to drive me crazy that my editor would (correctly) stick to the four space indents configured for the repo, when we use two space indents across all our GA workflow YAML files :D