### PR TITLE
style: change global `max_line_length` to 80 - [PROD4POD-1455]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_size = 4
 [*.ts]
 # This is being picked up by prettier/eslint, so in order to leave the existing
 # code alone for now, we overwrite max_line_length for TypeScript code.
-max_line_length = 100
+max_line_length = 80
 
 [COMMIT_EDITMSG]
 trim_trailing_whitespace = false

--- a/features/test/src/test.ts
+++ b/features/test/src/test.ts
@@ -63,20 +63,29 @@ export async function verifyResponseStatusOfFetchCall(): Promise<void> {
     console.log("verifyResponseStatusOfFetchCall()");
     const response = await polyOut.fetch("http://httpbin.org/robots.txt");
     if (typeof response.status === "number") setResult(response.status);
-    else throw new TypeError(`response.ok is not a number, it is: '${typeof response.status}'`);
+    else
+        throw new TypeError(
+            `response.ok is not a number, it is: '${typeof response.status}'`
+        );
 }
 
 export async function verifyResponseOkOfFetchCall(): Promise<void> {
     console.log("verifyResponseOkOfFetchCall()");
     const response = await polyOut.fetch("http://httpbin.org/robots.txt");
     if (typeof response.ok === "boolean") setResult(response.ok);
-    else throw new TypeError(`response.ok is not a boolean, it is: '${typeof response.ok}'`);
+    else
+        throw new TypeError(
+            `response.ok is not a boolean, it is: '${typeof response.ok}'`
+        );
 }
 
 export async function callFetchWithPostMethodAndBody(): Promise<void> {
     console.log("callFetchWithPostMethodAndBOdy()");
     const body = getInput(1);
-    await polyOut.fetch("http://httpbin.org/post", { method: "POST", body: body });
+    await polyOut.fetch("http://httpbin.org/post", {
+        method: "POST",
+        body: body,
+    });
 }
 
 export async function canCallPolyInAddWithNoQuads(): Promise<void> {
@@ -157,7 +166,9 @@ export async function addSupportsQuadsWithBlankNodeGraph(): Promise<void> {
 
 export async function addSupportsQuadsWithDefaultGraph(): Promise<void> {
     console.log(`addSupportsQuadsWithDefaultGraph()`);
-    const quad = QuadBuilder.fromInputs().withGraph(window.pod.dataFactory.defaultGraph()).build();
+    const quad = QuadBuilder.fromInputs()
+        .withGraph(window.pod.dataFactory.defaultGraph())
+        .build();
     await polyIn.add(quad);
 }
 
@@ -213,76 +224,94 @@ export async function canGetArrayWithSingleQuadFromPolyInSelect(): Promise<void>
     const expectedResult = QuadBuilder.fromQuad(quads[0]).build();
     const result = await polyIn.select({});
     if (result.length !== 1)
-        throw Error(`Expected array with 1 element, got ${result.length} elements`);
+        throw Error(
+            `Expected array with 1 element, got ${result.length} elements`
+        );
     if (!result[0].equals(expectedResult))
         throw Error(
-            `Expected element equal to '${JSON.stringify(expectedResult)}', got '${JSON.stringify(
-                result[0]
-            )}'`
+            `Expected element equal to '${JSON.stringify(
+                expectedResult
+            )}', got '${JSON.stringify(result[0])}'`
         );
 }
 
 export async function canGetArrayWithSingleQuadWithNamedNodeSubjectFromPolyInSelect(): Promise<void> {
-    console.log("canGetArrayWithSingleQuadWithNamedNodeSubjectFromPolyInSelect()");
+    console.log(
+        "canGetArrayWithSingleQuadWithNamedNodeSubjectFromPolyInSelect()"
+    );
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withSubject(pod.dataFactory.namedNode(quads[0].subject.value))
         .build();
     const result = await polyIn.select({});
     if (result.length !== 1)
-        throw Error(`Expected array with 1 element, got ${result.length} elements`);
+        throw Error(
+            `Expected array with 1 element, got ${result.length} elements`
+        );
     if (!result[0].equals(expectedResult))
         throw Error(
-            `Expected element equal to '${JSON.stringify(expectedResult)}', got '${JSON.stringify(
-                result[0]
-            )}'`
+            `Expected element equal to '${JSON.stringify(
+                expectedResult
+            )}', got '${JSON.stringify(result[0])}'`
         );
 }
 
 export async function canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInSelect(): Promise<void> {
-    console.log("canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInSelect()");
+    console.log(
+        "canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInSelect()"
+    );
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withSubject(pod.dataFactory.blankNode(quads[0].subject.value))
         .build();
     const result = await polyIn.select({});
     if (result.length !== 1)
-        throw Error(`Expected array with 1 element, got ${result.length} elements`);
+        throw Error(
+            `Expected array with 1 element, got ${result.length} elements`
+        );
     if (!result[0].equals(expectedResult))
         throw Error(
-            `Expected element equal to '${JSON.stringify(expectedResult)}', got '${JSON.stringify(
-                result[0]
-            )}'`
+            `Expected element equal to '${JSON.stringify(
+                expectedResult
+            )}', got '${JSON.stringify(result[0])}'`
         );
 }
 
 export async function canGetArrayWithSingleQuadWithNamedNodeObjectFromPolyInSelect(): Promise<void> {
-    console.log("canGetArrayWithSingleQuadWithNamedNodeObjectFromPolyInSelect()");
+    console.log(
+        "canGetArrayWithSingleQuadWithNamedNodeObjectFromPolyInSelect()"
+    );
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withObject(pod.dataFactory.namedNode(quads[0].object.value))
         .build();
     const result = await polyIn.select({});
     if (result.length !== 1)
-        throw Error(`Expected array with 1 element, got ${result.length} elements`);
+        throw Error(
+            `Expected array with 1 element, got ${result.length} elements`
+        );
     if (!result[0].equals(expectedResult))
         throw Error(
-            `Expected element equal to '${JSON.stringify(expectedResult)}', got '${JSON.stringify(
-                result[0]
-            )}'`
+            `Expected element equal to '${JSON.stringify(
+                expectedResult
+            )}', got '${JSON.stringify(result[0])}'`
         );
 }
 
 export async function canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInSelect(): Promise<void> {
-    console.log("canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInSelect()");
+    console.log(
+        "canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInSelect()"
+    );
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withObject(pod.dataFactory.blankNode(quads[0].object.value))
         .build();
     const result = await polyIn.select({});
     if (result.length !== 1)
-        throw Error(`Expected array with 1 element, got ${result.length} elements`);
+        throw Error(
+            `Expected array with 1 element, got ${result.length} elements`
+        );
     if (!result[0].equals(expectedResult))
         throw Error(
-            `Expected element equal to '${JSON.stringify(expectedResult)}', got '${JSON.stringify(
-                result[0]
-            )}'`
+            `Expected element equal to '${JSON.stringify(
+                expectedResult
+            )}', got '${JSON.stringify(result[0])}'`
         );
 }
 
@@ -293,44 +322,54 @@ export async function canGetArrayWithSingleQuadWithLiteralObjectFromPolyInSelect
         .build();
     const result = await polyIn.select({});
     if (result.length !== 1)
-        throw Error(`Expected array with 1 element, got ${result.length} elements`);
+        throw Error(
+            `Expected array with 1 element, got ${result.length} elements`
+        );
     if (!result[0].equals(expectedResult))
         throw Error(
-            `Expected element equal to '${JSON.stringify(expectedResult)}', got '${JSON.stringify(
-                result[0]
-            )}'`
+            `Expected element equal to '${JSON.stringify(
+                expectedResult
+            )}', got '${JSON.stringify(result[0])}'`
         );
 }
 
 export async function canGetArrayWithSingleQuadWithNamedNodeGraphFromPolyInSelect(): Promise<void> {
-    console.log("canGetArrayWithSingleQuadWithNamedNodeGraphFromPolyInSelect()");
+    console.log(
+        "canGetArrayWithSingleQuadWithNamedNodeGraphFromPolyInSelect()"
+    );
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withGraph(pod.dataFactory.namedNode(quads[0].graph.value))
         .build();
     const result = await polyIn.select({});
     if (result.length !== 1)
-        throw Error(`Expected array with 1 element, got ${result.length} elements`);
+        throw Error(
+            `Expected array with 1 element, got ${result.length} elements`
+        );
     if (!result[0].equals(expectedResult))
         throw Error(
-            `Expected element equal to '${JSON.stringify(expectedResult)}', got '${JSON.stringify(
-                result[0]
-            )}'`
+            `Expected element equal to '${JSON.stringify(
+                expectedResult
+            )}', got '${JSON.stringify(result[0])}'`
         );
 }
 
 export async function canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInSelect(): Promise<void> {
-    console.log("canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInSelect()");
+    console.log(
+        "canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInSelect()"
+    );
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withGraph(pod.dataFactory.blankNode(quads[0].graph.value))
         .build();
     const result = await polyIn.select({});
     if (result.length !== 1)
-        throw Error(`Expected array with 1 element, got ${result.length} elements`);
+        throw Error(
+            `Expected array with 1 element, got ${result.length} elements`
+        );
     if (!result[0].equals(expectedResult))
         throw Error(
-            `Expected element equal to '${JSON.stringify(expectedResult)}', got '${JSON.stringify(
-                result[0]
-            )}'`
+            `Expected element equal to '${JSON.stringify(
+                expectedResult
+            )}', got '${JSON.stringify(result[0])}'`
         );
 }
 
@@ -341,12 +380,14 @@ export async function canGetArrayWithSingleQuadWithDefaultGraphFromPolyInSelect(
         .build();
     const result = await polyIn.select({});
     if (result.length !== 1)
-        throw Error(`Expected array with 1 element, got ${result.length} elements`);
+        throw Error(
+            `Expected array with 1 element, got ${result.length} elements`
+        );
     if (!result[0].equals(expectedResult))
         throw Error(
-            `Expected element equal to '${JSON.stringify(expectedResult)}', got '${JSON.stringify(
-                result[0]
-            )}'`
+            `Expected element equal to '${JSON.stringify(
+                expectedResult
+            )}', got '${JSON.stringify(result[0])}'`
         );
 }
 
@@ -354,7 +395,9 @@ export async function canGetArrayWithMultipleQuadsFromPolyInSelect(): Promise<vo
     console.log("canGetArrayWithMultipleQuadsFromPolyInSelect()");
     const result = await polyIn.select({});
     if (result.length !== 2)
-        throw Error(`Expected array with 2 elements, got ${result.length} elements`);
+        throw Error(
+            `Expected array with 2 elements, got ${result.length} elements`
+        );
     if (!result[0].equals(quads[0]) && !result[1].equals(quads[0]))
         throw Error(
             `Expected one element equal to '${JSON.stringify(
@@ -471,6 +514,11 @@ class QuadBuilder {
     }
 
     build(): RDF.Quad {
-        return window.pod.dataFactory.quad(this.subject, this.predicate, this.object, this.graph);
+        return window.pod.dataFactory.quad(
+            this.subject,
+            this.predicate,
+            this.object,
+            this.graph
+        );
     }
 }

--- a/platform/feature-api/api/pod-api/.editorconfig
+++ b/platform/feature-api/api/pod-api/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+max_line_length = 100

--- a/platform/feature-api/api/pod-api/src/api.ts
+++ b/platform/feature-api/api/pod-api/src/api.ts
@@ -13,9 +13,9 @@ import { ExternalFile, FS } from "./fs";
  * A _matcher_ specifies a filter for querying the Pod store.
  */
 export interface Matcher {
-    subject: RDF.Quad_Subject;
-    predicate: RDF.Quad_Predicate;
-    object: RDF.Quad_Object;
+  subject: RDF.Quad_Subject;
+  predicate: RDF.Quad_Predicate;
+  object: RDF.Quad_Object;
 }
 
 /**
@@ -40,66 +40,66 @@ export interface Matcher {
  * on, except for internal purposes of the Feature.
  */
 export interface PolyIn {
-    /**
-     * @deprecated use `match()` instead.
-     *
-     * Queries the Pod for triples matching the given filter. For each property ([[Matcher.subject]],
-     * [[Matcher.predicate]], [[Matcher.object]]) that is specified in the argument, the result set is narrowed to only
-     * contain triples that match the property exactly.
-     *
-     * For example, when querying the store as follows:
-     *
-     * ```
-     * const results = await polyIn.select({
-     *     subject: factory.namedNode("http://example.org")
-     * })
-     * ```
-     *
-     * ... the result is guaranteed to only contain triples with the subject IRI `http://example.org`.
-     *
-     * Features cannot rely on obtaining a complete view of the data using this method. The results may only reflect a
-     * filtered subset due to e.g. access restrictions or incomplete synchronization across multiple machines.
-     *
-     * @param matcher a [[Matcher]] where any property may be left unspecified
-     *
-     * @returns a set of triples that conform to the specified [[Matcher]]
-     */
-    select(matcher: Partial<Matcher>): Promise<RDF.Quad[]>;
+  /**
+   * @deprecated use `match()` instead.
+   *
+   * Queries the Pod for triples matching the given filter. For each property ([[Matcher.subject]],
+   * [[Matcher.predicate]], [[Matcher.object]]) that is specified in the argument, the result set is narrowed to only
+   * contain triples that match the property exactly.
+   *
+   * For example, when querying the store as follows:
+   *
+   * ```
+   * const results = await polyIn.select({
+   *     subject: factory.namedNode("http://example.org")
+   * })
+   * ```
+   *
+   * ... the result is guaranteed to only contain triples with the subject IRI `http://example.org`.
+   *
+   * Features cannot rely on obtaining a complete view of the data using this method. The results may only reflect a
+   * filtered subset due to e.g. access restrictions or incomplete synchronization across multiple machines.
+   *
+   * @param matcher a [[Matcher]] where any property may be left unspecified
+   *
+   * @returns a set of triples that conform to the specified [[Matcher]]
+   */
+  select(matcher: Partial<Matcher>): Promise<RDF.Quad[]>;
 
-    /**
-     * Queries the Pod for triples matching the given filter.
-     * @param matcher a [[Matcher]] where any property may be left unspecified
-     */
-    match(matcher: Partial<Matcher>): Promise<RDF.Quad[]>;
+  /**
+   * Queries the Pod for triples matching the given filter.
+   * @param matcher a [[Matcher]] where any property may be left unspecified
+   */
+  match(matcher: Partial<Matcher>): Promise<RDF.Quad[]>;
 
-    /**
-     * Instructs the Pod to add triples to the store. Successful storage is not guaranteed, as that may be contingent
-     * on other constraints, e.g. access restrictions or synchronization across multiple machines.
-     *
-     * In general, (synchronous) storage errors _should_ be propagated by the Pod to the Feature, resulting in this
-     * method throwing an exception or returning a failed promise. Causes for this include, but are not limited to:
-     *
-     * - any of the triples is malformed, e.g. not using the default graph
-     * - internal storage error, e.g. disk not writable
-     * - permission violation
-     *
-     * Failures that are handed to the Feature should be handled by the Feature, for example by providing a fallback
-     * option or some form of UI to inform the user of the failure. Other errors are handled by the Pod directly, for
-     * example failure of synchronization across multiple devices.
-     *
-     * @param quads the triples that should be stored in the Pod
-     */
-    add(...quads: RDF.Quad[]): Promise<void>;
+  /**
+   * Instructs the Pod to add triples to the store. Successful storage is not guaranteed, as that may be contingent
+   * on other constraints, e.g. access restrictions or synchronization across multiple machines.
+   *
+   * In general, (synchronous) storage errors _should_ be propagated by the Pod to the Feature, resulting in this
+   * method throwing an exception or returning a failed promise. Causes for this include, but are not limited to:
+   *
+   * - any of the triples is malformed, e.g. not using the default graph
+   * - internal storage error, e.g. disk not writable
+   * - permission violation
+   *
+   * Failures that are handed to the Feature should be handled by the Feature, for example by providing a fallback
+   * option or some form of UI to inform the user of the failure. Other errors are handled by the Pod directly, for
+   * example failure of synchronization across multiple devices.
+   *
+   * @param quads the triples that should be stored in the Pod
+   */
+  add(...quads: RDF.Quad[]): Promise<void>;
 
-    /**
-     * @param quads the triples that should be removed from the Pod
-     */
-    delete(...quads: RDF.Quad[]): Promise<void>;
+  /**
+   * @param quads the triples that should be removed from the Pod
+   */
+  delete(...quads: RDF.Quad[]): Promise<void>;
 
-    /**
-     * @param quads the triples that should be removed from the Pod
-     */
-    has(...quads: RDF.Quad[]): Promise<boolean>;
+  /**
+   * @param quads the triples that should be removed from the Pod
+   */
+  has(...quads: RDF.Quad[]): Promise<boolean>;
 }
 
 /**
@@ -107,8 +107,8 @@ export interface PolyIn {
  * platform independent way.
  */
 export interface Entry {
-    id: string;
-    path: string;
+  id: string;
+  path: string;
 }
 
 /**
@@ -120,17 +120,17 @@ export interface Entry {
  * - [[Fetch]] for DOM-style HTTP requests (deprecated)
  */
 export interface PolyOut extends Omit<FS, "readdir"> {
-    /**
-     * @deprecated Use [[Network]] and its facilities instead.
-     * A standard-compliant implementation of `Fetch`. This feature is deprecated in favor of the [[Network]] interface
-     */
-    readonly fetch: Fetch;
+  /**
+   * @deprecated Use [[Network]] and its facilities instead.
+   * A standard-compliant implementation of `Fetch`. This feature is deprecated in favor of the [[Network]] interface
+   */
+  readonly fetch: Fetch;
 
-    /**
-     * @param pathToDir system-dependent path to read.
-     * @returns a Promise with id-path pairs [[Entry]] as payload.
-     */
-    readDir(pathToDir: string): Promise<Entry[]>;
+  /**
+   * @param pathToDir system-dependent path to read.
+   * @returns a Promise with id-path pairs [[Entry]] as payload.
+   */
+  readDir(pathToDir: string): Promise<Entry[]>;
 }
 
 /**
@@ -138,65 +138,65 @@ export interface PolyOut extends Omit<FS, "readdir"> {
  * user interactions with the container.
  */
 export interface PolyNav {
-    /**
-     * A way for features to display a contents of a web page
-     */
-    openUrl(url: string): Promise<void>;
-    /**
-     * Describe what actions are possible within the pod when a feature is loaded
-     */
-    setActiveActions(actions: string[]): Promise<void>;
-    /**
-     * Set a title in of a Pod
-     */
-    setTitle(title: string): Promise<void>;
-    /**
-     * Ask the user to pick a file
-     * @param type the type of file the user is asked to select, as a valid MIME type string. If no type is passed, the user can chose any type of file.
-     * @throws if an unsupported MIME type was passed as the type argument.
-     * @return an ExternalFile Object or `null` if the user cancelled.
-     */
-    pickFile(type?: string): Promise<ExternalFile | null>;
+  /**
+   * A way for features to display a contents of a web page
+   */
+  openUrl(url: string): Promise<void>;
+  /**
+   * Describe what actions are possible within the pod when a feature is loaded
+   */
+  setActiveActions(actions: string[]): Promise<void>;
+  /**
+   * Set a title in of a Pod
+   */
+  setTitle(title: string): Promise<void>;
+  /**
+   * Ask the user to pick a file
+   * @param type the type of file the user is asked to select, as a valid MIME type string. If no type is passed, the user can chose any type of file.
+   * @throws if an unsupported MIME type was passed as the type argument.
+   * @return an ExternalFile Object or `null` if the user cancelled.
+   */
+  pickFile(type?: string): Promise<ExternalFile | null>;
 }
 
 /**
  * `Info` allows the Feature to read information about the polyPod instance it is being executed in.
  */
 export interface Info {
-    /**
-     * A way for features to read the polyPod runtime identification
-     */
-    getRuntime(): Promise<string>;
+  /**
+   * A way for features to read the polyPod runtime identification
+   */
+  getRuntime(): Promise<string>;
 
-    /**
-     * A way for features to read the user visible polyPod version
-     */
-    getVersion(): Promise<string>;
+  /**
+   * A way for features to read the user visible polyPod version
+   */
+  getVersion(): Promise<string>;
 }
 
 /**
  * `Network` specifies how features can communicate with other devices or servers.
  */
 export interface Network {
-    /**
-     * A way for features to send HTTP POST requests
-     *
-     * @returns an error message if something went wrong, `undefined` upon success.
-     */
-    httpPost(
-        url: string,
-        body: string,
-        contentType?: string,
-        authorization?: string
-    ): Promise<string | undefined>;
+  /**
+   * A way for features to send HTTP POST requests
+   *
+   * @returns an error message if something went wrong, `undefined` upon success.
+   */
+  httpPost(
+    url: string,
+    body: string,
+    contentType?: string,
+    authorization?: string
+  ): Promise<string | undefined>;
 }
 
 /**
  * @hidden
  */
 export interface PolyLifecycle {
-    listFeatures(): Promise<Record<string, boolean>>;
-    startFeature(id: string, background: boolean): Promise<void>;
+  listFeatures(): Promise<Record<string, boolean>>;
+  startFeature(id: string, background: boolean): Promise<void>;
 }
 
 /**
@@ -224,63 +224,63 @@ export interface PolyLifecycle {
  * the API concurrently.
  */
 export interface Pod {
-    /**
-     * A [spec-compliant](http://rdf.js.org/data-model-spec/) data factory that is _not_ guaranteed to support variables.
-     *
-     * Example:
-     * ```
-     * const quad = factory.quad(
-     *   factory.namedNode("http://example.org/s"),
-     *   factory.namedNode("http://example.org/p"),
-     *   factory.namedNode("http://example.org/o")
-     * );
-     * ```
-     *
-     * The factory is an exception in that it is synchronous as opposed to the general asynchronous [[Pod]] API. This is
-     * by design for these reasons:
-     *
-     * 1. Features may construct a large number of RDF terms. Eventually, those will likely be saved in the Pod using
-     *    the [[add]] call. Round-tripping the construction of those terms across an asynchronous boundary will lead
-     *    to an unacceptable runtime overhead.
-     * 2. There are many small, self-contained data factory implementations that can be shipped with Pods, for example
-     *    [@rdfjs/data-model](https://github.com/rdfjs-base/data-model). The Polypoly `rdf-spec` package can be used to
-     *    ensure correctness of the factory implementations.
-     * 3. There is no point in imposing access-control over manipulation of RDF terms before they are stored in the Pod.
-     * 4. Pod implementors may choose to provide a custom implementation for more efficient serialization of RDF terms
-     *    that are passed into the Pod. This is much easier to implement when the Pod controls the creation of terms.
-     *
-     * Pertaining to the last point, Features _must_ use the factory to create new RDF terms.
-     */
-    readonly dataFactory: RDF.DataFactory;
+  /**
+   * A [spec-compliant](http://rdf.js.org/data-model-spec/) data factory that is _not_ guaranteed to support variables.
+   *
+   * Example:
+   * ```
+   * const quad = factory.quad(
+   *   factory.namedNode("http://example.org/s"),
+   *   factory.namedNode("http://example.org/p"),
+   *   factory.namedNode("http://example.org/o")
+   * );
+   * ```
+   *
+   * The factory is an exception in that it is synchronous as opposed to the general asynchronous [[Pod]] API. This is
+   * by design for these reasons:
+   *
+   * 1. Features may construct a large number of RDF terms. Eventually, those will likely be saved in the Pod using
+   *    the [[add]] call. Round-tripping the construction of those terms across an asynchronous boundary will lead
+   *    to an unacceptable runtime overhead.
+   * 2. There are many small, self-contained data factory implementations that can be shipped with Pods, for example
+   *    [@rdfjs/data-model](https://github.com/rdfjs-base/data-model). The Polypoly `rdf-spec` package can be used to
+   *    ensure correctness of the factory implementations.
+   * 3. There is no point in imposing access-control over manipulation of RDF terms before they are stored in the Pod.
+   * 4. Pod implementors may choose to provide a custom implementation for more efficient serialization of RDF terms
+   *    that are passed into the Pod. This is much easier to implement when the Pod controls the creation of terms.
+   *
+   * Pertaining to the last point, Features _must_ use the factory to create new RDF terms.
+   */
+  readonly dataFactory: RDF.DataFactory;
 
-    /**
-     * `polyIn` is the interface to interact with the Pod store. Refer to [[PolyIn]] for its definition.
-     */
-    readonly polyIn: PolyIn;
+  /**
+   * `polyIn` is the interface to interact with the Pod store. Refer to [[PolyIn]] for its definition.
+   */
+  readonly polyIn: PolyIn;
 
-    /**
-     * `polyOut` is the interface to interact with the outside world. Refer to [[PolyOut]] for its definition.
-     */
-    readonly polyOut: PolyOut;
+  /**
+   * `polyOut` is the interface to interact with the outside world. Refer to [[PolyOut]] for its definition.
+   */
+  readonly polyOut: PolyOut;
 
-    /**
-     * `polyNav` is the interface to interact the container. Refer to [[PolyNav]] for its definition.
-     */
-    readonly polyNav: PolyNav;
+  /**
+   * `polyNav` is the interface to interact the container. Refer to [[PolyNav]] for its definition.
+   */
+  readonly polyNav: PolyNav;
 
-    /**
-     * `info` is the interface to read information about the polyPod instance.
-     */
-    readonly info: Info;
+  /**
+   * `info` is the interface to read information about the polyPod instance.
+   */
+  readonly info: Info;
 
-    /**
-     * `network` is the interface to interact with other devices over the network. Refer to [[Network]] for its
-     * definition.
-     */
-    readonly network: Network;
+  /**
+   * `network` is the interface to interact with other devices over the network. Refer to [[Network]] for its
+   * definition.
+   */
+  readonly network: Network;
 
-    /**
-     * @hidden
-     */
-    readonly polyLifecycle?: PolyLifecycle;
+  /**
+   * @hidden
+   */
+  readonly polyLifecycle?: PolyLifecycle;
 }

--- a/platform/feature-api/api/pod-api/src/feature.ts
+++ b/platform/feature-api/api/pod-api/src/feature.ts
@@ -9,7 +9,7 @@
 import { Pod } from "./api";
 
 declare global {
-    interface Window {
-        pod: Pod;
-    }
+  interface Window {
+    pod: Pod;
+  }
 }

--- a/platform/feature-api/api/pod-api/src/fs.ts
+++ b/platform/feature-api/api/pod-api/src/fs.ts
@@ -8,16 +8,16 @@
  */
 
 export interface EncodingOptions {
-    encoding: BufferEncoding;
+  encoding: BufferEncoding;
 }
 
 export interface Stats {
-    isFile(): boolean;
-    isDirectory(): boolean;
-    getTime(): string;
-    getSize(): number;
-    getName(): string;
-    getId(): string;
+  isFile(): boolean;
+  isDirectory(): boolean;
+  getTime(): string;
+  getSize(): number;
+  getName(): string;
+  getId(): string;
 }
 
 /**
@@ -26,17 +26,17 @@ export interface Stats {
  * The [Node.js documentation](https://nodejs.org/api/fs.html) applies to the methods in this interface.
  */
 export interface FS {
-    readFile(path: string, options: EncodingOptions): Promise<string>;
-    readFile(path: string): Promise<Uint8Array>;
-    writeFile(path: string, content: string, options: EncodingOptions): Promise<void>;
-    stat(path: string): Promise<Stats>;
-    readdir(path: string): Promise<string[]>;
-    importArchive(url: string): Promise<string>;
-    removeArchive(fileId: string): Promise<void>;
+  readFile(path: string, options: EncodingOptions): Promise<string>;
+  readFile(path: string): Promise<Uint8Array>;
+  writeFile(path: string, content: string, options: EncodingOptions): Promise<void>;
+  stat(path: string): Promise<Stats>;
+  readdir(path: string): Promise<string[]>;
+  importArchive(url: string): Promise<string>;
+  removeArchive(fileId: string): Promise<void>;
 }
 
 export interface ExternalFile {
-    name: string;
-    url: string;
-    size: number;
+  name: string;
+  url: string;
+  size: number;
 }

--- a/platform/feature-api/api/pod-api/src/spec.ts
+++ b/platform/feature-api/api/pod-api/src/spec.ts
@@ -20,8 +20,8 @@ import chai, { assert } from "chai";
 import chaiAsPromised from "chai-as-promised";
 
 function encodeUtf8(string: string): Uint8Array {
-    if (typeof TextEncoder !== "undefined") return new TextEncoder().encode(string);
-    else return Buffer.from(string, "utf-8");
+  if (typeof TextEncoder !== "undefined") return new TextEncoder().encode(string);
+  else return Buffer.from(string, "utf-8");
 }
 
 /**
@@ -34,164 +34,157 @@ function encodeUtf8(string: string): Uint8Array {
  * access or provide a URI to a local httpbin service.
  */
 export class PodSpec {
-    constructor(
-        private readonly pod: Pod,
-        private readonly path: string,
-        private readonly httpbinUrl: string
-    ) {
-        chai.use(chaiAsPromised);
-    }
+  constructor(
+    private readonly pod: Pod,
+    private readonly path: string,
+    private readonly httpbinUrl: string
+  ) {
+    chai.use(chaiAsPromised);
+  }
 
-    polyIn(): void {
-        const { dataFactory, polyIn } = this.pod;
+  polyIn(): void {
+    const { dataFactory, polyIn } = this.pod;
 
-        describe("polyIn", () => {
-            describe("factory", () => {
-                new DataFactorySpec(dataFactory).run();
-            });
+    describe("polyIn", () => {
+      describe("factory", () => {
+        new DataFactorySpec(dataFactory).run();
+      });
 
-            it("add only allows default graph", async () => {
-                const quad = dataFactory.quad(
-                    dataFactory.namedNode("http://example.org/s"),
-                    dataFactory.namedNode("http://example.org/p"),
-                    dataFactory.namedNode("http://example.org/o"),
-                    dataFactory.namedNode("http://example.org/g")
-                );
-                await assert.isRejected(polyIn.add(quad), /default/);
-                await assert.isRejected(polyIn.has(quad), /default/);
-                await assert.isRejected(polyIn.delete(quad), /default/);
-            });
+      it("add only allows default graph", async () => {
+        const quad = dataFactory.quad(
+          dataFactory.namedNode("http://example.org/s"),
+          dataFactory.namedNode("http://example.org/p"),
+          dataFactory.namedNode("http://example.org/o"),
+          dataFactory.namedNode("http://example.org/g")
+        );
+        await assert.isRejected(polyIn.add(quad), /default/);
+        await assert.isRejected(polyIn.has(quad), /default/);
+        await assert.isRejected(polyIn.delete(quad), /default/);
+      });
 
-            it("add/select", async () => {
-                const { triple } = gens(dataFactory);
-                await fc.assert(
-                    fc.asyncProperty(fc.array(triple), async (quads) => {
-                        await polyIn.add(...quads);
-                        for (const quad of quads) {
-                            const selected = await polyIn.match(quad);
-                            assert.lengthOf(selected, 1);
-                            assert.ok(quad.equals(selected[0]));
-                            assert.ok(await polyIn.has(quad));
-                        }
-                    })
-                );
-            });
+      it("add/select", async () => {
+        const { triple } = gens(dataFactory);
+        await fc.assert(
+          fc.asyncProperty(fc.array(triple), async (quads) => {
+            await polyIn.add(...quads);
+            for (const quad of quads) {
+              const selected = await polyIn.match(quad);
+              assert.lengthOf(selected, 1);
+              assert.ok(quad.equals(selected[0]));
+              assert.ok(await polyIn.has(quad));
+            }
+          })
+        );
+      });
 
-            it("add/delete", async () => {
-                const { triple } = gens(dataFactory);
-                await fc.assert(
-                    fc.asyncProperty(fc.array(triple), async (quads) => {
-                        await polyIn.add(...quads);
-                        for (const quad of quads) {
-                            await polyIn.delete(quad);
-                            assert.notOk(await polyIn.has(quad));
-                        }
-                    })
-                );
-            });
+      it("add/delete", async () => {
+        const { triple } = gens(dataFactory);
+        await fc.assert(
+          fc.asyncProperty(fc.array(triple), async (quads) => {
+            await polyIn.add(...quads);
+            for (const quad of quads) {
+              await polyIn.delete(quad);
+              assert.notOk(await polyIn.has(quad));
+            }
+          })
+        );
+      });
+    });
+  }
+
+  polyOut(): void {
+    const { polyOut } = this.pod;
+
+    describe("polyOut", () => {
+      describe("Filesystem", () => {
+        const pathGen = fc
+          .hexaString({ minLength: 1, maxLength: 30 })
+          .map((path) => this.path + "/" + path);
+
+        async function skipIfExists(path: string): Promise<void> {
+          let cont = true;
+          try {
+            await polyOut.stat(path);
+            cont = false;
+          } catch {
+            // intentionally left blank
+          }
+          fc.pre(cont);
+        }
+
+        it("write/read", async () => {
+          await fc.assert(
+            fc.asyncProperty(pathGen, fc.fullUnicodeString(), async (path, content) => {
+              await skipIfExists(path);
+
+              await polyOut.writeFile(path, content, { encoding: "utf-8" });
+
+              await assert.eventually.equal(polyOut.readFile(path, { encoding: "utf-8" }), content);
+              await assert.eventually.deepEqual(polyOut.readFile(path), encodeUtf8(content));
+            })
+          );
         });
-    }
 
-    polyOut(): void {
-        const { polyOut } = this.pod;
+        it("readDir", async () => {
+          assert.isFulfilled(polyOut.readDir(this.path));
+          await fc.assert(
+            fc.asyncProperty(pathGen, fc.fullUnicodeString(), async (path, content) => {
+              await skipIfExists(path);
 
-        describe("polyOut", () => {
-            describe("Filesystem", () => {
-                const pathGen = fc
-                    .hexaString({ minLength: 1, maxLength: 30 })
-                    .map((path) => this.path + "/" + path);
-
-                async function skipIfExists(path: string): Promise<void> {
-                    let cont = true;
-                    try {
-                        await polyOut.stat(path);
-                        cont = false;
-                    } catch {
-                        // intentionally left blank
-                    }
-                    fc.pre(cont);
-                }
-
-                it("write/read", async () => {
-                    await fc.assert(
-                        fc.asyncProperty(pathGen, fc.fullUnicodeString(), async (path, content) => {
-                            await skipIfExists(path);
-
-                            await polyOut.writeFile(path, content, { encoding: "utf-8" });
-
-                            await assert.eventually.equal(
-                                polyOut.readFile(path, { encoding: "utf-8" }),
-                                content
-                            );
-                            await assert.eventually.deepEqual(
-                                polyOut.readFile(path),
-                                encodeUtf8(content)
-                            );
-                        })
-                    );
-                });
-
-                it("readDir", async () => {
-                    assert.isFulfilled(polyOut.readDir(this.path));
-                    await fc.assert(
-                        fc.asyncProperty(pathGen, fc.fullUnicodeString(), async (path, content) => {
-                            await skipIfExists(path);
-
-                            await polyOut.writeFile(path, content, { encoding: "utf-8" });
-                            const filesWithPath = (await polyOut.readDir(this.path)).map(
-                                (path) => this.path + "/" + path["path"]
-                            );
-                            assert.include(filesWithPath, path);
-                        })
-                    );
-                });
-
-                it("stat/read", async () => {
-                    await fc.assert(
-                        fc.asyncProperty(pathGen, async (path) => {
-                            await skipIfExists(path);
-
-                            await assert.isRejected(polyOut.readFile(path, { encoding: "utf-8" }));
-                        })
-                    );
-                });
-
-                it("stat (root)", async () => {
-                    const stat = await polyOut.stat(this.path);
-                    assert.ok(stat.isDirectory());
-                    assert.notOk(stat.isFile());
-                });
-
-                it("stat (files)", async () => {
-                    await fc.assert(
-                        fc.asyncProperty(pathGen, async (path) => {
-                            let assertion: () => void;
-                            try {
-                                const stat = await polyOut.stat(path);
-                                assertion = () =>
-                                    assert.notEqual(stat.isFile(), stat.isDirectory());
-                            } catch {
-                                assertion = () => {
-                                    // intentionally left blank
-                                };
-                            }
-                            assertion();
-                        })
-                    );
-                });
-            });
+              await polyOut.writeFile(path, content, { encoding: "utf-8" });
+              const filesWithPath = (await polyOut.readDir(this.path)).map(
+                (path) => this.path + "/" + path["path"]
+              );
+              assert.include(filesWithPath, path);
+            })
+          );
         });
-    }
 
-    run(): void {
-        this.polyIn();
-        this.polyOut();
-    }
+        it("stat/read", async () => {
+          await fc.assert(
+            fc.asyncProperty(pathGen, async (path) => {
+              await skipIfExists(path);
+
+              await assert.isRejected(polyOut.readFile(path, { encoding: "utf-8" }));
+            })
+          );
+        });
+
+        it("stat (root)", async () => {
+          const stat = await polyOut.stat(this.path);
+          assert.ok(stat.isDirectory());
+          assert.notOk(stat.isFile());
+        });
+
+        it("stat (files)", async () => {
+          await fc.assert(
+            fc.asyncProperty(pathGen, async (path) => {
+              let assertion: () => void;
+              try {
+                const stat = await polyOut.stat(path);
+                assertion = () => assert.notEqual(stat.isFile(), stat.isDirectory());
+              } catch {
+                assertion = () => {
+                  // intentionally left blank
+                };
+              }
+              assertion();
+            })
+          );
+        });
+      });
+    });
+  }
+
+  run(): void {
+    this.polyIn();
+    this.polyOut();
+  }
 }
 
 /**
  * Convenience function to instantiate the [[PodSpec]] and run it immediately afterwards.
  */
 export function podSpec(pod: Pod, path = "/", httpbinUrl = "https://httpbin.org"): void {
-    return new PodSpec(pod, path, httpbinUrl).run();
+  return new PodSpec(pod, path, httpbinUrl).run();
 }

--- a/platform/feature-api/api/pod-api/src/tests/default.test.ts
+++ b/platform/feature-api/api/pod-api/src/tests/default.test.ts
@@ -7,9 +7,9 @@ import { getHttpbinUrl } from "@polypoly-eu/fetch-spec";
 import { FS } from "../fs";
 
 describe("Mock pod", () => {
-    podSpec(
-        new DefaultPod(dataset(), new Volume().promises as unknown as FS, fetch),
-        "/",
-        getHttpbinUrl()
-    );
+  podSpec(
+    new DefaultPod(dataset(), new Volume().promises as unknown as FS, fetch),
+    "/",
+    getHttpbinUrl()
+  );
 });

--- a/platform/feature-api/api/rdf-convert/.editorconfig
+++ b/platform/feature-api/api/rdf-convert/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+max_line_length = 100

--- a/platform/feature-api/api/rdf-convert/src/index.ts
+++ b/platform/feature-api/api/rdf-convert/src/index.ts
@@ -7,13 +7,13 @@
 import * as RDF from "rdf-js";
 
 export function convert<T extends Exclude<RDF.Term, RDF.BaseQuad>>(
-    t: T,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    dataFactory: RDF.DataFactory<any>
+  t: T,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dataFactory: RDF.DataFactory<any>
 ): T;
 export function convert<InQuad extends RDF.BaseQuad, OutQuad extends RDF.BaseQuad>(
-    quad: InQuad,
-    dataFactory: RDF.DataFactory<InQuad, OutQuad>
+  quad: InQuad,
+  dataFactory: RDF.DataFactory<InQuad, OutQuad>
 ): OutQuad;
 
 /**
@@ -30,32 +30,32 @@ export function convert<InQuad extends RDF.BaseQuad, OutQuad extends RDF.BaseQua
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function convert(input: RDF.Term, dataFactory: RDF.DataFactory<any>): RDF.Term {
-    const term: RDF.Term = input;
+  const term: RDF.Term = input;
 
-    switch (term.termType) {
-        case "BlankNode":
-            return dataFactory.blankNode(term.value);
-        case "DefaultGraph":
-            return dataFactory.defaultGraph();
-        case "Literal":
-            return dataFactory.literal(
-                term.value,
-                term.language === "" ? convert(term.datatype, dataFactory) : term.language
-            );
-        case "NamedNode":
-            return dataFactory.namedNode(term.value);
-        case "Variable":
-            if (dataFactory.variable) return dataFactory.variable(term.value);
-            else throw new Error("Variables are not supported");
-        case "Quad":
-        default:
-            // backwards compatibility: term type should be "Quad", but some implementations don't
-            // set it accordingly
-            return dataFactory.quad(
-                convert(term.subject, dataFactory),
-                convert(term.predicate, dataFactory),
-                convert(term.object, dataFactory),
-                convert(term.graph, dataFactory)
-            );
-    }
+  switch (term.termType) {
+    case "BlankNode":
+      return dataFactory.blankNode(term.value);
+    case "DefaultGraph":
+      return dataFactory.defaultGraph();
+    case "Literal":
+      return dataFactory.literal(
+        term.value,
+        term.language === "" ? convert(term.datatype, dataFactory) : term.language
+      );
+    case "NamedNode":
+      return dataFactory.namedNode(term.value);
+    case "Variable":
+      if (dataFactory.variable) return dataFactory.variable(term.value);
+      else throw new Error("Variables are not supported");
+    case "Quad":
+    default:
+      // backwards compatibility: term type should be "Quad", but some implementations don't
+      // set it accordingly
+      return dataFactory.quad(
+        convert(term.subject, dataFactory),
+        convert(term.predicate, dataFactory),
+        convert(term.object, dataFactory),
+        convert(term.graph, dataFactory)
+      );
+  }
 }

--- a/platform/feature-api/api/rdf-convert/src/tests/_util.ts
+++ b/platform/feature-api/api/rdf-convert/src/tests/_util.ts
@@ -9,32 +9,32 @@ import Graphy from "@graphy/core.data.factory";
 import { DataFactory as N3 } from "n3";
 
 export const factories: Record<string, DataFactory> = {
-    "@rdfjs/data-model": RDFJS,
-    "@graphy/core.data.factory": Graphy,
-    n3: N3,
+  "@rdfjs/data-model": RDFJS,
+  "@graphy/core.data.factory": Graphy,
+  n3: N3,
 };
 
 export function convertSpec<Q extends RDF.BaseQuad>(
-    f1: DataFactory<Q>,
-    f2: DataFactory<RDF.BaseQuad, Q>
+  f1: DataFactory<Q>,
+  f2: DataFactory<RDF.BaseQuad, Q>
 ): void {
-    const { term, quad } = gens(f1);
+  const { term, quad } = gens(f1);
 
-    it("Equal after conversion (term)", () => {
-        fc.assert(
-            fc.property(term, (term) => {
-                const converted = convert(term, f2);
-                expect(term.equals(converted)).toBe(true);
-            })
-        );
-    });
+  it("Equal after conversion (term)", () => {
+    fc.assert(
+      fc.property(term, (term) => {
+        const converted = convert(term, f2);
+        expect(term.equals(converted)).toBe(true);
+      })
+    );
+  });
 
-    it("Equal after conversion (quad)", () => {
-        fc.assert(
-            fc.property(quad, (quad) => {
-                const converted = convert(quad, f2);
-                expect(quad.equals(converted)).toBe(true);
-            })
-        );
-    });
+  it("Equal after conversion (quad)", () => {
+    fc.assert(
+      fc.property(quad, (quad) => {
+        const converted = convert(quad, f2);
+        expect(quad.equals(converted)).toBe(true);
+      })
+    );
+  });
 }

--- a/platform/feature-api/api/rdf-convert/src/tests/index.test.ts
+++ b/platform/feature-api/api/rdf-convert/src/tests/index.test.ts
@@ -1,7 +1,7 @@
 import { factories, convertSpec } from "./_util";
 
 for (const [sourceName, sourceFactory] of Object.entries(factories))
-    for (const [targetName, targetFactory] of Object.entries(factories))
-        describe(`${sourceName} → ${targetName}`, () => {
-            convertSpec(sourceFactory, targetFactory);
-        });
+  for (const [targetName, targetFactory] of Object.entries(factories))
+    describe(`${sourceName} → ${targetName}`, () => {
+      convertSpec(sourceFactory, targetFactory);
+    });

--- a/platform/feature-api/api/rdf-spec/.editorconfig
+++ b/platform/feature-api/api/rdf-spec/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+max_line_length = 100

--- a/platform/feature-api/api/rdf-spec/src/data-factory.ts
+++ b/platform/feature-api/api/rdf-spec/src/data-factory.ts
@@ -31,686 +31,683 @@ import { BlankNode, DefaultGraph, Literal, NamedNode } from "rdf-data-factory";
  * Cross-factory interoperability can be tested using [[ConvertSpec]].
  */
 export class DataFactorySpec<OutQuad extends BaseQuad = Quad> {
-    constructor(private readonly dataFactory: DataFactory<OutQuad>) {}
+  constructor(private readonly dataFactory: DataFactory<OutQuad>) {}
 
-    blankNode(): void {
-        describe(".blankNode", () => {
-            it("should be a static method", () => {
-                assert.equal(typeof this.dataFactory.blankNode, "function");
-            });
+  blankNode(): void {
+    describe(".blankNode", () => {
+      it("should be a static method", () => {
+        assert.equal(typeof this.dataFactory.blankNode, "function");
+      });
 
-            it('should create an object with a termType property that contains the value "BlankNode"', () => {
-                const term = this.dataFactory.blankNode();
+      it('should create an object with a termType property that contains the value "BlankNode"', () => {
+        const term = this.dataFactory.blankNode();
 
-                assert.equal(term.termType, "BlankNode");
-            });
+        assert.equal(term.termType, "BlankNode");
+      });
 
-            it("should create an object with a value property that contains a unique identifier", () => {
-                const term1 = this.dataFactory.blankNode();
-                const term2 = this.dataFactory.blankNode();
+      it("should create an object with a value property that contains a unique identifier", () => {
+        const term1 = this.dataFactory.blankNode();
+        const term2 = this.dataFactory.blankNode();
 
-                assert.notEqual(term1.value, term2.value);
-            });
+        assert.notEqual(term1.value, term2.value);
+      });
 
-            it("should create an object with a value property that contains the given identifier", () => {
-                const id = "b1";
-                const term = this.dataFactory.blankNode(id);
+      it("should create an object with a value property that contains the given identifier", () => {
+        const id = "b1";
+        const term = this.dataFactory.blankNode(id);
 
-                assert.equal(term.value, id);
-            });
+        assert.equal(term.value, id);
+      });
 
-            describe(".equals", () => {
-                it("should be a method", () => {
-                    const term = this.dataFactory.blankNode();
+      describe(".equals", () => {
+        it("should be a method", () => {
+          const term = this.dataFactory.blankNode();
 
-                    assert.equal(typeof term.equals, "function");
-                });
-
-                it("should return true if termType and value are equal", () => {
-                    const id = "b1";
-                    const term = this.dataFactory.blankNode(id);
-
-                    const expectedMock: BlankNode = {
-                        termType: "BlankNode",
-                        value: id,
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(expectedMock), true);
-                });
-
-                it("should return false if termType is not equal", () => {
-                    const id = "b1";
-                    const term = this.dataFactory.blankNode(id);
-
-                    const expectedMock: NamedNode = {
-                        termType: "NamedNode",
-                        value: id,
-                        equals: () => true,
-                    };
-                    assert.equal(term.equals(expectedMock), false);
-                });
-
-                it("should return false if value is not equal", () => {
-                    const id = "b1";
-                    const term = this.dataFactory.blankNode(id);
-
-                    const expectedMock: BlankNode = {
-                        termType: "BlankNode",
-                        value: id + 1,
-                        equals: () => true,
-                    };
-                    assert.equal(term.equals(expectedMock), false);
-                });
-
-                it("should return false if value is falsy", () => {
-                    const id = "b1";
-                    const term = this.dataFactory.blankNode(id);
-
-                    assert.equal(term.equals(null), false);
-                });
-            });
+          assert.equal(typeof term.equals, "function");
         });
-    }
 
-    defaultGraph(): void {
-        describe(".defaultGraph", () => {
-            it("should be a static method", () => {
-                assert.equal(typeof this.dataFactory.defaultGraph, "function");
-            });
+        it("should return true if termType and value are equal", () => {
+          const id = "b1";
+          const term = this.dataFactory.blankNode(id);
 
-            it('should create an object with a termType property that contains the value "DefaultGraph"', () => {
-                const term = this.dataFactory.defaultGraph();
+          const expectedMock: BlankNode = {
+            termType: "BlankNode",
+            value: id,
+            equals: () => true,
+          };
 
-                assert.equal(term.termType, "DefaultGraph");
-            });
-
-            it("should create an object with a value property that contains an empty string", () => {
-                const term = this.dataFactory.defaultGraph();
-
-                assert.equal(term.value, "");
-            });
-
-            describe(".equals", () => {
-                it("should be a method", () => {
-                    const term = this.dataFactory.defaultGraph();
-
-                    assert.equal(typeof term.equals, "function");
-                });
-
-                it("should return true if termType and value are equal", () => {
-                    const term = this.dataFactory.defaultGraph();
-                    const mock: DefaultGraph = {
-                        termType: "DefaultGraph",
-                        value: "",
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), true);
-                });
-
-                it("should return false if termType is not equal", () => {
-                    const term = this.dataFactory.defaultGraph();
-                    const mock: NamedNode = {
-                        termType: "NamedNode",
-                        value: "",
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), false);
-                });
-
-                it("should return false if value is falsy", () => {
-                    const term = this.dataFactory.defaultGraph();
-
-                    assert.equal(term.equals(null), false);
-                });
-            });
+          assert.equal(term.equals(expectedMock), true);
         });
-    }
 
-    literal(): void {
-        describe(".literal", () => {
-            it("should be a static method", () => {
-                assert.equal(typeof this.dataFactory.literal, "function");
+        it("should return false if termType is not equal", () => {
+          const id = "b1";
+          const term = this.dataFactory.blankNode(id);
+
+          const expectedMock: NamedNode = {
+            termType: "NamedNode",
+            value: id,
+            equals: () => true,
+          };
+          assert.equal(term.equals(expectedMock), false);
+        });
+
+        it("should return false if value is not equal", () => {
+          const id = "b1";
+          const term = this.dataFactory.blankNode(id);
+
+          const expectedMock: BlankNode = {
+            termType: "BlankNode",
+            value: id + 1,
+            equals: () => true,
+          };
+          assert.equal(term.equals(expectedMock), false);
+        });
+
+        it("should return false if value is falsy", () => {
+          const id = "b1";
+          const term = this.dataFactory.blankNode(id);
+
+          assert.equal(term.equals(null), false);
+        });
+      });
+    });
+  }
+
+  defaultGraph(): void {
+    describe(".defaultGraph", () => {
+      it("should be a static method", () => {
+        assert.equal(typeof this.dataFactory.defaultGraph, "function");
+      });
+
+      it('should create an object with a termType property that contains the value "DefaultGraph"', () => {
+        const term = this.dataFactory.defaultGraph();
+
+        assert.equal(term.termType, "DefaultGraph");
+      });
+
+      it("should create an object with a value property that contains an empty string", () => {
+        const term = this.dataFactory.defaultGraph();
+
+        assert.equal(term.value, "");
+      });
+
+      describe(".equals", () => {
+        it("should be a method", () => {
+          const term = this.dataFactory.defaultGraph();
+
+          assert.equal(typeof term.equals, "function");
+        });
+
+        it("should return true if termType and value are equal", () => {
+          const term = this.dataFactory.defaultGraph();
+          const mock: DefaultGraph = {
+            termType: "DefaultGraph",
+            value: "",
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), true);
+        });
+
+        it("should return false if termType is not equal", () => {
+          const term = this.dataFactory.defaultGraph();
+          const mock: NamedNode = {
+            termType: "NamedNode",
+            value: "",
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), false);
+        });
+
+        it("should return false if value is falsy", () => {
+          const term = this.dataFactory.defaultGraph();
+
+          assert.equal(term.equals(null), false);
+        });
+      });
+    });
+  }
+
+  literal(): void {
+    describe(".literal", () => {
+      it("should be a static method", () => {
+        assert.equal(typeof this.dataFactory.literal, "function");
+      });
+
+      it('should create an object with a termType property that contains the value "Literal"', () => {
+        const string = "example";
+        const term = this.dataFactory.literal(string);
+
+        assert.equal(term.termType, "Literal");
+      });
+
+      it("should create an object with a value property that contains the given string", () => {
+        const string = "example";
+        const term = this.dataFactory.literal(string);
+
+        assert.equal(term.value, string);
+      });
+
+      it("should create an object with a language property that contains an empty string", () => {
+        const string = "example";
+        const term = this.dataFactory.literal(string);
+
+        assert.equal(term.language, "");
+      });
+
+      it("should create an object with a language property that contains the given language string", () => {
+        const string = "example";
+        const language = "en";
+        const term = this.dataFactory.literal(string, language);
+
+        assert.equal(term.language, language);
+      });
+
+      it('should create an object with a datatype property that contains a NamedNode with the value "http://www.w3.org/2001/XMLSchema#string"', () => {
+        const string = "example";
+        const term = this.dataFactory.literal(string);
+
+        assert.equal(term.datatype.termType, "NamedNode");
+        assert.equal(term.datatype.value, "http://www.w3.org/2001/XMLSchema#string");
+      });
+
+      it('should create an object with a datatype property that contains a NamedNode with the value "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"', () => {
+        const string = "example";
+        const language = "en";
+        const term = this.dataFactory.literal(string, language);
+
+        assert.equal(term.datatype.termType, "NamedNode");
+        assert.equal(term.datatype.value, "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString");
+      });
+
+      it("should create an object with a datatype property that contains a NamedNode with the given IRI", () => {
+        const string = "example";
+        const datatypeIRI = "http://example.org";
+        const datatypeNode = this.dataFactory.namedNode(datatypeIRI);
+        const term = this.dataFactory.literal(string, datatypeNode);
+
+        assert.equal(term.datatype.termType, "NamedNode");
+        assert.equal(term.datatype.value, datatypeIRI);
+      });
+
+      it("should create an object with a datatype property that contains the given NamedNode", () => {
+        const string = "example";
+        const datatype = this.dataFactory.namedNode("http://example.org");
+        const term = this.dataFactory.literal(string, datatype);
+
+        assert.equal(term.datatype.termType, "NamedNode");
+        assert.equal(term.datatype.value, datatype.value);
+      });
+
+      describe(".equals", () => {
+        it("should be a method", () => {
+          const term = this.dataFactory.literal("");
+
+          assert.equal(typeof term.equals, "function");
+        });
+
+        it("should return true if termType, value, language and datatype are equal", () => {
+          const string = "example";
+          const language = "en";
+          const term = this.dataFactory.literal(string, language);
+          const mock: Literal = {
+            termType: "Literal",
+            value: string,
+            language: language,
+            datatype: this.dataFactory.namedNode(
+              "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+            ),
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), true);
+        });
+
+        it("should return false if termType is not equal", () => {
+          const string = "example";
+          const language = "en";
+          const term = this.dataFactory.literal(string, language);
+          const mock: NamedNode = {
+            termType: "NamedNode",
+            value: string,
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), false);
+        });
+
+        it("should return false if value is not equal", () => {
+          const string = "example";
+          const language = "en";
+          const term = this.dataFactory.literal(string, language);
+          const mock: Literal = {
+            termType: "Literal",
+            value: string + "1",
+            language: language,
+            datatype: this.dataFactory.namedNode(
+              "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+            ),
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), false);
+        });
+
+        it("should return false if language is not equal", () => {
+          const string = "example";
+          const language = "en";
+          const term = this.dataFactory.literal(string, language);
+          const mock: Literal = {
+            termType: "Literal",
+            value: string,
+            language: "de",
+            datatype: this.dataFactory.namedNode(
+              "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+            ),
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), false);
+        });
+
+        it("should return false if datatype is not equal", () => {
+          const string = "example";
+          const language = "en";
+          const term = this.dataFactory.literal(string, language);
+          const mock: Literal = {
+            termType: "Literal",
+            value: string,
+            language: language,
+            datatype: this.dataFactory.namedNode("http://example.org"),
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), false);
+        });
+
+        it("should return false if value is falsy", () => {
+          const string = "example";
+          const language = "en";
+          const term = this.dataFactory.literal(string, language);
+
+          assert.equal(term.equals(null), false);
+        });
+      });
+    });
+  }
+
+  namedNode(): void {
+    describe(".namedNode", () => {
+      it("should be a static method", () => {
+        assert.equal(typeof this.dataFactory.namedNode, "function");
+      });
+
+      it('should create an object with a termType property that contains the value "NamedNode"', () => {
+        const iri = "http://example.org";
+        const term = this.dataFactory.namedNode(iri);
+
+        assert.equal(term.termType, "NamedNode");
+      });
+
+      it("should create an object with a value property that contains the given IRI", () => {
+        const iri = "http://example.org";
+        const term = this.dataFactory.namedNode(iri);
+
+        assert.equal(term.value, iri);
+      });
+
+      describe(".equals", () => {
+        it("should be a method", () => {
+          const iri = "http://example.org";
+          const term = this.dataFactory.namedNode(iri);
+
+          assert.equal(typeof term.equals, "function");
+        });
+
+        it("should return true if termType and value are equal", () => {
+          const iri = "http://example.org";
+          const term = this.dataFactory.namedNode(iri);
+          const mock: NamedNode = {
+            termType: "NamedNode",
+            value: iri,
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), true);
+        });
+
+        it("should return false if termType is not equal", () => {
+          const iri = "http://example.org";
+          const term = this.dataFactory.namedNode(iri);
+          const mock: BlankNode = {
+            termType: "BlankNode",
+            value: iri,
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), false);
+        });
+
+        it("should return false if value is not equal", () => {
+          const iri = "http://example.org";
+          const term = this.dataFactory.namedNode(iri);
+          const mock: NamedNode = {
+            termType: "NamedNode",
+            value: iri + 1,
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), false);
+        });
+
+        it("should return false if value is falsy", () => {
+          const iri = "http://example.org";
+          const term = this.dataFactory.namedNode(iri);
+
+          assert.equal(term.equals(null), false);
+        });
+      });
+    });
+  }
+
+  quad(): void {
+    describe(".quad", () => {
+      it("should be a static method", () => {
+        assert.equal(typeof this.dataFactory.quad, "function");
+      });
+
+      it("should create an object with .subject, .predicate, .object and .graph with the given values", () => {
+        const subject = this.dataFactory.namedNode("http://example.org/subject");
+        const predicate = this.dataFactory.namedNode("http://example.org/predicate");
+        const object = this.dataFactory.namedNode("http://example.org/object");
+        const graph = this.dataFactory.namedNode("http://example.org/graph");
+        const quad = this.dataFactory.quad(subject, predicate, object, graph);
+
+        assert.equal(subject.equals(quad.subject), true);
+        assert.equal(predicate.equals(quad.predicate), true);
+        assert.equal(object.equals(quad.object), true);
+        assert.equal(graph.equals(quad.graph), true);
+
+        assert.equal(quad.termType, "Quad");
+        assert.equal(quad.value, "");
+      });
+
+      it("should create an object .graph set to DefaultGraph if the argument isn't given", () => {
+        const subject = this.dataFactory.namedNode("http://example.org/subject");
+        const predicate = this.dataFactory.namedNode("http://example.org/predicate");
+        const object = this.dataFactory.namedNode("http://example.org/object");
+        const graph = this.dataFactory.defaultGraph();
+        const quad = this.dataFactory.quad(subject, predicate, object);
+
+        assert.equal(quad.graph.equals(graph), true);
+
+        assert.equal(quad.termType, "Quad");
+        assert.equal(quad.value, "");
+      });
+
+      describe(".equals", () => {
+        it("should return true if the other quad contains the same subject, predicate, object and graph", () => {
+          const subject = this.dataFactory.namedNode("http://example.org/subject");
+          const predicate = this.dataFactory.namedNode("http://example.org/predicate");
+          const object = this.dataFactory.namedNode("http://example.org/object");
+          const graph = this.dataFactory.namedNode("http://example.org/graph");
+          const quad1 = this.dataFactory.quad(subject, predicate, object, graph);
+          const quad2 = this.dataFactory.quad(subject, predicate, object, graph);
+
+          assert.equal(quad1.equals(quad2), true);
+        });
+
+        it("should return true even if the other equal quad is from a non-RDF* factory", () => {
+          const subject = this.dataFactory.namedNode("http://example.org/subject");
+          const predicate = this.dataFactory.namedNode("http://example.org/predicate");
+          const object = this.dataFactory.namedNode("http://example.org/object");
+          const graph = this.dataFactory.namedNode("http://example.org/graph");
+          const quad1 = this.dataFactory.quad(subject, predicate, object, graph);
+          const quad2 = { subject, predicate, object, graph };
+
+          // @ts-ignore just a test, ignore not assignable error
+          assert.equal(quad1.equals(quad2), true);
+        });
+
+        it("should return false if the subject of the other quad is not the same", () => {
+          const subject1 = this.dataFactory.namedNode("http://example.org/subject");
+          const subject2 = this.dataFactory.namedNode("http://example.com/subject");
+          const predicate = this.dataFactory.namedNode("http://example.org/predicate");
+          const object = this.dataFactory.namedNode("http://example.org/object");
+          const graph = this.dataFactory.namedNode("http://example.org/graph");
+          const quad1 = this.dataFactory.quad(subject1, predicate, object, graph);
+          const quad2 = this.dataFactory.quad(subject2, predicate, object, graph);
+
+          assert.equal(quad1.equals(quad2), false);
+        });
+
+        it("should return false even if the other non-equal quad is from a non-RDF* factory", () => {
+          const subject1 = this.dataFactory.namedNode("http://example.org/subject");
+          const subject2 = this.dataFactory.namedNode("http://example.com/subject");
+          const predicate = this.dataFactory.namedNode("http://example.org/predicate");
+          const object = this.dataFactory.namedNode("http://example.org/object");
+          const graph = this.dataFactory.namedNode("http://example.org/graph");
+          const quad1 = this.dataFactory.quad(subject1, predicate, object, graph);
+          const quad2 = { subject: subject2, predicate, object, graph };
+
+          // @ts-ignore this is just a test, no need to complete types
+          assert.equal(quad1.equals(quad2), false);
+        });
+
+        it("should return false if the predicate of the other quad is not the same", () => {
+          const subject = this.dataFactory.namedNode("http://example.org/subject");
+          const predicate1 = this.dataFactory.namedNode("http://example.org/predicate");
+          const predicate2 = this.dataFactory.namedNode("http://example.com/predicate");
+          const object = this.dataFactory.namedNode("http://example.org/object");
+          const graph = this.dataFactory.namedNode("http://example.org/graph");
+          const quad1 = this.dataFactory.quad(subject, predicate1, object, graph);
+          const quad2 = this.dataFactory.quad(subject, predicate2, object, graph);
+
+          assert.equal(quad1.equals(quad2), false);
+        });
+
+        it("should return false if the object of the other quad is not the same", () => {
+          const subject = this.dataFactory.namedNode("http://example.org/subject");
+          const predicate = this.dataFactory.namedNode("http://example.org/predicate");
+          const object1 = this.dataFactory.namedNode("http://example.org/object");
+          const object2 = this.dataFactory.namedNode("http://example.com/object");
+          const graph = this.dataFactory.namedNode("http://example.org/graph");
+          const quad1 = this.dataFactory.quad(subject, predicate, object1, graph);
+          const quad2 = this.dataFactory.quad(subject, predicate, object2, graph);
+
+          assert.equal(quad1.equals(quad2), false);
+        });
+
+        it("should return false if the graph of the other quad is not the same", () => {
+          const subject = this.dataFactory.namedNode("http://example.org/subject");
+          const predicate = this.dataFactory.namedNode("http://example.org/predicate");
+          const object = this.dataFactory.namedNode("http://example.org/object");
+          const graph1 = this.dataFactory.namedNode("http://example.org/graph");
+          const graph2 = this.dataFactory.namedNode("http://example.com/graph");
+          const quad1 = this.dataFactory.quad(subject, predicate, object, graph1);
+          const quad2 = this.dataFactory.quad(subject, predicate, object, graph2);
+
+          assert.equal(quad1.equals(quad2), false);
+        });
+
+        // TODO: recheck correctness of this test - what is a false value of a Term?
+        it("should return false if value is falsy", () => {
+          const subject = this.dataFactory.namedNode("http://example.org/subject");
+          const predicate = this.dataFactory.namedNode("http://example.org/predicate");
+          const object = this.dataFactory.namedNode("http://example.org/object");
+          const graph = this.dataFactory.namedNode("http://example.org/graph");
+          const quad = this.dataFactory.quad(subject, predicate, object, graph);
+
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          assert.equal(quad.equals(null!), false);
+        });
+
+        it("should return false if value is another term", () => {
+          const subject = this.dataFactory.namedNode("http://example.org/subject");
+          const predicate = this.dataFactory.namedNode("http://example.org/predicate");
+          const object = this.dataFactory.namedNode("http://example.org/object");
+          const graph = this.dataFactory.namedNode("http://example.org/graph");
+          const quad = this.dataFactory.quad(subject, predicate, object, graph);
+
+          assert.equal(
+            quad.equals(this.dataFactory.namedNode("http://example.org/subject")),
+            false
+          );
+          assert.equal(quad.equals(this.dataFactory.literal("abc")), false);
+          if (this.dataFactory.variable)
+            assert.equal(quad.equals(this.dataFactory.variable("var")), false);
+          assert.equal(quad.equals(this.dataFactory.blankNode("bnode")), false);
+          assert.equal(quad.equals(this.dataFactory.defaultGraph()), false);
+        });
+
+        it("should return true for an equal nested quad", () => {
+          const subject = this.dataFactory.quad(
+            this.dataFactory.namedNode("http://example.org/subjectInner1"),
+            this.dataFactory.namedNode("http://example.org/predicateInner1"),
+            this.dataFactory.namedNode("http://example.org/objectInner1")
+          );
+          const predicate = this.dataFactory.namedNode("http://example.org/predicate");
+          const object = this.dataFactory.quad(
+            this.dataFactory.namedNode("http://example.org/subjectInner2"),
+            this.dataFactory.namedNode("http://example.org/predicateInner2"),
+            this.dataFactory.namedNode("http://example.org/objectInner2"),
+            this.dataFactory.namedNode("http://example.org/graphInner2")
+          );
+          const graph = this.dataFactory.namedNode("http://example.org/graph");
+          const quad1 = this.dataFactory.quad(subject, predicate, object, graph);
+          const quad2 = this.dataFactory.quad(subject, predicate, object, graph);
+
+          assert.equal(quad1.equals(quad2), true);
+        });
+      });
+    });
+  }
+
+  variable(): void {
+    let dataFactoryVariable: (name: string) => Variable;
+
+    if (this.dataFactory.variable === undefined) return;
+    else dataFactoryVariable = this.dataFactory.variable.bind(this.dataFactory);
+
+    describe(".variable", () => {
+      it("should be a static method", () => {
+        assert.equal(typeof dataFactoryVariable, "function");
+      });
+
+      it('should create an object with a termType property that contains the value "Variable"', () => {
+        const name = "v";
+        const term = dataFactoryVariable(name);
+
+        assert.equal(term.termType, "Variable");
+      });
+
+      it("should create an object with a value property that contains the given name", () => {
+        const name = "v";
+        const term = dataFactoryVariable(name);
+
+        assert.equal(term.value, name);
+      });
+
+      describe(".equals", () => {
+        it("should be a method", () => {
+          const name = "v";
+          const term = dataFactoryVariable(name);
+
+          assert.equal(typeof term.equals, "function");
+        });
+
+        it("should return true if termType and value are equal", () => {
+          const name = "v";
+          const term = dataFactoryVariable(name);
+          const mock: Variable = {
+            termType: "Variable",
+            value: name,
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), true);
+        });
+
+        it("should return false if termType is not equal", () => {
+          const name = "v";
+          const term = dataFactoryVariable(name);
+          const mock: NamedNode = {
+            termType: "NamedNode",
+            value: name,
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), false);
+        });
+
+        it("should return false if value is not equal", () => {
+          const name = "v";
+          const term = dataFactoryVariable(name);
+          const mock: Variable = {
+            termType: "Variable",
+            value: name + "1",
+            equals: () => true,
+          };
+
+          assert.equal(term.equals(mock), false);
+        });
+
+        it("should return false if value is falsy", () => {
+          const name = "v";
+          const term = dataFactoryVariable(name);
+
+          assert.equal(term.equals(null), false);
+        });
+      });
+    });
+  }
+
+  gen(): void {
+    const gen = gens(this.dataFactory);
+    describe("Gens", () => {
+      describe("self-equals", () => {
+        for (const [key, g] of Object.entries(gen))
+          if (g !== undefined)
+            it(key, () => {
+              fc.assert(
+                fc.property(g, (term) => {
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  assert((term as any).equals(term));
+                })
+              );
             });
+      });
 
-            it('should create an object with a termType property that contains the value "Literal"', () => {
-                const string = "example";
-                const term = this.dataFactory.literal(string);
-
-                assert.equal(term.termType, "Literal");
-            });
-
-            it("should create an object with a value property that contains the given string", () => {
-                const string = "example";
-                const term = this.dataFactory.literal(string);
-
-                assert.equal(term.value, string);
-            });
-
-            it("should create an object with a language property that contains an empty string", () => {
-                const string = "example";
-                const term = this.dataFactory.literal(string);
-
-                assert.equal(term.language, "");
-            });
-
-            it("should create an object with a language property that contains the given language string", () => {
-                const string = "example";
-                const language = "en";
-                const term = this.dataFactory.literal(string, language);
-
-                assert.equal(term.language, language);
-            });
-
-            it('should create an object with a datatype property that contains a NamedNode with the value "http://www.w3.org/2001/XMLSchema#string"', () => {
-                const string = "example";
-                const term = this.dataFactory.literal(string);
-
-                assert.equal(term.datatype.termType, "NamedNode");
-                assert.equal(term.datatype.value, "http://www.w3.org/2001/XMLSchema#string");
-            });
-
-            it('should create an object with a datatype property that contains a NamedNode with the value "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"', () => {
-                const string = "example";
-                const language = "en";
-                const term = this.dataFactory.literal(string, language);
-
-                assert.equal(term.datatype.termType, "NamedNode");
-                assert.equal(
-                    term.datatype.value,
-                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+      describe("not equal (terms)", () => {
+        const keys = ["namedNode", "blankNode", "literal", "variable"];
+        for (const key1 of keys)
+          for (const key2 of keys)
+            if (key1 !== key2)
+              it(`${key1}/${key2}`, () => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const gen1 = (gen as any)[key1];
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const gen2 = (gen as any)[key2];
+                if (gen1 === undefined || gen2 === undefined) return;
+                fc.assert(
+                  fc.property(gen1, gen2, (term1, term2) => {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    assert.equal((term1 as any).equals(term2), false);
+                  })
                 );
-            });
-
-            it("should create an object with a datatype property that contains a NamedNode with the given IRI", () => {
-                const string = "example";
-                const datatypeIRI = "http://example.org";
-                const datatypeNode = this.dataFactory.namedNode(datatypeIRI);
-                const term = this.dataFactory.literal(string, datatypeNode);
-
-                assert.equal(term.datatype.termType, "NamedNode");
-                assert.equal(term.datatype.value, datatypeIRI);
-            });
-
-            it("should create an object with a datatype property that contains the given NamedNode", () => {
-                const string = "example";
-                const datatype = this.dataFactory.namedNode("http://example.org");
-                const term = this.dataFactory.literal(string, datatype);
-
-                assert.equal(term.datatype.termType, "NamedNode");
-                assert.equal(term.datatype.value, datatype.value);
-            });
-
-            describe(".equals", () => {
-                it("should be a method", () => {
-                    const term = this.dataFactory.literal("");
-
-                    assert.equal(typeof term.equals, "function");
-                });
-
-                it("should return true if termType, value, language and datatype are equal", () => {
-                    const string = "example";
-                    const language = "en";
-                    const term = this.dataFactory.literal(string, language);
-                    const mock: Literal = {
-                        termType: "Literal",
-                        value: string,
-                        language: language,
-                        datatype: this.dataFactory.namedNode(
-                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-                        ),
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), true);
-                });
-
-                it("should return false if termType is not equal", () => {
-                    const string = "example";
-                    const language = "en";
-                    const term = this.dataFactory.literal(string, language);
-                    const mock: NamedNode = {
-                        termType: "NamedNode",
-                        value: string,
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), false);
-                });
-
-                it("should return false if value is not equal", () => {
-                    const string = "example";
-                    const language = "en";
-                    const term = this.dataFactory.literal(string, language);
-                    const mock: Literal = {
-                        termType: "Literal",
-                        value: string + "1",
-                        language: language,
-                        datatype: this.dataFactory.namedNode(
-                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-                        ),
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), false);
-                });
-
-                it("should return false if language is not equal", () => {
-                    const string = "example";
-                    const language = "en";
-                    const term = this.dataFactory.literal(string, language);
-                    const mock: Literal = {
-                        termType: "Literal",
-                        value: string,
-                        language: "de",
-                        datatype: this.dataFactory.namedNode(
-                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-                        ),
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), false);
-                });
-
-                it("should return false if datatype is not equal", () => {
-                    const string = "example";
-                    const language = "en";
-                    const term = this.dataFactory.literal(string, language);
-                    const mock: Literal = {
-                        termType: "Literal",
-                        value: string,
-                        language: language,
-                        datatype: this.dataFactory.namedNode("http://example.org"),
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), false);
-                });
-
-                it("should return false if value is falsy", () => {
-                    const string = "example";
-                    const language = "en";
-                    const term = this.dataFactory.literal(string, language);
-
-                    assert.equal(term.equals(null), false);
-                });
-            });
-        });
-    }
-
-    namedNode(): void {
-        describe(".namedNode", () => {
-            it("should be a static method", () => {
-                assert.equal(typeof this.dataFactory.namedNode, "function");
-            });
-
-            it('should create an object with a termType property that contains the value "NamedNode"', () => {
-                const iri = "http://example.org";
-                const term = this.dataFactory.namedNode(iri);
-
-                assert.equal(term.termType, "NamedNode");
-            });
-
-            it("should create an object with a value property that contains the given IRI", () => {
-                const iri = "http://example.org";
-                const term = this.dataFactory.namedNode(iri);
-
-                assert.equal(term.value, iri);
-            });
-
-            describe(".equals", () => {
-                it("should be a method", () => {
-                    const iri = "http://example.org";
-                    const term = this.dataFactory.namedNode(iri);
-
-                    assert.equal(typeof term.equals, "function");
-                });
-
-                it("should return true if termType and value are equal", () => {
-                    const iri = "http://example.org";
-                    const term = this.dataFactory.namedNode(iri);
-                    const mock: NamedNode = {
-                        termType: "NamedNode",
-                        value: iri,
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), true);
-                });
-
-                it("should return false if termType is not equal", () => {
-                    const iri = "http://example.org";
-                    const term = this.dataFactory.namedNode(iri);
-                    const mock: BlankNode = {
-                        termType: "BlankNode",
-                        value: iri,
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), false);
-                });
-
-                it("should return false if value is not equal", () => {
-                    const iri = "http://example.org";
-                    const term = this.dataFactory.namedNode(iri);
-                    const mock: NamedNode = {
-                        termType: "NamedNode",
-                        value: iri + 1,
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), false);
-                });
-
-                it("should return false if value is falsy", () => {
-                    const iri = "http://example.org";
-                    const term = this.dataFactory.namedNode(iri);
-
-                    assert.equal(term.equals(null), false);
-                });
-            });
-        });
-    }
-
-    quad(): void {
-        describe(".quad", () => {
-            it("should be a static method", () => {
-                assert.equal(typeof this.dataFactory.quad, "function");
-            });
-
-            it("should create an object with .subject, .predicate, .object and .graph with the given values", () => {
-                const subject = this.dataFactory.namedNode("http://example.org/subject");
-                const predicate = this.dataFactory.namedNode("http://example.org/predicate");
-                const object = this.dataFactory.namedNode("http://example.org/object");
-                const graph = this.dataFactory.namedNode("http://example.org/graph");
-                const quad = this.dataFactory.quad(subject, predicate, object, graph);
-
-                assert.equal(subject.equals(quad.subject), true);
-                assert.equal(predicate.equals(quad.predicate), true);
-                assert.equal(object.equals(quad.object), true);
-                assert.equal(graph.equals(quad.graph), true);
-
-                assert.equal(quad.termType, "Quad");
-                assert.equal(quad.value, "");
-            });
-
-            it("should create an object .graph set to DefaultGraph if the argument isn't given", () => {
-                const subject = this.dataFactory.namedNode("http://example.org/subject");
-                const predicate = this.dataFactory.namedNode("http://example.org/predicate");
-                const object = this.dataFactory.namedNode("http://example.org/object");
-                const graph = this.dataFactory.defaultGraph();
-                const quad = this.dataFactory.quad(subject, predicate, object);
-
-                assert.equal(quad.graph.equals(graph), true);
-
-                assert.equal(quad.termType, "Quad");
-                assert.equal(quad.value, "");
-            });
-
-            describe(".equals", () => {
-                it("should return true if the other quad contains the same subject, predicate, object and graph", () => {
-                    const subject = this.dataFactory.namedNode("http://example.org/subject");
-                    const predicate = this.dataFactory.namedNode("http://example.org/predicate");
-                    const object = this.dataFactory.namedNode("http://example.org/object");
-                    const graph = this.dataFactory.namedNode("http://example.org/graph");
-                    const quad1 = this.dataFactory.quad(subject, predicate, object, graph);
-                    const quad2 = this.dataFactory.quad(subject, predicate, object, graph);
-
-                    assert.equal(quad1.equals(quad2), true);
-                });
-
-                it("should return true even if the other equal quad is from a non-RDF* factory", () => {
-                    const subject = this.dataFactory.namedNode("http://example.org/subject");
-                    const predicate = this.dataFactory.namedNode("http://example.org/predicate");
-                    const object = this.dataFactory.namedNode("http://example.org/object");
-                    const graph = this.dataFactory.namedNode("http://example.org/graph");
-                    const quad1 = this.dataFactory.quad(subject, predicate, object, graph);
-                    const quad2 = { subject, predicate, object, graph };
-
-                    // @ts-ignore just a test, ignore not assignable error
-                    assert.equal(quad1.equals(quad2), true);
-                });
-
-                it("should return false if the subject of the other quad is not the same", () => {
-                    const subject1 = this.dataFactory.namedNode("http://example.org/subject");
-                    const subject2 = this.dataFactory.namedNode("http://example.com/subject");
-                    const predicate = this.dataFactory.namedNode("http://example.org/predicate");
-                    const object = this.dataFactory.namedNode("http://example.org/object");
-                    const graph = this.dataFactory.namedNode("http://example.org/graph");
-                    const quad1 = this.dataFactory.quad(subject1, predicate, object, graph);
-                    const quad2 = this.dataFactory.quad(subject2, predicate, object, graph);
-
-                    assert.equal(quad1.equals(quad2), false);
-                });
-
-                it("should return false even if the other non-equal quad is from a non-RDF* factory", () => {
-                    const subject1 = this.dataFactory.namedNode("http://example.org/subject");
-                    const subject2 = this.dataFactory.namedNode("http://example.com/subject");
-                    const predicate = this.dataFactory.namedNode("http://example.org/predicate");
-                    const object = this.dataFactory.namedNode("http://example.org/object");
-                    const graph = this.dataFactory.namedNode("http://example.org/graph");
-                    const quad1 = this.dataFactory.quad(subject1, predicate, object, graph);
-                    const quad2 = { subject: subject2, predicate, object, graph };
-
-                    // @ts-ignore this is just a test, no need to complete types
-                    assert.equal(quad1.equals(quad2), false);
-                });
-
-                it("should return false if the predicate of the other quad is not the same", () => {
-                    const subject = this.dataFactory.namedNode("http://example.org/subject");
-                    const predicate1 = this.dataFactory.namedNode("http://example.org/predicate");
-                    const predicate2 = this.dataFactory.namedNode("http://example.com/predicate");
-                    const object = this.dataFactory.namedNode("http://example.org/object");
-                    const graph = this.dataFactory.namedNode("http://example.org/graph");
-                    const quad1 = this.dataFactory.quad(subject, predicate1, object, graph);
-                    const quad2 = this.dataFactory.quad(subject, predicate2, object, graph);
-
-                    assert.equal(quad1.equals(quad2), false);
-                });
-
-                it("should return false if the object of the other quad is not the same", () => {
-                    const subject = this.dataFactory.namedNode("http://example.org/subject");
-                    const predicate = this.dataFactory.namedNode("http://example.org/predicate");
-                    const object1 = this.dataFactory.namedNode("http://example.org/object");
-                    const object2 = this.dataFactory.namedNode("http://example.com/object");
-                    const graph = this.dataFactory.namedNode("http://example.org/graph");
-                    const quad1 = this.dataFactory.quad(subject, predicate, object1, graph);
-                    const quad2 = this.dataFactory.quad(subject, predicate, object2, graph);
-
-                    assert.equal(quad1.equals(quad2), false);
-                });
-
-                it("should return false if the graph of the other quad is not the same", () => {
-                    const subject = this.dataFactory.namedNode("http://example.org/subject");
-                    const predicate = this.dataFactory.namedNode("http://example.org/predicate");
-                    const object = this.dataFactory.namedNode("http://example.org/object");
-                    const graph1 = this.dataFactory.namedNode("http://example.org/graph");
-                    const graph2 = this.dataFactory.namedNode("http://example.com/graph");
-                    const quad1 = this.dataFactory.quad(subject, predicate, object, graph1);
-                    const quad2 = this.dataFactory.quad(subject, predicate, object, graph2);
-
-                    assert.equal(quad1.equals(quad2), false);
-                });
-
-                // TODO: recheck correctness of this test - what is a false value of a Term?
-                it("should return false if value is falsy", () => {
-                    const subject = this.dataFactory.namedNode("http://example.org/subject");
-                    const predicate = this.dataFactory.namedNode("http://example.org/predicate");
-                    const object = this.dataFactory.namedNode("http://example.org/object");
-                    const graph = this.dataFactory.namedNode("http://example.org/graph");
-                    const quad = this.dataFactory.quad(subject, predicate, object, graph);
-
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    assert.equal(quad.equals(null!), false);
-                });
-
-                it("should return false if value is another term", () => {
-                    const subject = this.dataFactory.namedNode("http://example.org/subject");
-                    const predicate = this.dataFactory.namedNode("http://example.org/predicate");
-                    const object = this.dataFactory.namedNode("http://example.org/object");
-                    const graph = this.dataFactory.namedNode("http://example.org/graph");
-                    const quad = this.dataFactory.quad(subject, predicate, object, graph);
-
-                    assert.equal(
-                        quad.equals(this.dataFactory.namedNode("http://example.org/subject")),
-                        false
-                    );
-                    assert.equal(quad.equals(this.dataFactory.literal("abc")), false);
-                    if (this.dataFactory.variable)
-                        assert.equal(quad.equals(this.dataFactory.variable("var")), false);
-                    assert.equal(quad.equals(this.dataFactory.blankNode("bnode")), false);
-                    assert.equal(quad.equals(this.dataFactory.defaultGraph()), false);
-                });
-
-                it("should return true for an equal nested quad", () => {
-                    const subject = this.dataFactory.quad(
-                        this.dataFactory.namedNode("http://example.org/subjectInner1"),
-                        this.dataFactory.namedNode("http://example.org/predicateInner1"),
-                        this.dataFactory.namedNode("http://example.org/objectInner1")
-                    );
-                    const predicate = this.dataFactory.namedNode("http://example.org/predicate");
-                    const object = this.dataFactory.quad(
-                        this.dataFactory.namedNode("http://example.org/subjectInner2"),
-                        this.dataFactory.namedNode("http://example.org/predicateInner2"),
-                        this.dataFactory.namedNode("http://example.org/objectInner2"),
-                        this.dataFactory.namedNode("http://example.org/graphInner2")
-                    );
-                    const graph = this.dataFactory.namedNode("http://example.org/graph");
-                    const quad1 = this.dataFactory.quad(subject, predicate, object, graph);
-                    const quad2 = this.dataFactory.quad(subject, predicate, object, graph);
-
-                    assert.equal(quad1.equals(quad2), true);
-                });
-            });
-        });
-    }
-
-    variable(): void {
-        let dataFactoryVariable: (name: string) => Variable;
-
-        if (this.dataFactory.variable === undefined) return;
-        else dataFactoryVariable = this.dataFactory.variable.bind(this.dataFactory);
-
-        describe(".variable", () => {
-            it("should be a static method", () => {
-                assert.equal(typeof dataFactoryVariable, "function");
-            });
-
-            it('should create an object with a termType property that contains the value "Variable"', () => {
-                const name = "v";
-                const term = dataFactoryVariable(name);
-
-                assert.equal(term.termType, "Variable");
-            });
-
-            it("should create an object with a value property that contains the given name", () => {
-                const name = "v";
-                const term = dataFactoryVariable(name);
-
-                assert.equal(term.value, name);
-            });
-
-            describe(".equals", () => {
-                it("should be a method", () => {
-                    const name = "v";
-                    const term = dataFactoryVariable(name);
-
-                    assert.equal(typeof term.equals, "function");
-                });
-
-                it("should return true if termType and value are equal", () => {
-                    const name = "v";
-                    const term = dataFactoryVariable(name);
-                    const mock: Variable = {
-                        termType: "Variable",
-                        value: name,
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), true);
-                });
-
-                it("should return false if termType is not equal", () => {
-                    const name = "v";
-                    const term = dataFactoryVariable(name);
-                    const mock: NamedNode = {
-                        termType: "NamedNode",
-                        value: name,
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), false);
-                });
-
-                it("should return false if value is not equal", () => {
-                    const name = "v";
-                    const term = dataFactoryVariable(name);
-                    const mock: Variable = {
-                        termType: "Variable",
-                        value: name + "1",
-                        equals: () => true,
-                    };
-
-                    assert.equal(term.equals(mock), false);
-                });
-
-                it("should return false if value is falsy", () => {
-                    const name = "v";
-                    const term = dataFactoryVariable(name);
-
-                    assert.equal(term.equals(null), false);
-                });
-            });
-        });
-    }
-
-    gen(): void {
-        const gen = gens(this.dataFactory);
-        describe("Gens", () => {
-            describe("self-equals", () => {
-                for (const [key, g] of Object.entries(gen))
-                    if (g !== undefined)
-                        it(key, () => {
-                            fc.assert(
-                                fc.property(g, (term) => {
-                                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                    assert((term as any).equals(term));
-                                })
-                            );
-                        });
-            });
-
-            describe("not equal (terms)", () => {
-                const keys = ["namedNode", "blankNode", "literal", "variable"];
-                for (const key1 of keys)
-                    for (const key2 of keys)
-                        if (key1 !== key2)
-                            it(`${key1}/${key2}`, () => {
-                                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                const gen1 = (gen as any)[key1];
-                                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                const gen2 = (gen as any)[key2];
-                                if (gen1 === undefined || gen2 === undefined) return;
-                                fc.assert(
-                                    fc.property(gen1, gen2, (term1, term2) => {
-                                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                        assert.equal((term1 as any).equals(term2), false);
-                                    })
-                                );
-                            });
-            });
-        });
-    }
-
-    run(): void {
-        this.blankNode();
-        this.defaultGraph();
-        this.literal();
-        this.namedNode();
-        this.quad();
-        this.variable();
-        this.gen();
-    }
+              });
+      });
+    });
+  }
+
+  run(): void {
+    this.blankNode();
+    this.defaultGraph();
+    this.literal();
+    this.namedNode();
+    this.quad();
+    this.variable();
+    this.gen();
+  }
 }

--- a/platform/feature-api/api/rdf-spec/src/dataset.ts
+++ b/platform/feature-api/api/rdf-spec/src/dataset.ts
@@ -17,281 +17,281 @@ import { namespace } from "./namespace";
  * [reference implementation](https://github.com/rdfjs-base/dataset).
  */
 export class DatasetSpec<
-    OutQuad extends BaseQuad = Quad,
-    D extends DatasetCore<OutQuad> = DatasetCore<OutQuad>
+  OutQuad extends BaseQuad = Quad,
+  D extends DatasetCore<OutQuad> = DatasetCore<OutQuad>
 > {
-    constructor(
-        private readonly datasetFactory: DatasetCoreFactory<OutQuad, OutQuad, D>,
-        private readonly dataFactory: DataFactory<OutQuad>
-    ) {}
+  constructor(
+    private readonly datasetFactory: DatasetCoreFactory<OutQuad, OutQuad, D>,
+    private readonly dataFactory: DataFactory<OutQuad>
+  ) {}
 
-    factory(): void {
-        const ex = namespace("http://example.org/", this.dataFactory);
+  factory(): void {
+    const ex = namespace("http://example.org/", this.dataFactory);
 
-        describe("factory", () => {
-            it("should be a function", () => {
-                assert.strictEqual(typeof this.datasetFactory.dataset, "function");
-            });
+    describe("factory", () => {
+      it("should be a function", () => {
+        assert.strictEqual(typeof this.datasetFactory.dataset, "function");
+      });
 
-            it("should add the given Quads", () => {
-                const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object1);
-                const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object2);
+      it("should add the given Quads", () => {
+        const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object1);
+        const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object2);
 
-                const dataset = this.datasetFactory.dataset([quad1, quad2]);
+        const dataset = this.datasetFactory.dataset([quad1, quad2]);
 
-                assert(dataset.has(quad1));
-                assert(dataset.has(quad2));
-            });
-        });
-    }
+        assert(dataset.has(quad1));
+        assert(dataset.has(quad2));
+      });
+    });
+  }
 
-    size(): void {
-        const ex = namespace("http://example.org/", this.dataFactory);
+  size(): void {
+    const ex = namespace("http://example.org/", this.dataFactory);
 
-        describe("size", () => {
-            it("should be a number property", () => {
-                const dataset = this.datasetFactory.dataset();
+    describe("size", () => {
+      it("should be a number property", () => {
+        const dataset = this.datasetFactory.dataset();
 
-                assert.strictEqual(typeof dataset.size, "number");
-            });
+        assert.strictEqual(typeof dataset.size, "number");
+      });
 
-            it("should be 0 if there are no Quads in the Dataset", () => {
-                const dataset = this.datasetFactory.dataset();
+      it("should be 0 if there are no Quads in the Dataset", () => {
+        const dataset = this.datasetFactory.dataset();
 
-                assert.strictEqual(dataset.size, 0);
-            });
+        assert.strictEqual(dataset.size, 0);
+      });
 
-            it("should be equal to the number of Quads in the Dataset", () => {
-                const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object1);
-                const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object2);
-                const dataset = this.datasetFactory.dataset([quad1, quad2]);
+      it("should be equal to the number of Quads in the Dataset", () => {
+        const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object1);
+        const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object2);
+        const dataset = this.datasetFactory.dataset([quad1, quad2]);
 
-                assert.strictEqual(dataset.size, 2);
-            });
-        });
-    }
+        assert.strictEqual(dataset.size, 2);
+      });
+    });
+  }
 
-    add(): void {
-        const ex = namespace("http://example.org/", this.dataFactory);
+  add(): void {
+    const ex = namespace("http://example.org/", this.dataFactory);
 
-        describe("add", () => {
-            it("should be a function", () => {
-                const dataset = this.datasetFactory.dataset();
+    describe("add", () => {
+      it("should be a function", () => {
+        const dataset = this.datasetFactory.dataset();
 
-                assert.strictEqual(typeof dataset.add, "function");
-            });
+        assert.strictEqual(typeof dataset.add, "function");
+      });
 
-            it("should add the given Quad", () => {
-                const quad = this.dataFactory.quad(ex.subject, ex.predicate, ex.object);
-                const dataset = this.datasetFactory.dataset();
+      it("should add the given Quad", () => {
+        const quad = this.dataFactory.quad(ex.subject, ex.predicate, ex.object);
+        const dataset = this.datasetFactory.dataset();
 
-                dataset.add(quad);
+        dataset.add(quad);
 
-                assert(dataset.has(quad));
-            });
+        assert(dataset.has(quad));
+      });
 
-            it("should not add duplicate Quads", () => {
-                const quadA = this.dataFactory.quad(ex.subject, ex.predicate, ex.object);
-                const quadB = this.dataFactory.quad(ex.subject, ex.predicate, ex.object);
-                const dataset = this.datasetFactory.dataset();
+      it("should not add duplicate Quads", () => {
+        const quadA = this.dataFactory.quad(ex.subject, ex.predicate, ex.object);
+        const quadB = this.dataFactory.quad(ex.subject, ex.predicate, ex.object);
+        const dataset = this.datasetFactory.dataset();
 
-                dataset.add(quadA);
-                dataset.add(quadB);
+        dataset.add(quadA);
+        dataset.add(quadB);
 
-                assert.strictEqual(dataset.size, 1);
-            });
-        });
-    }
+        assert.strictEqual(dataset.size, 1);
+      });
+    });
+  }
 
-    delete(): void {
-        const ex = namespace("http://example.org/", this.dataFactory);
+  delete(): void {
+    const ex = namespace("http://example.org/", this.dataFactory);
 
-        describe("delete", () => {
-            it("should be a function", () => {
-                const dataset = this.datasetFactory.dataset();
+    describe("delete", () => {
+      it("should be a function", () => {
+        const dataset = this.datasetFactory.dataset();
 
-                assert.strictEqual(typeof dataset.delete, "function");
-            });
+        assert.strictEqual(typeof dataset.delete, "function");
+      });
 
-            it("should remove the given Quad", () => {
-                const quad = this.dataFactory.quad(ex.subject, ex.predicate, ex.object);
-                const dataset = this.datasetFactory.dataset([quad]);
+      it("should remove the given Quad", () => {
+        const quad = this.dataFactory.quad(ex.subject, ex.predicate, ex.object);
+        const dataset = this.datasetFactory.dataset([quad]);
 
-                dataset.delete(quad);
+        dataset.delete(quad);
 
-                assert(!dataset.has(quad));
-            });
+        assert(!dataset.has(quad));
+      });
 
-            it("should remove only the given Quad", () => {
-                const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object1);
-                const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object2);
-                const dataset = this.datasetFactory.dataset([quad1, quad2]);
+      it("should remove only the given Quad", () => {
+        const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object1);
+        const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object2);
+        const dataset = this.datasetFactory.dataset([quad1, quad2]);
 
-                dataset.delete(quad1);
+        dataset.delete(quad1);
 
-                assert(!dataset.has(quad1));
-                assert(dataset.has(quad2));
-            });
+        assert(!dataset.has(quad1));
+        assert(dataset.has(quad2));
+      });
 
-            it("should remove the Quad with the same SPOG as the given Quad", () => {
-                const quad = this.dataFactory.quad(ex.subject, ex.predicate, ex.object);
-                const quadCloned = this.dataFactory.quad(
-                    quad.subject,
-                    quad.predicate,
-                    quad.object,
-                    quad.graph
-                );
-                const dataset = this.datasetFactory.dataset([quad]);
+      it("should remove the Quad with the same SPOG as the given Quad", () => {
+        const quad = this.dataFactory.quad(ex.subject, ex.predicate, ex.object);
+        const quadCloned = this.dataFactory.quad(
+          quad.subject,
+          quad.predicate,
+          quad.object,
+          quad.graph
+        );
+        const dataset = this.datasetFactory.dataset([quad]);
 
-                dataset.delete(quadCloned);
+        dataset.delete(quadCloned);
 
-                assert(!dataset.has(quad));
-            });
-        });
-    }
+        assert(!dataset.has(quad));
+      });
+    });
+  }
 
-    has(): void {
-        const ex = namespace("http://example.org/", this.dataFactory);
+  has(): void {
+    const ex = namespace("http://example.org/", this.dataFactory);
 
-        describe("has", () => {
-            it("should be a function", () => {
-                const dataset = this.datasetFactory.dataset();
+    describe("has", () => {
+      it("should be a function", () => {
+        const dataset = this.datasetFactory.dataset();
 
-                assert.strictEqual(typeof dataset.has, "function");
-            });
+        assert.strictEqual(typeof dataset.has, "function");
+      });
 
-            it("should return false if the given Quad is not in the Dataset", () => {
-                const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object1);
-                const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object2);
-                const dataset = this.datasetFactory.dataset([quad1]);
+      it("should return false if the given Quad is not in the Dataset", () => {
+        const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object1);
+        const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object2);
+        const dataset = this.datasetFactory.dataset([quad1]);
 
-                assert(!dataset.has(quad2));
-            });
+        assert(!dataset.has(quad2));
+      });
 
-            it("should return true if the given Quad is in the Dataset", () => {
-                const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object1);
-                const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object2);
-                const dataset = this.datasetFactory.dataset([quad1, quad2]);
+      it("should return true if the given Quad is in the Dataset", () => {
+        const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object1);
+        const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object2);
+        const dataset = this.datasetFactory.dataset([quad1, quad2]);
 
-                assert(dataset.has(quad2));
-            });
-        });
-    }
+        assert(dataset.has(quad2));
+      });
+    });
+  }
 
-    match(): void {
-        const ex = namespace("http://example.org/", this.dataFactory);
+  match(): void {
+    const ex = namespace("http://example.org/", this.dataFactory);
 
-        describe("match", () => {
-            it("should be a function", () => {
-                const dataset = this.datasetFactory.dataset();
+    describe("match", () => {
+      it("should be a function", () => {
+        const dataset = this.datasetFactory.dataset();
 
-                assert.strictEqual(typeof dataset.match, "function");
-            });
+        assert.strictEqual(typeof dataset.match, "function");
+      });
 
-            it("should use the given subject to select Quads", () => {
-                const quad1 = this.dataFactory.quad(ex.subject1, ex.predicate, ex.object);
-                const quad2 = this.dataFactory.quad(ex.subject2, ex.predicate, ex.object);
-                const dataset = this.datasetFactory.dataset([quad1, quad2]);
+      it("should use the given subject to select Quads", () => {
+        const quad1 = this.dataFactory.quad(ex.subject1, ex.predicate, ex.object);
+        const quad2 = this.dataFactory.quad(ex.subject2, ex.predicate, ex.object);
+        const dataset = this.datasetFactory.dataset([quad1, quad2]);
 
-                const matches = dataset.match(ex.subject2);
-
-                assert.strictEqual(matches.size, 1);
-                assert(matches.has(quad2));
-            });
-
-            it("should use the given predicate to select Quads", () => {
-                const quad1 = this.dataFactory.quad(ex.subject, ex.predicate1, ex.object);
-                const quad2 = this.dataFactory.quad(ex.subject, ex.predicate2, ex.object);
-                const dataset = this.datasetFactory.dataset([quad1, quad2]);
-
-                const matches = dataset.match(null, ex.predicate2);
-
-                assert.strictEqual(matches.size, 1);
-                assert(matches.has(quad2));
-            });
-
-            it("should use the given object to select Quads", () => {
-                const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object1);
-                const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object2);
-                const dataset = this.datasetFactory.dataset([quad1, quad2]);
-
-                const matches = dataset.match(null, null, ex.object2);
-
-                assert.strictEqual(matches.size, 1);
-                assert(matches.has(quad2));
-            });
-
-            it("should use the given graph to select Quads", () => {
-                const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object, ex.graph1);
-                const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object, ex.graph2);
-                const dataset = this.datasetFactory.dataset([quad1, quad2]);
-
-                const matches = dataset.match(null, null, null, ex.graph2);
-
-                assert.strictEqual(matches.size, 1);
-                assert(matches.has(quad2));
-            });
-
-            it("should return an empty Dataset if there are no matches", () => {
-                const quad1 = this.dataFactory.quad(ex.subject1, ex.predicate, ex.object);
-                const quad2 = this.dataFactory.quad(ex.subject2, ex.predicate, ex.object);
-                const dataset = this.datasetFactory.dataset([quad1, quad2]);
-
-                const matches = dataset.match(null, null, ex.object3);
-
-                assert.strictEqual(matches.size, 0);
-            });
-        });
-    }
-
-    iterator(): void {
-        const ex = namespace("http://example.org/", this.dataFactory);
-
-        describe("Symbol.iterator", () => {
-            it("should be a function", () => {
-                const dataset = this.datasetFactory.dataset();
-
-                assert.strictEqual(typeof dataset[Symbol.iterator], "function");
-            });
-
-            it("should return an iterator", () => {
-                const quad1 = this.dataFactory.quad(ex.subject1, ex.predicate, ex.object);
-                const quad2 = this.dataFactory.quad(ex.subject2, ex.predicate, ex.object);
-                const dataset = this.datasetFactory.dataset([quad1, quad2]);
-
-                const iterator = dataset[Symbol.iterator]();
-
-                assert.strictEqual(typeof iterator.next, "function");
-                assert.strictEqual(typeof iterator.next().value, "object");
-            });
-
-            it("should iterate over all Quads", () => {
-                const quad1 = this.dataFactory.quad(ex.subject1, ex.predicate, ex.object);
-                const quad2 = this.dataFactory.quad(ex.subject2, ex.predicate, ex.object);
-                const dataset = this.datasetFactory.dataset([quad1, quad2]);
-
-                const iterator = dataset[Symbol.iterator]();
-
-                const output = this.datasetFactory.dataset();
-
-                for (let item = iterator.next(); item.value; item = iterator.next()) {
-                    output.add(item.value);
-                }
-
-                assert.strictEqual(output.size, 2);
-                assert(output.has(quad1));
-                assert(output.has(quad2));
-            });
-        });
-    }
-
-    run(): void {
-        this.factory();
-        this.size();
-        this.add();
-        this.delete();
-        this.has();
-        this.match();
-        this.iterator();
-    }
+        const matches = dataset.match(ex.subject2);
+
+        assert.strictEqual(matches.size, 1);
+        assert(matches.has(quad2));
+      });
+
+      it("should use the given predicate to select Quads", () => {
+        const quad1 = this.dataFactory.quad(ex.subject, ex.predicate1, ex.object);
+        const quad2 = this.dataFactory.quad(ex.subject, ex.predicate2, ex.object);
+        const dataset = this.datasetFactory.dataset([quad1, quad2]);
+
+        const matches = dataset.match(null, ex.predicate2);
+
+        assert.strictEqual(matches.size, 1);
+        assert(matches.has(quad2));
+      });
+
+      it("should use the given object to select Quads", () => {
+        const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object1);
+        const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object2);
+        const dataset = this.datasetFactory.dataset([quad1, quad2]);
+
+        const matches = dataset.match(null, null, ex.object2);
+
+        assert.strictEqual(matches.size, 1);
+        assert(matches.has(quad2));
+      });
+
+      it("should use the given graph to select Quads", () => {
+        const quad1 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object, ex.graph1);
+        const quad2 = this.dataFactory.quad(ex.subject, ex.predicate, ex.object, ex.graph2);
+        const dataset = this.datasetFactory.dataset([quad1, quad2]);
+
+        const matches = dataset.match(null, null, null, ex.graph2);
+
+        assert.strictEqual(matches.size, 1);
+        assert(matches.has(quad2));
+      });
+
+      it("should return an empty Dataset if there are no matches", () => {
+        const quad1 = this.dataFactory.quad(ex.subject1, ex.predicate, ex.object);
+        const quad2 = this.dataFactory.quad(ex.subject2, ex.predicate, ex.object);
+        const dataset = this.datasetFactory.dataset([quad1, quad2]);
+
+        const matches = dataset.match(null, null, ex.object3);
+
+        assert.strictEqual(matches.size, 0);
+      });
+    });
+  }
+
+  iterator(): void {
+    const ex = namespace("http://example.org/", this.dataFactory);
+
+    describe("Symbol.iterator", () => {
+      it("should be a function", () => {
+        const dataset = this.datasetFactory.dataset();
+
+        assert.strictEqual(typeof dataset[Symbol.iterator], "function");
+      });
+
+      it("should return an iterator", () => {
+        const quad1 = this.dataFactory.quad(ex.subject1, ex.predicate, ex.object);
+        const quad2 = this.dataFactory.quad(ex.subject2, ex.predicate, ex.object);
+        const dataset = this.datasetFactory.dataset([quad1, quad2]);
+
+        const iterator = dataset[Symbol.iterator]();
+
+        assert.strictEqual(typeof iterator.next, "function");
+        assert.strictEqual(typeof iterator.next().value, "object");
+      });
+
+      it("should iterate over all Quads", () => {
+        const quad1 = this.dataFactory.quad(ex.subject1, ex.predicate, ex.object);
+        const quad2 = this.dataFactory.quad(ex.subject2, ex.predicate, ex.object);
+        const dataset = this.datasetFactory.dataset([quad1, quad2]);
+
+        const iterator = dataset[Symbol.iterator]();
+
+        const output = this.datasetFactory.dataset();
+
+        for (let item = iterator.next(); item.value; item = iterator.next()) {
+          output.add(item.value);
+        }
+
+        assert.strictEqual(output.size, 2);
+        assert(output.has(quad1));
+        assert(output.has(quad2));
+      });
+    });
+  }
+
+  run(): void {
+    this.factory();
+    this.size();
+    this.add();
+    this.delete();
+    this.has();
+    this.match();
+    this.iterator();
+  }
 }

--- a/platform/feature-api/api/rdf-spec/src/gen.ts
+++ b/platform/feature-api/api/rdf-spec/src/gen.ts
@@ -8,13 +8,13 @@ import fc, { Arbitrary } from "fast-check";
 import * as RDF from "rdf-js";
 
 export interface Gens<Q extends RDF.BaseQuad = RDF.Quad> {
-    namedNode: Arbitrary<RDF.NamedNode>;
-    blankNode: Arbitrary<RDF.BlankNode>;
-    literal: Arbitrary<RDF.Literal>;
-    variable?: Arbitrary<RDF.Variable>;
-    term: Arbitrary<Exclude<RDF.Term, RDF.BaseQuad>>;
-    triple: Arbitrary<Q>;
-    quad: Arbitrary<Q>;
+  namedNode: Arbitrary<RDF.NamedNode>;
+  blankNode: Arbitrary<RDF.BlankNode>;
+  literal: Arbitrary<RDF.Literal>;
+  variable?: Arbitrary<RDF.Variable>;
+  term: Arbitrary<Exclude<RDF.Term, RDF.BaseQuad>>;
+  triple: Arbitrary<Q>;
+  quad: Arbitrary<Q>;
 }
 
 /**
@@ -29,46 +29,46 @@ export interface Gens<Q extends RDF.BaseQuad = RDF.Quad> {
  * - variables are hexadecimal strings and are only generated if the data factory supports them
  */
 export function gens<Q extends RDF.BaseQuad = RDF.Quad>(factory: RDF.DataFactory<Q>): Gens<Q> {
-    const namedNode = fc.webUrl().map((url) => factory.namedNode(url));
+  const namedNode = fc.webUrl().map((url) => factory.namedNode(url));
 
-    const blankNode = fc.hexaString().map((id) => factory.blankNode(id));
+  const blankNode = fc.hexaString().map((id) => factory.blankNode(id));
 
-    const literal = fc
-        .tuple(fc.hexaString(), fc.oneof(fc.constant(undefined), namedNode))
-        .map(([value, datatype]) => factory.literal(value, datatype));
+  const literal = fc
+    .tuple(fc.hexaString(), fc.oneof(fc.constant(undefined), namedNode))
+    .map(([value, datatype]) => factory.literal(value, datatype));
 
-    const variable = factory.variable
-        ? // @ts-ignore factory.variable does exist if it's true
-          fc.hexaString().map((id) => factory.variable(id))
-        : undefined;
+  const variable = factory.variable
+    ? // @ts-ignore factory.variable does exist if it's true
+      fc.hexaString().map((id) => factory.variable(id))
+    : undefined;
 
-    const variables = variable ? [variable] : [];
+  const variables = variable ? [variable] : [];
 
-    const term = fc.oneof(
-        namedNode,
-        blankNode,
-        literal,
-        fc.constant(factory.defaultGraph()),
-        ...variables
-    );
+  const term = fc.oneof(
+    namedNode,
+    blankNode,
+    literal,
+    fc.constant(factory.defaultGraph()),
+    ...variables
+  );
 
-    const subject = fc.oneof(namedNode, blankNode, ...variables);
-    const predicate = fc.oneof(namedNode, ...variables);
-    const object = fc.oneof(namedNode, literal, blankNode, ...variables);
-    const graph = fc.oneof(fc.constant(factory.defaultGraph()), namedNode, blankNode, ...variables);
+  const subject = fc.oneof(namedNode, blankNode, ...variables);
+  const predicate = fc.oneof(namedNode, ...variables);
+  const object = fc.oneof(namedNode, literal, blankNode, ...variables);
+  const graph = fc.oneof(fc.constant(factory.defaultGraph()), namedNode, blankNode, ...variables);
 
-    const triple = fc.tuple(subject, predicate, object).map(([s, p, o]) => factory.quad(s, p, o));
-    const quad = fc
-        .tuple(subject, predicate, object, graph)
-        .map(([s, p, o, g]) => factory.quad(s, p, o, g));
+  const triple = fc.tuple(subject, predicate, object).map(([s, p, o]) => factory.quad(s, p, o));
+  const quad = fc
+    .tuple(subject, predicate, object, graph)
+    .map(([s, p, o, g]) => factory.quad(s, p, o, g));
 
-    return {
-        namedNode,
-        blankNode,
-        literal,
-        variable,
-        term,
-        triple,
-        quad,
-    };
+  return {
+    namedNode,
+    blankNode,
+    literal,
+    variable,
+    term,
+    triple,
+    quad,
+  };
 }

--- a/platform/feature-api/api/rdf-spec/src/namespace.ts
+++ b/platform/feature-api/api/rdf-spec/src/namespace.ts
@@ -26,13 +26,13 @@ import { BaseQuad, DataFactory, NamedNode } from "rdf-js";
  * @returns A record (backed by a `Proxy`) that can be accessed at any property
  */
 export function namespace<Q extends BaseQuad>(
-    baseIRI: string,
-    dataFactory: Pick<DataFactory<Q>, "namedNode">
+  baseIRI: string,
+  dataFactory: Pick<DataFactory<Q>, "namedNode">
 ): Record<string, NamedNode> {
-    return new Proxy(
-        {},
-        {
-            get: (target, property: string) => dataFactory.namedNode(`${baseIRI}${property}`),
-        }
-    );
+  return new Proxy(
+    {},
+    {
+      get: (target, property: string) => dataFactory.namedNode(`${baseIRI}${property}`),
+    }
+  );
 }

--- a/platform/feature-api/api/rdf-spec/src/tests/_factories.ts
+++ b/platform/feature-api/api/rdf-spec/src/tests/_factories.ts
@@ -8,13 +8,13 @@ import { DataFactory as Ruben } from "rdf-data-factory";
 /** This is a fix to make Graphy support with RDF*
  * Just like the rest of the other data factories */
 Object.assign(Object.getPrototypeOf(Graphy.quad()), {
-    termType: "Quad",
-    value: "",
+  termType: "Quad",
+  value: "",
 });
 
 export const factories: Record<string, DataFactory> = {
-    "@rdfjs/data-model": RDFJS,
-    "@graphy/core.data.factory": Graphy,
-    "rdf-data-factory": new Ruben(),
-    n3: N3,
+  "@rdfjs/data-model": RDFJS,
+  "@graphy/core.data.factory": Graphy,
+  "rdf-data-factory": new Ruben(),
+  n3: N3,
 };

--- a/platform/feature-api/api/rdf-spec/src/tests/data-factory.test.ts
+++ b/platform/feature-api/api/rdf-spec/src/tests/data-factory.test.ts
@@ -2,6 +2,6 @@ import { DataFactorySpec } from "../data-factory";
 import { factories } from "./_factories";
 
 for (const [name, factory] of Object.entries(factories))
-    describe(name, () => {
-        new DataFactorySpec(factory).run();
-    });
+  describe(name, () => {
+    new DataFactorySpec(factory).run();
+  });

--- a/platform/feature-api/api/rdf-spec/src/tests/dataset.test.ts
+++ b/platform/feature-api/api/rdf-spec/src/tests/dataset.test.ts
@@ -8,17 +8,17 @@ import GraphyDataset from "@graphy/memory.dataset.fast";
 import Graphy from "@graphy/core.data.factory";
 
 describe("@rdfjs/dataset", () => {
-    new DatasetSpec(RDFJSDatasetCoreFactory, RDFJSDataFactory).run();
+  new DatasetSpec(RDFJSDatasetCoreFactory, RDFJSDataFactory).run();
 });
 
 describe("@graphy/memory.dataset.fast", () => {
-    const graphyFactory: DatasetCoreFactory = {
-        dataset(quads?: Quad[]): DatasetCore {
-            const set = GraphyDataset();
-            set.addAll(quads || []);
-            return set;
-        },
-    };
+  const graphyFactory: DatasetCoreFactory = {
+    dataset(quads?: Quad[]): DatasetCore {
+      const set = GraphyDataset();
+      set.addAll(quads || []);
+      return set;
+    },
+  };
 
-    new DatasetSpec(graphyFactory, Graphy).run();
+  new DatasetSpec(graphyFactory, Graphy).run();
 });

--- a/platform/feature-api/api/rdf-spec/src/tests/namespace.test.ts
+++ b/platform/feature-api/api/rdf-spec/src/tests/namespace.test.ts
@@ -3,9 +3,9 @@ import DataFactory from "@rdfjs/data-model";
 import assert from "assert";
 
 describe("Namespace", () => {
-    it("Namespace", () => {
-        const ex = namespace("http://example.org/", DataFactory);
-        assert.deepStrictEqual(ex.subject, DataFactory.namedNode("http://example.org/subject"));
-        assert(ex.subject.equals(DataFactory.namedNode("http://example.org/subject")));
-    });
+  it("Namespace", () => {
+    const ex = namespace("http://example.org/", DataFactory);
+    assert.deepStrictEqual(ex.subject, DataFactory.namedNode("http://example.org/subject"));
+    assert(ex.subject.equals(DataFactory.namedNode("http://example.org/subject")));
+  });
 });

--- a/platform/feature-api/api/rdf/.editorconfig
+++ b/platform/feature-api/api/rdf/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+max_line_length = 100

--- a/platform/feature-api/api/rdf/src/index.ts
+++ b/platform/feature-api/api/rdf/src/index.ts
@@ -15,137 +15,137 @@ import * as RDF from "rdf-js";
  * This class defines a generic [[equals]] function according to the RDFJS specification.
  */
 export abstract class Model {
-    abstract termType: string;
+  abstract termType: string;
 
-    equals(other: RDF.Term | null): boolean {
-        if (other === null || other === undefined || other.termType !== this.termType) return false;
+  equals(other: RDF.Term | null): boolean {
+    if (other === null || other === undefined || other.termType !== this.termType) return false;
 
-        for (const [key, value] of Object.entries(this)) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const otherValue = (other as any)[key];
-            if (value instanceof Model) {
-                if (!value.equals(otherValue)) return false;
-            } else if (otherValue !== value) return false;
-        }
-
-        return true;
+    for (const [key, value] of Object.entries(this)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const otherValue = (other as any)[key];
+      if (value instanceof Model) {
+        if (!value.equals(otherValue)) return false;
+      } else if (otherValue !== value) return false;
     }
+
+    return true;
+  }
 }
 
 export class NamedNode<Iri extends string = string> extends Model implements RDF.NamedNode {
-    termType: "NamedNode" = "NamedNode";
+  termType: "NamedNode" = "NamedNode";
 
-    constructor(public value: Iri) {
-        super();
-        Object.freeze(this);
-    }
+  constructor(public value: Iri) {
+    super();
+    Object.freeze(this);
+  }
 }
 
 export class BlankNode extends Model implements RDF.BlankNode {
-    private static nextId = 0;
+  private static nextId = 0;
 
-    termType: "BlankNode" = "BlankNode";
+  termType: "BlankNode" = "BlankNode";
 
-    value: string;
+  value: string;
 
-    constructor(value?: string) {
-        super();
+  constructor(value?: string) {
+    super();
 
-        if (value) this.value = value;
-        else this.value = "b" + ++BlankNode.nextId;
+    if (value) this.value = value;
+    else this.value = "b" + ++BlankNode.nextId;
 
-        Object.freeze(this);
-    }
+    Object.freeze(this);
+  }
 }
 
 export class Literal extends Model implements RDF.Literal {
-    static readonly langStringDatatype = new NamedNode(
-        "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    );
-    static readonly stringDatatype = new NamedNode("http://www.w3.org/2001/XMLSchema#string");
+  static readonly langStringDatatype = new NamedNode(
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+  );
+  static readonly stringDatatype = new NamedNode("http://www.w3.org/2001/XMLSchema#string");
 
-    language: string;
-    datatype: RDF.NamedNode;
-    termType: "Literal" = "Literal";
+  language: string;
+  datatype: RDF.NamedNode;
+  termType: "Literal" = "Literal";
 
-    constructor(public value: string, languageOrDatatype?: string | RDF.NamedNode) {
-        super();
+  constructor(public value: string, languageOrDatatype?: string | RDF.NamedNode) {
+    super();
 
-        if (typeof languageOrDatatype === "string") {
-            if (languageOrDatatype.indexOf(":") === -1) {
-                this.language = languageOrDatatype;
-                this.datatype = Literal.langStringDatatype;
-            } else {
-                this.language = "";
-                this.datatype = new NamedNode(languageOrDatatype);
-            }
-        } else {
-            this.language = "";
-            this.datatype = languageOrDatatype || Literal.stringDatatype;
-        }
-
-        Object.freeze(this);
+    if (typeof languageOrDatatype === "string") {
+      if (languageOrDatatype.indexOf(":") === -1) {
+        this.language = languageOrDatatype;
+        this.datatype = Literal.langStringDatatype;
+      } else {
+        this.language = "";
+        this.datatype = new NamedNode(languageOrDatatype);
+      }
+    } else {
+      this.language = "";
+      this.datatype = languageOrDatatype || Literal.stringDatatype;
     }
+
+    Object.freeze(this);
+  }
 }
 
 export class Variable extends Model implements RDF.Variable {
-    termType: "Variable" = "Variable";
+  termType: "Variable" = "Variable";
 
-    constructor(public value: string) {
-        super();
-        Object.freeze(this);
-    }
+  constructor(public value: string) {
+    super();
+    Object.freeze(this);
+  }
 }
 
 export class DefaultGraph extends Model implements RDF.DefaultGraph {
-    static readonly instance: DefaultGraph = new DefaultGraph();
+  static readonly instance: DefaultGraph = new DefaultGraph();
 
-    private constructor() {
-        super();
-        Object.freeze(this);
-    }
+  private constructor() {
+    super();
+    Object.freeze(this);
+  }
 
-    termType: "DefaultGraph" = "DefaultGraph";
-    value: "" = "";
+  termType: "DefaultGraph" = "DefaultGraph";
+  value: "" = "";
 }
 
 export class Quad implements RDF.Quad {
-    constructor(
-        public subject: RDF.Quad_Subject,
-        public predicate: RDF.Quad_Predicate,
-        public object: RDF.Quad_Object,
-        public graph: RDF.Quad_Graph
-    ) {
-        Object.freeze(this);
-    }
+  constructor(
+    public subject: RDF.Quad_Subject,
+    public predicate: RDF.Quad_Predicate,
+    public object: RDF.Quad_Object,
+    public graph: RDF.Quad_Graph
+  ) {
+    Object.freeze(this);
+  }
 
-    termType: "Quad" = "Quad";
-    value: "" = "";
+  termType: "Quad" = "Quad";
+  value: "" = "";
 
-    equals(other: RDF.Term | null | undefined): boolean {
-        // `|| !other.termType` is for backwards-compatibility with old factories without RDF* support.
-        return (
-            !!other &&
-            (other.termType === "Quad" || !other.termType) &&
-            other.subject.equals(this.subject) &&
-            other.predicate.equals(this.predicate) &&
-            other.object.equals(this.object) &&
-            other.graph.equals(this.graph)
-        );
-    }
+  equals(other: RDF.Term | null | undefined): boolean {
+    // `|| !other.termType` is for backwards-compatibility with old factories without RDF* support.
+    return (
+      !!other &&
+      (other.termType === "Quad" || !other.termType) &&
+      other.subject.equals(this.subject) &&
+      other.predicate.equals(this.predicate) &&
+      other.object.equals(this.object) &&
+      other.graph.equals(this.graph)
+    );
+  }
 }
 
 const prototypes = {
-    subject: [NamedNode.prototype, BlankNode.prototype, Variable.prototype, Quad.prototype],
-    predicate: [NamedNode.prototype, Variable.prototype],
-    object: [
-        NamedNode.prototype,
-        Literal.prototype,
-        BlankNode.prototype,
-        Variable.prototype,
-        Quad.prototype,
-    ],
-    graph: [DefaultGraph.prototype, NamedNode.prototype, BlankNode.prototype, Variable.prototype],
+  subject: [NamedNode.prototype, BlankNode.prototype, Variable.prototype, Quad.prototype],
+  predicate: [NamedNode.prototype, Variable.prototype],
+  object: [
+    NamedNode.prototype,
+    Literal.prototype,
+    BlankNode.prototype,
+    Variable.prototype,
+    Quad.prototype,
+  ],
+  graph: [DefaultGraph.prototype, NamedNode.prototype, BlankNode.prototype, Variable.prototype],
 };
 
 /**
@@ -177,75 +177,73 @@ const prototypes = {
  * For the semantics of the methods, refer to [the spec](https://rdf.js.org/data-model-spec/).
  */
 export class DataFactory implements RDF.DataFactory<Quad, Quad> {
-    constructor(private readonly strict: boolean) {
-        Object.freeze(this);
+  constructor(private readonly strict: boolean) {
+    Object.freeze(this);
+  }
+
+  blankNode(value?: string): BlankNode {
+    if (this.strict) {
+      if (value !== undefined && typeof value !== "string")
+        throw new Error("Expected string or undefined");
     }
 
-    blankNode(value?: string): BlankNode {
-        if (this.strict) {
-            if (value !== undefined && typeof value !== "string")
-                throw new Error("Expected string or undefined");
-        }
+    return new BlankNode(value);
+  }
 
-        return new BlankNode(value);
+  defaultGraph(): DefaultGraph {
+    return DefaultGraph.instance;
+  }
+
+  literal(value: string, languageOrDatatype?: string | NamedNode): Literal {
+    if (this.strict) {
+      if (typeof value !== "string") throw new Error("Expected string as value");
+
+      if (
+        languageOrDatatype !== undefined &&
+        typeof languageOrDatatype !== "string" &&
+        Object.getPrototypeOf(languageOrDatatype) !== NamedNode.prototype
+      )
+        throw new Error("Expected undefined, string or NamedNode prototype as language/datatype");
     }
 
-    defaultGraph(): DefaultGraph {
-        return DefaultGraph.instance;
+    return new Literal(value, languageOrDatatype);
+  }
+
+  namedNode<Iri extends string = string>(value: Iri): NamedNode<Iri> {
+    if (this.strict) {
+      if (typeof value !== "string") throw new Error("Expected string");
     }
 
-    literal(value: string, languageOrDatatype?: string | NamedNode): Literal {
-        if (this.strict) {
-            if (typeof value !== "string") throw new Error("Expected string as value");
+    return new NamedNode(value);
+  }
 
-            if (
-                languageOrDatatype !== undefined &&
-                typeof languageOrDatatype !== "string" &&
-                Object.getPrototypeOf(languageOrDatatype) !== NamedNode.prototype
-            )
-                throw new Error(
-                    "Expected undefined, string or NamedNode prototype as language/datatype"
-                );
-        }
-
-        return new Literal(value, languageOrDatatype);
+  quad(
+    subject: RDF.Quad_Subject,
+    predicate: RDF.Quad_Predicate,
+    object: RDF.Quad_Object,
+    graph?: RDF.Quad_Graph
+  ): Quad {
+    if (this.strict) {
+      if (!prototypes.subject.includes(Object.getPrototypeOf(subject)))
+        throw new Error("Invalid prototype of subject");
+      if (!prototypes.predicate.includes(Object.getPrototypeOf(predicate)))
+        throw new Error("Invalid prototype of predicate");
+      if (!prototypes.object.includes(Object.getPrototypeOf(object)))
+        throw new Error("Invalid prototype of object");
+      if (graph !== undefined && !prototypes.graph.includes(Object.getPrototypeOf(graph)))
+        throw new Error("Invalid prototype of graph");
     }
 
-    namedNode<Iri extends string = string>(value: Iri): NamedNode<Iri> {
-        if (this.strict) {
-            if (typeof value !== "string") throw new Error("Expected string");
-        }
+    return new Quad(subject, predicate, object, graph || this.defaultGraph());
+  }
 
-        return new NamedNode(value);
+  variable(value: string): Variable {
+    if (this.strict) {
+      if (typeof value !== "string") throw new Error("Expected string");
     }
 
-    quad(
-        subject: RDF.Quad_Subject,
-        predicate: RDF.Quad_Predicate,
-        object: RDF.Quad_Object,
-        graph?: RDF.Quad_Graph
-    ): Quad {
-        if (this.strict) {
-            if (!prototypes.subject.includes(Object.getPrototypeOf(subject)))
-                throw new Error("Invalid prototype of subject");
-            if (!prototypes.predicate.includes(Object.getPrototypeOf(predicate)))
-                throw new Error("Invalid prototype of predicate");
-            if (!prototypes.object.includes(Object.getPrototypeOf(object)))
-                throw new Error("Invalid prototype of object");
-            if (graph !== undefined && !prototypes.graph.includes(Object.getPrototypeOf(graph)))
-                throw new Error("Invalid prototype of graph");
-        }
-
-        return new Quad(subject, predicate, object, graph || this.defaultGraph());
-    }
-
-    variable(value: string): Variable {
-        if (this.strict) {
-            if (typeof value !== "string") throw new Error("Expected string");
-        }
-
-        return new Variable(value);
-    }
+    return new Variable(value);
+  }
 }
 
 /**

--- a/platform/feature-api/api/rdf/src/tests/default.test.ts
+++ b/platform/feature-api/api/rdf/src/tests/default.test.ts
@@ -2,5 +2,5 @@ import { dataFactory } from "../index";
 import { DataFactorySpec } from "@polypoly-eu/rdf-spec";
 
 describe("Spec", () => {
-    new DataFactorySpec(dataFactory).run();
+  new DataFactorySpec(dataFactory).run();
 });

--- a/platform/feature-api/api/rdf/src/tests/strict.test.ts
+++ b/platform/feature-api/api/rdf/src/tests/strict.test.ts
@@ -5,28 +5,28 @@ import * as Foreign from "@rdfjs/data-model";
 const dataFactory = new DataFactory(true);
 
 describe("Spec", () => {
-    new DataFactorySpec(dataFactory).run();
+  new DataFactorySpec(dataFactory).run();
 });
 
 describe("Strict", () => {
-    it("Rejects foreign terms (quad)", () => {
-        const s = Foreign.namedNode("http://example.org/s");
-        const p = Foreign.namedNode("http://example.org/p");
-        const o = Foreign.namedNode("http://example.org/o");
+  it("Rejects foreign terms (quad)", () => {
+    const s = Foreign.namedNode("http://example.org/s");
+    const p = Foreign.namedNode("http://example.org/p");
+    const o = Foreign.namedNode("http://example.org/o");
 
-        expect(() => dataFactory.quad(s, p, o)).toThrowError(/prototype/);
-    });
+    expect(() => dataFactory.quad(s, p, o)).toThrowError(/prototype/);
+  });
 
-    it("Rejects foreign terms (literal)", () => {
-        const dt = Foreign.namedNode("http://example.org/t");
+  it("Rejects foreign terms (literal)", () => {
+    const dt = Foreign.namedNode("http://example.org/t");
 
-        expect(() => dataFactory.literal("hi", dt)).toThrowError(/prototype/);
-    });
+    expect(() => dataFactory.literal("hi", dt)).toThrowError(/prototype/);
+  });
 
-    // TODO: recheck correctness of this test
-    // what is an ill-typed invocation of a string value?
-    it("Rejects ill-typed invocations", () => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        expect(() => dataFactory.variable(null!)).toThrowError();
-    });
+  // TODO: recheck correctness of this test
+  // what is an ill-typed invocation of a string value?
+  it("Rejects ill-typed invocations", () => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(() => dataFactory.variable(null!)).toThrowError();
+  });
 });

--- a/platform/feature-api/communication/bubblewrap/.editorconfig
+++ b/platform/feature-api/communication/bubblewrap/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+max_line_length = 100

--- a/platform/feature-api/communication/bubblewrap/src/main/javascript/benchmarks/rdf.bench.ts
+++ b/platform/feature-api/communication/bubblewrap/src/main/javascript/benchmarks/rdf.bench.ts
@@ -11,12 +11,12 @@ import * as assert from "assert";
 const suite = new Suite();
 
 const classes: Classes = {
-    "@polypoly-eu/rdf.NamedNode": RDF.NamedNode,
-    "@polypoly-eu/rdf.BlankNode": RDF.BlankNode,
-    "@polypoly-eu/rdf.Literal": RDF.Literal,
-    "@polypoly-eu/rdf.Variable": RDF.Variable,
-    "@polypoly-eu/rdf.DefaultGraph": RDF.DefaultGraph,
-    "@polypoly-eu/rdf.Quad": RDF.Quad,
+  "@polypoly-eu/rdf.NamedNode": RDF.NamedNode,
+  "@polypoly-eu/rdf.BlankNode": RDF.BlankNode,
+  "@polypoly-eu/rdf.Literal": RDF.Literal,
+  "@polypoly-eu/rdf.Variable": RDF.Variable,
+  "@polypoly-eu/rdf.DefaultGraph": RDF.DefaultGraph,
+  "@polypoly-eu/rdf.Quad": RDF.Quad,
 };
 
 const bubblewrap = Bubblewrap.create(classes);
@@ -24,63 +24,63 @@ const bubblewrapStrict = Bubblewrap.create(classes, true);
 const bubblewrapRaw = Bubblewrap.create();
 
 async function loadDataset(): Promise<Quad[]> {
-    const path = join(__dirname, "..", "..", "resources", "dataset.nt");
-    const content = await fs.readFile(path, { encoding: "utf-8" });
-    const parser = new Parser();
-    return parser.parse(content);
+  const path = join(__dirname, "..", "..", "resources", "dataset.nt");
+  const content = await fs.readFile(path, { encoding: "utf-8" });
+  const parser = new Parser();
+  return parser.parse(content);
 }
 
 function convertDataset(quads: Quad[]): RDF.Quad[] {
-    return quads.map((quad) => convert(quad, RDF.dataFactory));
+  return quads.map((quad) => convert(quad, RDF.dataFactory));
 }
 
 async function runBench(): Promise<void> {
-    const dataset = convertDataset(await loadDataset());
-    const encoded = bubblewrap.encode(dataset);
-    const encodedStrict = bubblewrapStrict.encode(dataset);
-    assert.deepStrictEqual(encoded, encodedStrict);
-    const encodedRaw = bubblewrapRaw.encode(dataset);
-    assert.notDeepStrictEqual(encoded, encodedRaw);
+  const dataset = convertDataset(await loadDataset());
+  const encoded = bubblewrap.encode(dataset);
+  const encodedStrict = bubblewrapStrict.encode(dataset);
+  assert.deepStrictEqual(encoded, encodedStrict);
+  const encodedRaw = bubblewrapRaw.encode(dataset);
+  assert.notDeepStrictEqual(encoded, encodedRaw);
 
-    assert.deepStrictEqual(convertDataset(bubblewrapRaw.decode(encodedRaw)), dataset);
+  assert.deepStrictEqual(convertDataset(bubblewrapRaw.decode(encodedRaw)), dataset);
 
-    console.log(`Measuring ${dataset.length} quads`);
+  console.log(`Measuring ${dataset.length} quads`);
 
-    suite
-        .add("encoding", () => {
-            bubblewrap.encode(dataset);
-        })
-        .add("encoding (strict)", () => {
-            bubblewrapStrict.encode(dataset);
-        })
-        .add("encoding (raw)", () => {
-            bubblewrapRaw.encode(dataset);
-        })
-        .add("decoding", () => {
-            bubblewrap.decode(encoded);
-        })
-        .add("decoding (strict)", () => {
-            bubblewrapStrict.decode(encodedStrict);
-        })
-        .add("decoding (raw)", () => {
-            bubblewrapRaw.decode(encodedRaw);
-        })
-        .add("decoding (raw-then-convert)", () => {
-            convertDataset(bubblewrapRaw.decode(encodedRaw));
-        })
-        .add("roundtrip", () => {
-            bubblewrap.decode(bubblewrap.encode(dataset));
-        })
-        .add("roundtrip (strict)", () => {
-            bubblewrapStrict.decode(bubblewrapStrict.encode(dataset));
-        })
-        .add("roundtrip (raw-then-convert)", () => {
-            convertDataset(bubblewrapRaw.decode(bubblewrapRaw.encode(dataset)));
-        })
-        .on("cycle", (event: Event) => {
-            console.log(event.target.toString());
-        })
-        .run();
+  suite
+    .add("encoding", () => {
+      bubblewrap.encode(dataset);
+    })
+    .add("encoding (strict)", () => {
+      bubblewrapStrict.encode(dataset);
+    })
+    .add("encoding (raw)", () => {
+      bubblewrapRaw.encode(dataset);
+    })
+    .add("decoding", () => {
+      bubblewrap.decode(encoded);
+    })
+    .add("decoding (strict)", () => {
+      bubblewrapStrict.decode(encodedStrict);
+    })
+    .add("decoding (raw)", () => {
+      bubblewrapRaw.decode(encodedRaw);
+    })
+    .add("decoding (raw-then-convert)", () => {
+      convertDataset(bubblewrapRaw.decode(encodedRaw));
+    })
+    .add("roundtrip", () => {
+      bubblewrap.decode(bubblewrap.encode(dataset));
+    })
+    .add("roundtrip (strict)", () => {
+      bubblewrapStrict.decode(bubblewrapStrict.encode(dataset));
+    })
+    .add("roundtrip (raw-then-convert)", () => {
+      convertDataset(bubblewrapRaw.decode(bubblewrapRaw.encode(dataset)));
+    })
+    .on("cycle", (event: Event) => {
+      console.log(event.target.toString());
+    })
+    .run();
 }
 
 runBench();

--- a/platform/feature-api/communication/bubblewrap/src/main/javascript/tests/index.test.ts
+++ b/platform/feature-api/communication/bubblewrap/src/main/javascript/tests/index.test.ts
@@ -7,173 +7,170 @@ import { Bubblewrap, Class, Classes, deserialize, serialize } from "../index";
 type TypeInfo<T> = [Class<T>, Arbitrary<T>];
 
 type TypeInfos<T extends Record<string, unknown>> = {
-    [P in keyof T]: TypeInfo<T[P]>;
+  [P in keyof T]: TypeInfo<T[P]>;
 };
 
 class BubblewrapSpec<T extends Record<string, unknown>> {
-    readonly bubblewrap: Bubblewrap;
+  readonly bubblewrap: Bubblewrap;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly gen: Arbitrary<[Class<any>, unknown]>;
+
+  constructor(private readonly infos: TypeInfos<T>) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private readonly gen: Arbitrary<[Class<any>, unknown]>;
+    const gens: Arbitrary<[Class<any>, unknown]>[] = [];
+    const constructors: Classes = {};
 
-    constructor(private readonly infos: TypeInfos<T>) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const gens: Arbitrary<[Class<any>, unknown]>[] = [];
-        const constructors: Classes = {};
-
-        for (const [key, [constructor, gen]] of Object.entries(this.infos)) {
-            gens.push(gen.map((value: unknown) => [constructor, value]));
-            constructors[key] = constructor;
-        }
-
-        this.bubblewrap = Bubblewrap.create(constructors, true);
-
-        this.gen = fc.oneof(...gens);
+    for (const [key, [constructor, gen]] of Object.entries(this.infos)) {
+      gens.push(gen.map((value: unknown) => [constructor, value]));
+      constructors[key] = constructor;
     }
 
-    run(): void {
-        const { gen, bubblewrap } = this;
+    this.bubblewrap = Bubblewrap.create(constructors, true);
 
-        it("decode/encode", () => {
-            fc.assert(
-                fc.property(gen, ([constructor, t]) => {
-                    const encoded = bubblewrap.encode(t);
-                    expect(encoded).toBeInstanceOf(Uint8Array);
-                    const decoded = bubblewrap.decode(encoded);
-                    expect(decoded).toStrictEqual(t);
-                    expect(decoded).toBeInstanceOf(constructor);
-                })
-            );
-        });
-    }
+    this.gen = fc.oneof(...gens);
+  }
+
+  run(): void {
+    const { gen, bubblewrap } = this;
+
+    it("decode/encode", () => {
+      fc.assert(
+        fc.property(gen, ([constructor, t]) => {
+          const encoded = bubblewrap.encode(t);
+          expect(encoded).toBeInstanceOf(Uint8Array);
+          const decoded = bubblewrap.decode(encoded);
+          expect(decoded).toStrictEqual(t);
+          expect(decoded).toBeInstanceOf(constructor);
+        })
+      );
+    });
+  }
 }
 
 class TestA {
-    constructor(public a: string) {}
+  constructor(public a: string) {}
 }
 
 class TestB extends TestA {
-    constructor(a: string, public b: string) {
-        super(a);
-    }
+  constructor(a: string, public b: string) {
+    super(a);
+  }
 }
 
 class MyError extends Error {
-    constructor(private readonly mymsg: string) {
-        super(`My message: ${mymsg}`);
-    }
+  constructor(private readonly mymsg: string) {
+    super(`My message: ${mymsg}`);
+  }
 
-    static [deserialize](mymsg: string): MyError {
-        return new MyError(mymsg);
-    }
+  static [deserialize](mymsg: string): MyError {
+    return new MyError(mymsg);
+  }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [serialize](): any {
-        return this.mymsg;
-    }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [serialize](): any {
+    return this.mymsg;
+  }
 }
 
 type Types = {
-    A: TestA;
-    B: TestB;
-    MyError: MyError;
-    "@polypoly-eu/rdf.NamedNode": RDF.NamedNode;
-    "@polypoly-eu/rdf.BlankNode": RDF.BlankNode;
-    "@polypoly-eu/rdf.Literal": RDF.Literal;
-    "@polypoly-eu/rdf.Variable": RDF.Variable;
-    "@polypoly-eu/rdf.DefaultGraph": RDF.DefaultGraph;
-    "@polypoly-eu/rdf.Quad": RDF.Quad;
+  A: TestA;
+  B: TestB;
+  MyError: MyError;
+  "@polypoly-eu/rdf.NamedNode": RDF.NamedNode;
+  "@polypoly-eu/rdf.BlankNode": RDF.BlankNode;
+  "@polypoly-eu/rdf.Literal": RDF.Literal;
+  "@polypoly-eu/rdf.Variable": RDF.Variable;
+  "@polypoly-eu/rdf.DefaultGraph": RDF.DefaultGraph;
+  "@polypoly-eu/rdf.Quad": RDF.Quad;
 };
 
 const gen = gens(RDF.dataFactory);
 
 const infos: TypeInfos<Types> = {
-    A: [TestA, fc.fullUnicodeString().map((a) => new TestA(a))],
-    B: [
-        TestB,
-        fc.tuple(fc.fullUnicodeString(), fc.fullUnicodeString()).map(([a, b]) => new TestB(a, b)),
-    ],
-    MyError: [MyError, fc.hexaString().map((m) => new MyError(m))],
-    "@polypoly-eu/rdf.NamedNode": [RDF.NamedNode, gen.namedNode],
-    "@polypoly-eu/rdf.BlankNode": [RDF.BlankNode, gen.blankNode],
-    "@polypoly-eu/rdf.Literal": [RDF.Literal, gen.literal],
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    "@polypoly-eu/rdf.Variable": [RDF.Variable, gen.variable!],
-    "@polypoly-eu/rdf.DefaultGraph": [
-        RDF.DefaultGraph,
-        fc.constant(RDF.dataFactory.defaultGraph()),
-    ],
-    "@polypoly-eu/rdf.Quad": [RDF.Quad, gen.quad],
+  A: [TestA, fc.fullUnicodeString().map((a) => new TestA(a))],
+  B: [
+    TestB,
+    fc.tuple(fc.fullUnicodeString(), fc.fullUnicodeString()).map(([a, b]) => new TestB(a, b)),
+  ],
+  MyError: [MyError, fc.hexaString().map((m) => new MyError(m))],
+  "@polypoly-eu/rdf.NamedNode": [RDF.NamedNode, gen.namedNode],
+  "@polypoly-eu/rdf.BlankNode": [RDF.BlankNode, gen.blankNode],
+  "@polypoly-eu/rdf.Literal": [RDF.Literal, gen.literal],
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  "@polypoly-eu/rdf.Variable": [RDF.Variable, gen.variable!],
+  "@polypoly-eu/rdf.DefaultGraph": [RDF.DefaultGraph, fc.constant(RDF.dataFactory.defaultGraph())],
+  "@polypoly-eu/rdf.Quad": [RDF.Quad, gen.quad],
 };
 
 describe("Bubblewrap", () => {
-    describe("Spec", () => {
-        new BubblewrapSpec(infos).run();
+  describe("Spec", () => {
+    new BubblewrapSpec(infos).run();
+  });
+
+  describe("RDF", () => {
+    const { bubblewrap } = new BubblewrapSpec(infos);
+
+    for (const [key, g] of Object.entries(gen))
+      it(key, () => {
+        fc.assert(
+          fc.property(g, (term) => {
+            const decoded = bubblewrap.decode(bubblewrap.encode(term));
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            expect((term as any).equals(decoded)).toBe(true);
+            expect(decoded.equals(term)).toBe(true);
+          })
+        );
+      });
+  });
+
+  describe("Builtins", () => {
+    it("Error", () => {
+      const bubblewrap = Bubblewrap.create();
+
+      fc.assert(
+        fc.property(fc.string(), (msg) => {
+          const err = new Error(msg);
+          const decoded = bubblewrap.decode(bubblewrap.encode(err));
+          expect(decoded).toEqual(err);
+          expect(decoded).toBeInstanceOf(Error);
+        })
+      );
     });
 
-    describe("RDF", () => {
-        const { bubblewrap } = new BubblewrapSpec(infos);
-
-        for (const [key, g] of Object.entries(gen))
-            it(key, () => {
-                fc.assert(
-                    fc.property(g, (term) => {
-                        const decoded = bubblewrap.decode(bubblewrap.encode(term));
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        expect((term as any).equals(decoded)).toBe(true);
-                        expect(decoded.equals(term)).toBe(true);
-                    })
-                );
-            });
+    it("Error (non-strict)", () => {
+      const bubblewrap = Bubblewrap.create();
+      const err = new MyError("test");
+      const decoded = bubblewrap.decode(bubblewrap.encode(err));
+      expect(Object.getPrototypeOf(decoded)).toBe(Error.prototype);
     });
 
-    describe("Builtins", () => {
-        it("Error", () => {
-            const bubblewrap = Bubblewrap.create();
-
-            fc.assert(
-                fc.property(fc.string(), (msg) => {
-                    const err = new Error(msg);
-                    const decoded = bubblewrap.decode(bubblewrap.encode(err));
-                    expect(decoded).toEqual(err);
-                    expect(decoded).toBeInstanceOf(Error);
-                })
-            );
-        });
-
-        it("Error (non-strict)", () => {
-            const bubblewrap = Bubblewrap.create();
-            const err = new MyError("test");
-            const decoded = bubblewrap.decode(bubblewrap.encode(err));
-            expect(Object.getPrototypeOf(decoded)).toBe(Error.prototype);
-        });
-
-        it("Error (strict)", () => {
-            const bubblewrap = Bubblewrap.create({}, true);
-            const err = new MyError("test");
-            expect(() => bubblewrap.encode(err)).toThrowError(/unknown prototype/);
-        });
+    it("Error (strict)", () => {
+      const bubblewrap = Bubblewrap.create({}, true);
+      const err = new MyError("test");
+      expect(() => bubblewrap.encode(err)).toThrowError(/unknown prototype/);
     });
+  });
 
-    describe("Add class", () => {
-        it("Adds classes, throws if duplicated", () => {
-            const bubblewrap = Bubblewrap.create();
-            const someClasses: Classes = { TestA: TestA, TestB: TestB };
-            const bubblewrapPlus = bubblewrap.addClasses(someClasses);
-            expect(bubblewrapPlus).not.toBeNull();
-            const someOtherClasses: Classes = { TestB: TestB };
-            expect(() => bubblewrapPlus.addClasses(someOtherClasses)).toThrowError(/Duplicate/);
-        });
+  describe("Add class", () => {
+    it("Adds classes, throws if duplicated", () => {
+      const bubblewrap = Bubblewrap.create();
+      const someClasses: Classes = { TestA: TestA, TestB: TestB };
+      const bubblewrapPlus = bubblewrap.addClasses(someClasses);
+      expect(bubblewrapPlus).not.toBeNull();
+      const someOtherClasses: Classes = { TestB: TestB };
+      expect(() => bubblewrapPlus.addClasses(someOtherClasses)).toThrowError(/Duplicate/);
     });
+  });
 
-    describe("Tests undefined", () => {
-        it("Tries to encode/decode undefined/null", () => {
-            const bw = Bubblewrap.create();
-            let encodedUndefined = bw.encode(undefined);
-            expect(encodedUndefined).not.toBeNull();
-            expect(bw.decode(encodedUndefined)).toBeNull();
-            encodedUndefined = bw.encode(null);
-            expect(encodedUndefined).not.toBeNull();
-            expect(bw.decode(encodedUndefined)).toBeNull();
-        });
+  describe("Tests undefined", () => {
+    it("Tries to encode/decode undefined/null", () => {
+      const bw = Bubblewrap.create();
+      let encodedUndefined = bw.encode(undefined);
+      expect(encodedUndefined).not.toBeNull();
+      expect(bw.decode(encodedUndefined)).toBeNull();
+      encodedUndefined = bw.encode(null);
+      expect(encodedUndefined).not.toBeNull();
+      expect(bw.decode(encodedUndefined)).toBeNull();
     });
+  });
 });

--- a/platform/feature-api/communication/port-authority/.editorconfig
+++ b/platform/feature-api/communication/port-authority/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+max_line_length = 100

--- a/platform/feature-api/communication/port-authority/src/browser.ts
+++ b/platform/feature-api/communication/port-authority/src/browser.ts
@@ -20,15 +20,15 @@ import { Handler, mapPort, Port, ReceivePort } from "./port";
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function fromBrowserMessagePort(port: MessagePort): Port<MessageEvent, any> {
-    return {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        send(value: any): void {
-            port.postMessage(value);
-        },
-        addHandler(handler: Handler<MessageEvent>): void {
-            port.addEventListener("message", (message) => handler(message));
-        },
-    };
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    send(value: any): void {
+      port.postMessage(value);
+    },
+    addHandler(handler: Handler<MessageEvent>): void {
+      port.addEventListener("message", (message) => handler(message));
+    },
+  };
 }
 
 /**
@@ -73,28 +73,28 @@ export function fromBrowserMessagePort(port: MessagePort): Port<MessageEvent, an
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function iframeInnerPort(secret: string): Promise<Port<any, any>> {
-    return new Promise((resolve, reject) => {
-        const handler: Handler<MessageEvent> = (event) => {
-            if (event.source !== window.parent || event.data !== secret) return;
+  return new Promise((resolve, reject) => {
+    const handler: Handler<MessageEvent> = (event) => {
+      if (event.source !== window.parent || event.data !== secret) return;
 
-            if (event.ports.length === 1) {
-                event.ports[0].start();
-                const rawPort = fromBrowserMessagePort(event.ports[0]);
-                resolve(
-                    mapPort(
-                        rawPort,
-                        (event) => event.data,
-                        (any) => any
-                    )
-                );
-            } else {
-                reject(`Malformed message`);
-            }
+      if (event.ports.length === 1) {
+        event.ports[0].start();
+        const rawPort = fromBrowserMessagePort(event.ports[0]);
+        resolve(
+          mapPort(
+            rawPort,
+            (event) => event.data,
+            (any) => any
+          )
+        );
+      } else {
+        reject(`Malformed message`);
+      }
 
-            window.removeEventListener("message", handler);
-        };
-        window.addEventListener("message", handler);
-    });
+      window.removeEventListener("message", handler);
+    };
+    window.addEventListener("message", handler);
+  });
 }
 
 /**
@@ -120,21 +120,21 @@ export function iframeInnerPort(secret: string): Promise<Port<any, any>> {
  * ```
  */
 export function iframeOuterPort(
-    secret: string,
-    iframe: HTMLIFrameElement,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    init?: (port: ReceivePort<any>) => void
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  secret: string,
+  iframe: HTMLIFrameElement,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  init?: (port: ReceivePort<any>) => void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Port<any, any> {
-    const { port1, port2 } = new MessageChannel();
-    const rawPort = fromBrowserMessagePort(port1);
-    const port = mapPort(
-        rawPort,
-        (event) => event.data,
-        (any) => any
-    );
-    if (init) init(port);
-    port1.start();
-    iframe.contentWindow?.postMessage(secret, "*", [port2]);
-    return port;
+  const { port1, port2 } = new MessageChannel();
+  const rawPort = fromBrowserMessagePort(port1);
+  const port = mapPort(
+    rawPort,
+    (event) => event.data,
+    (any) => any
+  );
+  if (init) init(port);
+  port1.start();
+  iframe.contentWindow?.postMessage(secret, "*", [port2]);
+  return port;
 }

--- a/platform/feature-api/communication/port-authority/src/fetch.ts
+++ b/platform/feature-api/communication/port-authority/src/fetch.ts
@@ -36,34 +36,34 @@ import { rethrowPromise, Try } from "./util";
  * @param fetch the Fetch implementation; `window.fetch` can be used in the browser and a polyfill on Node.js
  */
 export function fetchPort<T>(
-    url: string,
-    contentType: string,
-    parse: (body: Body) => Promise<T>,
-    fetch: typeof window.fetch
+  url: string,
+  contentType: string,
+  parse: (body: Body) => Promise<T>,
+  fetch: typeof window.fetch
 ): RequestPort<BodyInit, T> {
-    return {
-        send: async (request) => {
-            const response = await fetch(url, {
-                headers: {
-                    "Content-Type": contentType,
-                },
-                method: "post",
-                body: request.request,
-            });
-
-            if (!response.ok) {
-                request.resolvers.reject(new Error("Invalid response code"));
-                return;
-            }
-
-            try {
-                const parsed = await parse(response);
-                request.resolvers.resolve(parsed);
-            } catch (err) {
-                request.resolvers.reject(err);
-            }
+  return {
+    send: async (request) => {
+      const response = await fetch(url, {
+        headers: {
+          "Content-Type": contentType,
         },
-    };
+        method: "post",
+        body: request.request,
+      });
+
+      if (!response.ok) {
+        request.resolvers.reject(new Error("Invalid response code"));
+        return;
+      }
+
+      try {
+        const parsed = await parse(response);
+        request.resolvers.resolve(parsed);
+      } catch (err) {
+        request.resolvers.reject(err);
+      }
+    },
+  };
 }
 
 /**
@@ -74,18 +74,18 @@ export function fetchPort<T>(
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function jsonFetchPort(url: string, fetch: typeof window.fetch): RequestPort<any, any> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const rawPort = fetchPort<any>(
-        url,
-        "application/json",
-        async (body) => rethrowPromise(await body.json()),
-        fetch
-    );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rawPort = fetchPort<any>(
+    url,
+    "application/json",
+    async (body) => rethrowPromise(await body.json()),
+    fetch
+  );
 
-    return mapSendPort(rawPort, (data) => ({
-        resolvers: data.resolvers,
-        request: JSON.stringify(data.request),
-    }));
+  return mapSendPort(rawPort, (data) => ({
+    resolvers: data.resolvers,
+    request: JSON.stringify(data.request),
+  }));
 }
 
 /**
@@ -96,26 +96,26 @@ export function jsonFetchPort(url: string, fetch: typeof window.fetch): RequestP
  * stream using Bubblewrap. Conversely, incoming responses are decoded using Bubblewrap.
  */
 export function bubblewrapFetchPort(
-    url: string,
-    bubblewrap: Bubblewrap,
-    fetch: typeof window.fetch
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  url: string,
+  bubblewrap: Bubblewrap,
+  fetch: typeof window.fetch
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): RequestPort<any, any> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const rawPort = fetchPort<any>(
-        url,
-        "application/octet-stream",
-        async (body) => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const decoded: Try<any> = bubblewrap.decode(new Uint8Array(await body.arrayBuffer()));
-            if (decoded.tag === "failure") throw decoded.err;
-            else return decoded.value;
-        },
-        fetch
-    );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rawPort = fetchPort<any>(
+    url,
+    "application/octet-stream",
+    async (body) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const decoded: Try<any> = bubblewrap.decode(new Uint8Array(await body.arrayBuffer()));
+      if (decoded.tag === "failure") throw decoded.err;
+      else return decoded.value;
+    },
+    fetch
+  );
 
-    return mapSendPort(rawPort, (data) => ({
-        resolvers: data.resolvers,
-        request: bubblewrap.encode(data.request),
-    }));
+  return mapSendPort(rawPort, (data) => ({
+    resolvers: data.resolvers,
+    request: bubblewrap.encode(data.request),
+  }));
 }

--- a/platform/feature-api/communication/port-authority/src/node.ts
+++ b/platform/feature-api/communication/port-authority/src/node.ts
@@ -27,16 +27,16 @@ import createServer, { NextHandleFunction, HandleFunction } from "connect";
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function fromNodeMessagePort(port: MessagePort): Port<any, any> {
-    return {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        send(value: any): void {
-            port.postMessage(value);
-        },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        addHandler(handler: Handler<any>): void {
-            port.on("message", handler);
-        },
-    };
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    send(value: any): void {
+      port.postMessage(value);
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    addHandler(handler: Handler<any>): void {
+      port.on("message", handler);
+    },
+  };
 }
 
 /**
@@ -67,51 +67,51 @@ export function fromNodeMessagePort(port: MessagePort): Port<any, any> {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function middlewarePort<T, Body = any>(
-    contentType: string,
-    format: (result: Try<T>) => Body
+  contentType: string,
+  format: (result: Try<T>) => Body
 ): [HandleFunction, ResponsePort<Body, T>] {
-    let _handler: Handler<WithResolvers<Body, T>> | undefined = undefined;
+  let _handler: Handler<WithResolvers<Body, T>> | undefined = undefined;
 
-    const middleware: NextHandleFunction = async (_request, response, next) => {
-        if (_request.method === "GET") {
-            // this is to signal that the endpoint exists
-            response.writeHead(200);
-            response.end();
-            return;
-        }
+  const middleware: NextHandleFunction = async (_request, response, next) => {
+    if (_request.method === "GET") {
+      // this is to signal that the endpoint exists
+      response.writeHead(200);
+      response.end();
+      return;
+    }
 
-        if (_handler === undefined) return; // yolo
+    if (_handler === undefined) return; // yolo
 
-        const handler = _handler;
-        const request = _request as IncomingMessage & { body: Body };
+    const handler = _handler;
+    const request = _request as IncomingMessage & { body: Body };
 
-        if (request.method !== "POST") next();
+    if (request.method !== "POST") next();
 
-        const result = await recoverPromise(
-            new Promise<T>((resolve, reject) => {
-                handler({
-                    request: request.body,
-                    resolvers: { resolve, reject },
-                });
-            })
-        );
+    const result = await recoverPromise(
+      new Promise<T>((resolve, reject) => {
+        handler({
+          request: request.body,
+          resolvers: { resolve, reject },
+        });
+      })
+    );
 
-        const body = format(result);
+    const body = format(result);
 
-        response.setHeader("Content-Type", contentType);
-        response.writeHead(200);
-        response.write(body);
-        response.end();
-    };
+    response.setHeader("Content-Type", contentType);
+    response.writeHead(200);
+    response.write(body);
+    response.end();
+  };
 
-    return [
-        middleware,
-        {
-            addHandler: (handler) => {
-                if (_handler === undefined) _handler = handler;
-            },
-        },
-    ];
+  return [
+    middleware,
+    {
+      addHandler: (handler) => {
+        if (_handler === undefined) _handler = handler;
+      },
+    },
+  ];
 }
 
 /**
@@ -122,27 +122,27 @@ export function middlewarePort<T, Body = any>(
  * `JSON.parse`.
  */
 export function jsonMiddlewarePort(
-    options?: OptionsJson
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options?: OptionsJson
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): [RequestListener, ResponsePort<any, any>] {
-    const contentType = "application/json";
+  const contentType = "application/json";
 
-    const server = createServer();
+  const server = createServer();
 
-    server.use(
-        json({
-            ...options,
-            strict: false,
-            type: contentType,
-        })
-    );
+  server.use(
+    json({
+      ...options,
+      strict: false,
+      type: contentType,
+    })
+  );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const [handler, port] = middlewarePort<any, any>(contentType, JSON.stringify);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [handler, port] = middlewarePort<any, any>(contentType, JSON.stringify);
 
-    server.use(handler);
+  server.use(handler);
 
-    return [server, port];
+  return [server, port];
 }
 
 /**
@@ -154,32 +154,32 @@ export function jsonMiddlewarePort(
  * are decoded using standard Bubblewrap decoding.
  */
 export function bubblewrapMiddlewarePort(
-    bubblewrap: Bubblewrap,
-    options?: Options
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  bubblewrap: Bubblewrap,
+  options?: Options
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): [RequestListener, ResponsePort<any, any>] {
-    const contentType = "application/octet-stream";
+  const contentType = "application/octet-stream";
 
-    const server = createServer();
+  const server = createServer();
 
-    server.use(
-        raw({
-            ...options,
-            type: contentType,
-        })
-    );
+  server.use(
+    raw({
+      ...options,
+      type: contentType,
+    })
+  );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const [handler, rawPort] = middlewarePort<any, Buffer>(contentType, (value) =>
-        Buffer.from(bubblewrap.encode(value))
-    );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [handler, rawPort] = middlewarePort<any, Buffer>(contentType, (value) =>
+    Buffer.from(bubblewrap.encode(value))
+  );
 
-    server.use(handler);
+  server.use(handler);
 
-    const port = mapReceivePort(rawPort, (data) => ({
-        resolvers: data.resolvers,
-        request: bubblewrap.decode(data.request),
-    }));
+  const port = mapReceivePort(rawPort, (data) => ({
+    resolvers: data.resolvers,
+    request: bubblewrap.decode(data.request),
+  }));
 
-    return [server, port];
+  return [server, port];
 }

--- a/platform/feature-api/communication/port-authority/src/port.ts
+++ b/platform/feature-api/communication/port-authority/src/port.ts
@@ -16,7 +16,7 @@ export type Handler<T> = (t: T) => void;
  * the handler.
  */
 export function mapHandler<T, U>(handler: Handler<T>, f: (x: U) => T): Handler<U> {
-    return (u) => handler(f(u));
+  return (u) => handler(f(u));
 }
 
 /**
@@ -37,7 +37,7 @@ export function mapHandler<T, U>(handler: Handler<T>, f: (x: U) => T): Handler<U
  * Implementations of this may be synchronous, for example the port returned by [[loopback]].
  */
 export interface SendPort<Out> {
-    send(value: Out): void;
+  send(value: Out): void;
 }
 
 /**
@@ -45,9 +45,9 @@ export interface SendPort<Out> {
  * to outgoing messages _before_ they are sent on the original port.
  */
 export function mapSendPort<Out, Out2>(port: SendPort<Out>, f: (x: Out2) => Out): SendPort<Out2> {
-    return {
-        send: (value) => port.send(f(value)),
-    };
+  return {
+    send: (value) => port.send(f(value)),
+  };
 }
 
 /**
@@ -64,7 +64,7 @@ export function mapSendPort<Out, Out2>(port: SendPort<Out>, f: (x: Out2) => Out)
  * scope for this abstraction, but can be implemented by users on top of raw ports.
  */
 export interface ReceivePort<In> {
-    addHandler(handler: Handler<In>): void;
+  addHandler(handler: Handler<In>): void;
 }
 
 /**
@@ -72,12 +72,12 @@ export interface ReceivePort<In> {
  * function to incoming messages _before_ they are sent to the handlers.
  */
 export function mapReceivePort<In, In2>(
-    port: ReceivePort<In>,
-    f: (x: In) => In2
+  port: ReceivePort<In>,
+  f: (x: In) => In2
 ): ReceivePort<In2> {
-    return {
-        addHandler: (handler) => port.addHandler(mapHandler(handler, f)),
-    };
+  return {
+    addHandler: (handler) => port.addHandler(mapHandler(handler, f)),
+  };
 }
 
 /**
@@ -96,14 +96,14 @@ export interface Port<In, Out> extends SendPort<Out>, ReceivePort<In> {}
  * See [[mapSendPort]] and [[mapReceivePort]] for the components.
  */
 export function mapPort<In1, Out1, In2, Out2>(
-    port: Port<In1, Out1>,
-    inf: (in1: In1) => In2,
-    outf: (out2: Out2) => Out1
+  port: Port<In1, Out1>,
+  inf: (in1: In1) => In2,
+  outf: (out2: Out2) => Out1
 ): Port<In2, Out2> {
-    return {
-        ...mapSendPort(port, outf),
-        ...mapReceivePort(port, inf),
-    };
+  return {
+    ...mapSendPort(port, outf),
+    ...mapReceivePort(port, inf),
+  };
 }
 
 /**
@@ -113,7 +113,7 @@ export function mapPort<In1, Out1, In2, Out2>(
  * @param to port to which messages are forwarded
  */
 export function forward<InOut>(from: ReceivePort<InOut>, to: SendPort<InOut>): void {
-    from.addHandler((t) => to.send(t));
+  from.addHandler((t) => to.send(t));
 }
 
 /**
@@ -123,8 +123,8 @@ export function forward<InOut>(from: ReceivePort<InOut>, to: SendPort<InOut>): v
  * the first port to the second, and again for the other direction.
  */
 export function connect<InOut>(port1: Port<InOut, InOut>, port2: Port<InOut, InOut>): void {
-    forward(port1, port2);
-    forward(port2, port1);
+  forward(port1, port2);
+  forward(port2, port1);
 }
 
 /**
@@ -135,15 +135,15 @@ export function connect<InOut>(port1: Port<InOut, InOut>, port2: Port<InOut, InO
  * Communication is fully synchronous.
  */
 export function loopback<InOut>(): [SendPort<InOut>, ReceivePort<InOut>] {
-    const handlers: Handler<InOut>[] = [];
-    return [
-        {
-            send: (value) => handlers.forEach((handler) => handler(value)),
-        },
-        {
-            addHandler: (handler) => handlers.push(handler),
-        },
-    ];
+  const handlers: Handler<InOut>[] = [];
+  return [
+    {
+      send: (value) => handlers.forEach((handler) => handler(value)),
+    },
+    {
+      addHandler: (handler) => handlers.push(handler),
+    },
+  ];
 }
 
 /**
@@ -152,10 +152,10 @@ export function loopback<InOut>(): [SendPort<InOut>, ReceivePort<InOut>] {
  * The resulting port shares the implementation of the underlying half ports.
  */
 export function join<In, Out>(send: SendPort<Out>, receive: ReceivePort<In>): Port<In, Out> {
-    return {
-        send: (out: Out) => send.send(out),
-        addHandler: (handler: Handler<In>) => receive.addHandler(handler),
-    };
+  return {
+    send: (out: Out) => send.send(out),
+    addHandler: (handler: Handler<In>) => receive.addHandler(handler),
+  };
 }
 
 /**
@@ -165,14 +165,14 @@ export function join<In, Out>(send: SendPort<Out>, receive: ReceivePort<In>): Po
  * This function is the dual to [[SendPort.send]] because it allows to observe exactly one message.
  */
 export function receiveSingle<In>(port: ReceivePort<In>): Promise<In> {
-    return new Promise((resolve) => {
-        let done = false;
-        const handler: Handler<In> = (data) => {
-            if (done) return;
+  return new Promise((resolve) => {
+    let done = false;
+    const handler: Handler<In> = (data) => {
+      if (done) return;
 
-            done = true;
-            resolve(data);
-        };
-        port.addHandler(handler);
-    });
+      done = true;
+      resolve(data);
+    };
+    port.addHandler(handler);
+  });
 }

--- a/platform/feature-api/communication/port-authority/src/procedure.ts
+++ b/platform/feature-api/communication/port-authority/src/procedure.ts
@@ -40,9 +40,9 @@ import { Handler, Port, ReceivePort, SendPort } from "./port";
  * [Promise specification](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
  */
 export interface PromiseResolvers<Res> {
-    resolve(t: Res | Promise<Res>): void;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    reject(err?: any): void;
+  resolve(t: Res | Promise<Res>): void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reject(err?: any): void;
 }
 
 /**
@@ -50,8 +50,8 @@ export interface PromiseResolvers<Res> {
  * semantics is that the object is a _request_ and that the response is set through the callbacks.
  */
 export interface WithResolvers<Req, Res> {
-    request: Req;
-    resolvers: PromiseResolvers<Res>;
+  request: Req;
+  resolvers: PromiseResolvers<Res>;
 }
 
 /**
@@ -91,13 +91,13 @@ export type Procedure<Req, Res> = (req: Req) => Promise<Res>;
  * @returns a function that can be used to transparently send messages over a [[RequestPort]] and await the response
  */
 export function client<Req, Res>(port: RequestPort<Req, Res>): Procedure<Req, Res> {
-    return (req) =>
-        new Promise<Res>((resolve, reject) => {
-            port.send({
-                request: req,
-                resolvers: { resolve, reject },
-            });
-        });
+  return (req) =>
+    new Promise<Res>((resolve, reject) => {
+      port.send({
+        request: req,
+        resolvers: { resolve, reject },
+      });
+    });
 }
 
 /**
@@ -123,25 +123,25 @@ export function client<Req, Res>(port: RequestPort<Req, Res>): Procedure<Req, Re
  * @param procedure the function that is called for each incoming message
  */
 export function server<Req, Res>(
-    port: ResponsePort<Req, Res>,
-    procedure: Procedure<Req, Res>
+  port: ResponsePort<Req, Res>,
+  procedure: Procedure<Req, Res>
 ): void {
-    port.addHandler(async (request) => {
-        try {
-            const response = await procedure(request.request);
-            request.resolvers.resolve(response);
-        } catch (err) {
-            request.resolvers.reject(err);
-        }
-    });
+  port.addHandler(async (request) => {
+    try {
+      const response = await procedure(request.request);
+      request.resolvers.resolve(response);
+    } catch (err) {
+      request.resolvers.reject(err);
+    }
+  });
 }
 
 /**
  * A simple wrapper around requests with an associated request identifier.
  */
 export interface ClientRequest<Req> {
-    request: Req;
-    id: number;
+  request: Req;
+  id: number;
 }
 
 /**
@@ -190,27 +190,27 @@ export type ServerResponse<Res> = { id: number; response: Res } | { id: number; 
  * ```
  */
 export function liftClient<Req, Res>(
-    port: Port<ServerResponse<Res>, ClientRequest<Req>>
+  port: Port<ServerResponse<Res>, ClientRequest<Req>>
 ): RequestPort<Req, Res> {
-    let id = 0;
-    const pending = new Map<number, PromiseResolvers<Res>>();
-    port.addHandler((response) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const { resolve, reject } = pending.get(response.id)!;
-        if ("error" in response) reject(response.error);
-        else resolve(response.response);
-    });
+  let id = 0;
+  const pending = new Map<number, PromiseResolvers<Res>>();
+  port.addHandler((response) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { resolve, reject } = pending.get(response.id)!;
+    if ("error" in response) reject(response.error);
+    else resolve(response.response);
+  });
 
-    return {
-        send: (req) => {
-            const currentId = ++id;
-            pending.set(currentId, req.resolvers);
-            port.send({
-                request: req.request,
-                id: currentId,
-            });
-        },
-    };
+  return {
+    send: (req) => {
+      const currentId = ++id;
+      pending.set(currentId, req.resolvers);
+      port.send({
+        request: req.request,
+        id: currentId,
+      });
+    },
+  };
 }
 
 /**
@@ -245,36 +245,36 @@ export function liftClient<Req, Res>(
  * the same requests is generally ill-defined.
  */
 export function liftServer<Req, Res>(
-    port: Port<ClientRequest<Req>, ServerResponse<Res>>
+  port: Port<ClientRequest<Req>, ServerResponse<Res>>
 ): ResponsePort<Req, Res> {
-    let handler: Handler<WithResolvers<Req, Res>> | undefined = undefined;
+  let handler: Handler<WithResolvers<Req, Res>> | undefined = undefined;
 
-    port.addHandler(async (request) => {
-        const h = handler;
-        if (!h) return;
+  port.addHandler(async (request) => {
+    const h = handler;
+    if (!h) return;
 
-        try {
-            const response = await new Promise<Res>((resolve, reject) => {
-                h({
-                    request: request.request,
-                    resolvers: { resolve, reject },
-                });
-            });
-            port.send({
-                id: request.id,
-                response,
-            });
-        } catch (err) {
-            port.send({
-                id: request.id,
-                error: err,
-            });
-        }
-    });
+    try {
+      const response = await new Promise<Res>((resolve, reject) => {
+        h({
+          request: request.request,
+          resolvers: { resolve, reject },
+        });
+      });
+      port.send({
+        id: request.id,
+        response,
+      });
+    } catch (err) {
+      port.send({
+        id: request.id,
+        error: err,
+      });
+    }
+  });
 
-    return {
-        addHandler: (h) => {
-            if (!handler) handler = h;
-        },
-    };
+  return {
+    addHandler: (h) => {
+      if (!handler) handler = h;
+    },
+  };
 }

--- a/platform/feature-api/communication/port-authority/src/specs/port.ts
+++ b/platform/feature-api/communication/port-authority/src/specs/port.ts
@@ -9,125 +9,122 @@ chai.use(chaiAsPromised);
 export type PortSpecLifecycle = <T>() => Promise<Resource<[SendPort<T>, ReceivePort<T>]>>;
 
 interface Fixture<T> {
-    send: SendPort<T>;
-    receive: ReceivePort<T>;
-    cleanup(): Promise<void>;
+  send: SendPort<T>;
+  receive: ReceivePort<T>;
+  cleanup(): Promise<void>;
 }
 
 export class PortSpec<T> {
-    constructor(
-        private readonly lifecycle: PortSpecLifecycle,
-        private readonly gen: Arbitrary<T>
-    ) {}
+  constructor(private readonly lifecycle: PortSpecLifecycle, private readonly gen: Arbitrary<T>) {}
 
-    private async createFixture(): Promise<Fixture<T>> {
-        const result = await this.lifecycle<T>();
-        return {
-            send: result.value[0],
-            receive: result.value[1],
-            cleanup: async () => {
-                if (result.cleanup) await result.cleanup();
-            },
-        };
-    }
+  private async createFixture(): Promise<Fixture<T>> {
+    const result = await this.lifecycle<T>();
+    return {
+      send: result.value[0],
+      receive: result.value[1],
+      cleanup: async () => {
+        if (result.cleanup) await result.cleanup();
+      },
+    };
+  }
 
-    run(): void {
-        it("Transmits messages", async () => {
-            let fixture: Fixture<T>;
+  run(): void {
+    it("Transmits messages", async () => {
+      let fixture: Fixture<T>;
 
-            const prop = fc.asyncProperty(this.gen, async (t) => {
-                const received = new Promise<T>((resolve) => {
-                    fixture.receive.addHandler(resolve);
-                });
-
-                fixture.send.send(t);
-
-                await assert.eventually.deepEqual(received, t);
-            });
-
-            await fc.assert(
-                prop
-                    .beforeEach(async () => {
-                        fixture = await this.createFixture();
-                    })
-                    .afterEach(() => fixture.cleanup())
-            );
+      const prop = fc.asyncProperty(this.gen, async (t) => {
+        const received = new Promise<T>((resolve) => {
+          fixture.receive.addHandler(resolve);
         });
 
-        it("Transmits messages to multiple handlers", async () => {
-            let fixture: Fixture<T>;
+        fixture.send.send(t);
 
-            const prop = fc.asyncProperty(this.gen, fc.integer(0, 10), async (t, count) => {
-                const promises: Promise<T>[] = [];
-                for (let i = 0; i < count; ++i)
-                    promises.push(
-                        new Promise<T>((resolve) => {
-                            fixture.receive.addHandler(resolve);
-                        })
-                    );
+        await assert.eventually.deepEqual(received, t);
+      });
 
-                fixture.send.send(t);
+      await fc.assert(
+        prop
+          .beforeEach(async () => {
+            fixture = await this.createFixture();
+          })
+          .afterEach(() => fixture.cleanup())
+      );
+    });
 
-                for (const p of promises) await assert.eventually.deepEqual(p, t);
-            });
+    it("Transmits messages to multiple handlers", async () => {
+      let fixture: Fixture<T>;
 
-            await fc.assert(
-                prop
-                    .beforeEach(async () => {
-                        fixture = await this.createFixture();
-                    })
-                    .afterEach(() => fixture.cleanup())
-            );
+      const prop = fc.asyncProperty(this.gen, fc.integer(0, 10), async (t, count) => {
+        const promises: Promise<T>[] = [];
+        for (let i = 0; i < count; ++i)
+          promises.push(
+            new Promise<T>((resolve) => {
+              fixture.receive.addHandler(resolve);
+            })
+          );
+
+        fixture.send.send(t);
+
+        for (const p of promises) await assert.eventually.deepEqual(p, t);
+      });
+
+      await fc.assert(
+        prop
+          .beforeEach(async () => {
+            fixture = await this.createFixture();
+          })
+          .afterEach(() => fixture.cleanup())
+      );
+    });
+
+    it("Transmits multiple messages", async () => {
+      let fixture: Fixture<T>;
+
+      const prop = fc.asyncProperty(fc.array(this.gen), async (ts) => {
+        const count = ts.length;
+        fc.pre(count > 0);
+
+        const received = new Promise<T[]>((resolve) => {
+          const elements: T[] = [];
+          fixture.receive.addHandler((t) => {
+            elements.push(t);
+            if (elements.length === count) resolve(elements);
+          });
         });
 
-        it("Transmits multiple messages", async () => {
-            let fixture: Fixture<T>;
+        for (const t of ts) fixture.send.send(t);
 
-            const prop = fc.asyncProperty(fc.array(this.gen), async (ts) => {
-                const count = ts.length;
-                fc.pre(count > 0);
+        assert.sameDeepMembers(await received, ts);
+      });
 
-                const received = new Promise<T[]>((resolve) => {
-                    const elements: T[] = [];
-                    fixture.receive.addHandler((t) => {
-                        elements.push(t);
-                        if (elements.length === count) resolve(elements);
-                    });
-                });
-
-                for (const t of ts) fixture.send.send(t);
-
-                assert.sameDeepMembers(await received, ts);
-            });
-
-            await fc.assert(
-                prop
-                    .beforeEach(async () => {
-                        fixture = await this.createFixture();
-                    })
-                    .afterEach(() => fixture.cleanup())
-            );
-        });
-    }
+      await fc.assert(
+        prop
+          .beforeEach(async () => {
+            fixture = await this.createFixture();
+          })
+          .afterEach(() => fixture.cleanup())
+      );
+    });
+  }
 }
 
 export function portSpec(lifecycle: PortSpecLifecycle): void {
-    describe("number", () => {
-        new PortSpec(lifecycle, fc.integer()).run();
-    });
+  describe("number", () => {
+    new PortSpec(lifecycle, fc.integer()).run();
+  });
 
-    describe("string", () => {
-        new PortSpec(lifecycle, fc.string()).run();
-    });
+  describe("string", () => {
+    new PortSpec(lifecycle, fc.string()).run();
+  });
 
-    describe("Array<number | string>", () => {
-        new PortSpec(lifecycle, fc.array(fc.oneof(fc.integer(), fc.string()))).run();
-    });
+  describe("Array<number | string>", () => {
+    new PortSpec(lifecycle, fc.array(fc.oneof(fc.integer(), fc.string()))).run();
+  });
 
-    describe("Uint8Array", () => {
-        new PortSpec(
-            lifecycle,
-            fc.array(fc.integer(0, 255)).map((array) => Uint8Array.from(array))
-        ).run();
-    });
+  describe("Uint8Array", () => {
+    new PortSpec(
+      lifecycle,
+      fc.array(fc.integer(0, 255)).map((array) => Uint8Array.from(array))
+    ).run();
+  });
 }

--- a/platform/feature-api/communication/port-authority/src/specs/procedure.ts
+++ b/platform/feature-api/communication/port-authority/src/specs/procedure.ts
@@ -8,83 +8,83 @@ chai.use(chaiAsPromised);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const procs: Record<string, Procedure<any, any>> = {
-    "number => number (success)": async (n: number) => n + 1,
-    "number => number (fail-on-odd)": async (n: number) => {
-        if (n % 2 == 0) return n - 1;
-        else throw "odd";
-    },
+  "number => number (success)": async (n: number) => n + 1,
+  "number => number (fail-on-odd)": async (n: number) => {
+    if (n % 2 == 0) return n - 1;
+    else throw "odd";
+  },
 };
 
 function probeFunctionEquality<T, U>(
-    f1: (t: T) => Promise<U>,
-    f2: (t: T) => Promise<U>,
-    gen: Arbitrary<T>
+  f1: (t: T) => Promise<U>,
+  f2: (t: T) => Promise<U>,
+  gen: Arbitrary<T>
 ): IAsyncProperty<[T]> {
-    return fc.asyncProperty(gen, async (t) => {
-        assert.deepEqual(await recoverPromise(f1(t)), await recoverPromise(f2(t)));
-    });
+  return fc.asyncProperty(gen, async (t) => {
+    assert.deepEqual(await recoverPromise(f1(t)), await recoverPromise(f2(t)));
+  });
 }
 
 export type ProcedureSpecLifecycle = <T, U>() => Promise<
-    Resource<[RequestPort<T, U>, ResponsePort<T, U>]>
+  Resource<[RequestPort<T, U>, ResponsePort<T, U>]>
 >;
 
 export class ProcedureSpec<T, U> {
-    constructor(
-        private readonly lifecycle: ProcedureSpecLifecycle,
-        private readonly proc: Procedure<T, U>,
-        private readonly gen: Arbitrary<T>
-    ) {}
+  constructor(
+    private readonly lifecycle: ProcedureSpecLifecycle,
+    private readonly proc: Procedure<T, U>,
+    private readonly gen: Arbitrary<T>
+  ) {}
 
-    run(): void {
-        let send: RequestPort<T, U>;
-        let receive: ResponsePort<T, U>;
-        let cleanup: () => Promise<void>;
+  run(): void {
+    let send: RequestPort<T, U>;
+    let receive: ResponsePort<T, U>;
+    let cleanup: () => Promise<void>;
 
-        beforeEach(async () => {
-            const result = await this.lifecycle<T, U>();
-            send = result.value[0];
-            receive = result.value[1];
-            cleanup = async () => {
-                if (result.cleanup) await result.cleanup();
-            };
-        });
+    beforeEach(async () => {
+      const result = await this.lifecycle<T, U>();
+      send = result.value[0];
+      receive = result.value[1];
+      cleanup = async () => {
+        if (result.cleanup) await result.cleanup();
+      };
+    });
 
-        afterEach(async () => {
-            await cleanup();
-        });
+    afterEach(async () => {
+      await cleanup();
+    });
 
-        it("Emulates reference function", async () => {
-            server(receive, this.proc);
+    it("Emulates reference function", async () => {
+      server(receive, this.proc);
 
-            await fc.assert(probeFunctionEquality<T, U>(client(send), this.proc, this.gen));
-        });
+      await fc.assert(probeFunctionEquality<T, U>(client(send), this.proc, this.gen));
+    });
 
-        it("Ignores additional handlers", async () => {
-            // TODO multiplexing behaviour?
+    it("Ignores additional handlers", async () => {
+      // TODO multiplexing behaviour?
 
-            let called = false;
+      let called = false;
 
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const mockP: Procedure<any, any> = async () => {
-                called = true;
-            };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockP: Procedure<any, any> = async () => {
+        called = true;
+      };
 
-            server(receive, this.proc);
-            server(receive, mockP);
+      server(receive, this.proc);
+      server(receive, mockP);
 
-            await fc.assert(probeFunctionEquality<T, U>(client(send), this.proc, this.gen));
+      await fc.assert(probeFunctionEquality<T, U>(client(send), this.proc, this.gen));
 
-            assert.isFalse(called);
-        });
-    }
+      assert.isFalse(called);
+    });
+  }
 }
 
 export function procedureSpec(lifecycle: ProcedureSpecLifecycle): void {
-    const gen = fc.integer(0, 100);
+  const gen = fc.integer(0, 100);
 
-    for (const [label, proc] of Object.entries(procs))
-        describe(label, () => {
-            new ProcedureSpec(lifecycle, proc, gen).run();
-        });
+  for (const [label, proc] of Object.entries(procs))
+    describe(label, () => {
+      new ProcedureSpec(lifecycle, proc, gen).run();
+    });
 }

--- a/platform/feature-api/communication/port-authority/src/tests/_lifecycles.ts
+++ b/platform/feature-api/communication/port-authority/src/tests/_lifecycles.ts
@@ -6,77 +6,77 @@ import { Bubblewrap } from "@polypoly-eu/bubblewrap";
 import { mapResource, Resource } from "../util";
 
 export const loopbackLifecycle: PortSpecLifecycle = async () => ({
-    value: loopback(),
+  value: loopback(),
 });
 
 export function forwardLifecycle(l1: PortSpecLifecycle, l2: PortSpecLifecycle): PortSpecLifecycle {
-    return async <T>() => {
-        const ports1 = await l1<T>();
-        const ports2 = await l2<T>();
+  return async <T>() => {
+    const ports1 = await l1<T>();
+    const ports2 = await l2<T>();
 
-        const [p1Send, p1Recv] = ports1.value;
-        const [p2Send, p2Recv] = ports2.value;
+    const [p1Send, p1Recv] = ports1.value;
+    const [p2Send, p2Recv] = ports2.value;
 
-        forward(p1Recv, p2Send);
+    forward(p1Recv, p2Send);
 
-        return {
-            value: [p1Send, p2Recv],
-            cleanup: async () => {
-                if (ports1.cleanup) await ports1.cleanup();
-                if (ports2.cleanup) await ports2.cleanup();
-            },
-        };
+    return {
+      value: [p1Send, p2Recv],
+      cleanup: async () => {
+        if (ports1.cleanup) await ports1.cleanup();
+        if (ports2.cleanup) await ports2.cleanup();
+      },
     };
+  };
 }
 
 export function bubblewrapLifecycle(
-    l: PortSpecLifecycle,
-    bubblewrap: Bubblewrap
+  l: PortSpecLifecycle,
+  bubblewrap: Bubblewrap
 ): PortSpecLifecycle {
-    return async () => {
-        const ports = await l<Uint8Array>();
-        return mapResource(ports, ([send, recv]) => {
-            return [
-                mapSendPort(send, (data) => bubblewrap.encode(data)),
-                mapReceivePort(recv, (buf) => bubblewrap.decode(buf)),
-            ];
-        });
-    };
+  return async () => {
+    const ports = await l<Uint8Array>();
+    return mapResource(ports, ([send, recv]) => {
+      return [
+        mapSendPort(send, (data) => bubblewrap.encode(data)),
+        mapReceivePort(recv, (buf) => bubblewrap.decode(buf)),
+      ];
+    });
+  };
 }
 
 export function flipLifecycle(
-    l: <T>() => Promise<Resource<[Port<T, T>, Port<T, T>]>>
+  l: <T>() => Promise<Resource<[Port<T, T>, Port<T, T>]>>
 ): PortSpecLifecycle {
-    return async <T>() => {
-        const ports = await l<T>();
-        const [p1, p2] = ports.value;
+  return async <T>() => {
+    const ports = await l<T>();
+    const [p1, p2] = ports.value;
 
-        return {
-            value: [p2, p1],
-            cleanup: async () => {
-                if (ports.cleanup) await ports.cleanup();
-            },
-        };
+    return {
+      value: [p2, p1],
+      cleanup: async () => {
+        if (ports.cleanup) await ports.cleanup();
+      },
     };
+  };
 }
 
 export function procedureLiftedLifecycle(l: PortSpecLifecycle): ProcedureSpecLifecycle {
-    return async <T, U>() => {
-        const clientL = await l<ClientRequest<T>>();
-        const serverL = await l<ServerResponse<U>>();
+  return async <T, U>() => {
+    const clientL = await l<ClientRequest<T>>();
+    const serverL = await l<ServerResponse<U>>();
 
-        const [clientSend, serverReceive] = clientL.value;
-        const [serverSend, clientReceive] = serverL.value;
+    const [clientSend, serverReceive] = clientL.value;
+    const [serverSend, clientReceive] = serverL.value;
 
-        const clientPort = join(clientSend, clientReceive);
-        const serverPort = join(serverSend, serverReceive);
+    const clientPort = join(clientSend, clientReceive);
+    const serverPort = join(serverSend, serverReceive);
 
-        return {
-            value: [liftClient(clientPort), liftServer(serverPort)],
-            cleanup: async () => {
-                if (clientL.cleanup) await clientL.cleanup();
-                if (serverL.cleanup) await serverL.cleanup();
-            },
-        };
+    return {
+      value: [liftClient(clientPort), liftServer(serverPort)],
+      cleanup: async () => {
+        if (clientL.cleanup) await clientL.cleanup();
+        if (serverL.cleanup) await serverL.cleanup();
+      },
     };
+  };
 }

--- a/platform/feature-api/communication/port-authority/src/tests/browser/_common.ts
+++ b/platform/feature-api/communication/port-authority/src/tests/browser/_common.ts
@@ -3,27 +3,27 @@ import { fromBrowserMessagePort } from "../../browser";
 import { Resource } from "../../util";
 
 export async function browserLoopbackLifecycle<T, U>(): Promise<
-    Resource<[Port<T, U>, Port<U, T>]>
+  Resource<[Port<T, U>, Port<U, T>]>
 > {
-    const { port1, port2 } = new MessageChannel();
-    port1.start();
-    port2.start();
-    return {
-        value: [
-            mapPort(
-                fromBrowserMessagePort(port1),
-                (event) => event.data as T,
-                (u) => u
-            ),
-            mapPort(
-                fromBrowserMessagePort(port2),
-                (event) => event.data as U,
-                (t) => t
-            ),
-        ],
-        cleanup: async () => {
-            port1.close();
-            port2.close();
-        },
-    };
+  const { port1, port2 } = new MessageChannel();
+  port1.start();
+  port2.start();
+  return {
+    value: [
+      mapPort(
+        fromBrowserMessagePort(port1),
+        (event) => event.data as T,
+        (u) => u
+      ),
+      mapPort(
+        fromBrowserMessagePort(port2),
+        (event) => event.data as U,
+        (t) => t
+      ),
+    ],
+    cleanup: async () => {
+      port1.close();
+      port2.close();
+    },
+  };
 }

--- a/platform/feature-api/communication/port-authority/src/tests/browser/port.test.ts
+++ b/platform/feature-api/communication/port-authority/src/tests/browser/port.test.ts
@@ -3,11 +3,11 @@ import { forwardLifecycle } from "../_lifecycles";
 import { browserLoopbackLifecycle } from "./_common";
 
 describe("Browser", () => {
-    describe("Loopback", () => {
-        portSpec(browserLoopbackLifecycle);
-    });
+  describe("Loopback", () => {
+    portSpec(browserLoopbackLifecycle);
+  });
 
-    describe("Forward", () => {
-        portSpec(forwardLifecycle(browserLoopbackLifecycle, browserLoopbackLifecycle));
-    });
+  describe("Forward", () => {
+    portSpec(forwardLifecycle(browserLoopbackLifecycle, browserLoopbackLifecycle));
+  });
 });

--- a/platform/feature-api/communication/port-authority/src/tests/browser/procedure.test.ts
+++ b/platform/feature-api/communication/port-authority/src/tests/browser/procedure.test.ts
@@ -3,7 +3,7 @@ import { procedureSpec } from "../../specs/procedure";
 import { procedureLiftedLifecycle } from "../_lifecycles";
 
 describe("Browser/Procedure", () => {
-    describe("lifted", () => {
-        procedureSpec(procedureLiftedLifecycle(browserLoopbackLifecycle));
-    });
+  describe("lifted", () => {
+    procedureSpec(procedureLiftedLifecycle(browserLoopbackLifecycle));
+  });
 });

--- a/platform/feature-api/communication/port-authority/src/tests/node/_common.ts
+++ b/platform/feature-api/communication/port-authority/src/tests/node/_common.ts
@@ -4,12 +4,12 @@ import { fromNodeMessagePort } from "../../node";
 import { Resource } from "../../util";
 
 export async function nodeLoopbackLifecycle<T, U>(): Promise<Resource<[Port<T, U>, Port<U, T>]>> {
-    const { port1, port2 } = new MessageChannel();
-    return {
-        value: [fromNodeMessagePort(port1) as Port<T, U>, fromNodeMessagePort(port2) as Port<U, T>],
-        cleanup: async () => {
-            port1.close();
-            port2.close();
-        },
-    };
+  const { port1, port2 } = new MessageChannel();
+  return {
+    value: [fromNodeMessagePort(port1) as Port<T, U>, fromNodeMessagePort(port2) as Port<U, T>],
+    cleanup: async () => {
+      port1.close();
+      port2.close();
+    },
+  };
 }

--- a/platform/feature-api/communication/port-authority/src/tests/node/port.test.ts
+++ b/platform/feature-api/communication/port-authority/src/tests/node/port.test.ts
@@ -3,15 +3,15 @@ import { forwardLifecycle, flipLifecycle } from "../_lifecycles";
 import { nodeLoopbackLifecycle } from "./_common";
 
 describe("Node/Port", () => {
-    describe("Loopback", () => {
-        portSpec(nodeLoopbackLifecycle);
+  describe("Loopback", () => {
+    portSpec(nodeLoopbackLifecycle);
 
-        describe("Flipped", () => {
-            portSpec(flipLifecycle(nodeLoopbackLifecycle));
-        });
+    describe("Flipped", () => {
+      portSpec(flipLifecycle(nodeLoopbackLifecycle));
     });
+  });
 
-    describe("Forward", () => {
-        portSpec(forwardLifecycle(nodeLoopbackLifecycle, nodeLoopbackLifecycle));
-    });
+  describe("Forward", () => {
+    portSpec(forwardLifecycle(nodeLoopbackLifecycle, nodeLoopbackLifecycle));
+  });
 });

--- a/platform/feature-api/communication/port-authority/src/tests/node/procedure.test.ts
+++ b/platform/feature-api/communication/port-authority/src/tests/node/procedure.test.ts
@@ -11,81 +11,81 @@ import { Bubblewrap } from "@polypoly-eu/bubblewrap";
 import fetch from "node-fetch";
 
 async function startServer(app: RequestListener): Promise<[Server, number]> {
-    const server = createServer(app);
+  const server = createServer(app);
 
-    await new Promise((resolve) => {
-        server.listen();
-        server.once("listening", () => resolve(server));
-    });
+  await new Promise((resolve) => {
+    server.listen();
+    server.once("listening", () => resolve(server));
+  });
 
-    const port = (server.address() as AddressInfo).port;
+  const port = (server.address() as AddressInfo).port;
 
-    return [server, port];
+  return [server, port];
 }
 
 function stopServer(server: Server): Promise<void> {
-    return new Promise((resolve) => {
-        server.close(() => resolve());
-    });
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
 }
 
 const jsonHttpLifecycle: ProcedureSpecLifecycle = async () => {
-    const [app, receive] = jsonMiddlewarePort();
-    const [server, port] = await startServer(app);
+  const [app, receive] = jsonMiddlewarePort();
+  const [server, port] = await startServer(app);
 
-    const send = jsonFetchPort(`http://localhost:${port}/`, fetch);
+  const send = jsonFetchPort(`http://localhost:${port}/`, fetch);
 
-    return {
-        value: [send, receive],
-        cleanup: () => stopServer(server),
-    };
+  return {
+    value: [send, receive],
+    cleanup: () => stopServer(server),
+  };
 };
 
 const rawHttpLifecycle: ProcedureSpecLifecycle = async () => {
-    const bubblewrap = Bubblewrap.create();
+  const bubblewrap = Bubblewrap.create();
 
-    const [app, receive] = bubblewrapMiddlewarePort(bubblewrap);
-    const [server, port] = await startServer(app);
+  const [app, receive] = bubblewrapMiddlewarePort(bubblewrap);
+  const [server, port] = await startServer(app);
 
-    const send = bubblewrapFetchPort(`http://localhost:${port}/`, bubblewrap, fetch);
+  const send = bubblewrapFetchPort(`http://localhost:${port}/`, bubblewrap, fetch);
 
-    return {
-        value: [send, receive],
-        cleanup: () => stopServer(server),
-    };
+  return {
+    value: [send, receive],
+    cleanup: () => stopServer(server),
+  };
 };
 
 describe("Node/Procedure", () => {
-    describe("lifted", () => {
-        procedureSpec(procedureLiftedLifecycle(nodeLoopbackLifecycle));
+  describe("lifted", () => {
+    procedureSpec(procedureLiftedLifecycle(nodeLoopbackLifecycle));
+  });
+
+  describe("HTTP/fetch (JSON)", () => {
+    procedureSpec(jsonHttpLifecycle);
+  });
+
+  describe("HTTP/fetch (Uint8Array)", () => {
+    procedureSpec(rawHttpLifecycle);
+  });
+
+  describe("GET", () => {
+    let server: Server;
+    let port: number;
+
+    beforeEach(async () => {
+      const [app] = jsonMiddlewarePort();
+      const [_server, _port] = await startServer(app);
+      server = _server;
+      port = _port;
     });
 
-    describe("HTTP/fetch (JSON)", () => {
-        procedureSpec(jsonHttpLifecycle);
+    it("supports GET", async () => {
+      const response = await fetch(`http://localhost:${port}/`);
+      expect(response.ok).toBe(true);
     });
 
-    describe("HTTP/fetch (Uint8Array)", () => {
-        procedureSpec(rawHttpLifecycle);
+    afterEach(async () => {
+      await stopServer(server);
     });
-
-    describe("GET", () => {
-        let server: Server;
-        let port: number;
-
-        beforeEach(async () => {
-            const [app] = jsonMiddlewarePort();
-            const [_server, _port] = await startServer(app);
-            server = _server;
-            port = _port;
-        });
-
-        it("supports GET", async () => {
-            const response = await fetch(`http://localhost:${port}/`);
-            expect(response.ok).toBe(true);
-        });
-
-        afterEach(async () => {
-            await stopServer(server);
-        });
-    });
+  });
 });

--- a/platform/feature-api/communication/port-authority/src/tests/universal/port.test.ts
+++ b/platform/feature-api/communication/port-authority/src/tests/universal/port.test.ts
@@ -8,23 +8,23 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 
 describe("Universal/Port", () => {
-    describe("Loopback", () => {
-        portSpec(loopbackLifecycle);
-    });
+  describe("Loopback", () => {
+    portSpec(loopbackLifecycle);
+  });
 
-    describe("Bubblewrap", () => {
-        portSpec(bubblewrapLifecycle(loopbackLifecycle, Bubblewrap.create()));
-    });
+  describe("Bubblewrap", () => {
+    portSpec(bubblewrapLifecycle(loopbackLifecycle, Bubblewrap.create()));
+  });
 
-    describe("Forward", () => {
-        portSpec(forwardLifecycle(loopbackLifecycle, loopbackLifecycle));
-    });
+  describe("Forward", () => {
+    portSpec(forwardLifecycle(loopbackLifecycle, loopbackLifecycle));
+  });
 
-    it("receiveSingle", async () => {
-        const [send, receive] = (await loopbackLifecycle<number>()).value;
-        const promise = receiveSingle(receive);
-        send.send(1);
-        send.send(2);
-        await assert.eventually.equal(promise, 1);
-    });
+  it("receiveSingle", async () => {
+    const [send, receive] = (await loopbackLifecycle<number>()).value;
+    const promise = receiveSingle(receive);
+    send.send(1);
+    send.send(2);
+    await assert.eventually.equal(promise, 1);
+  });
 });

--- a/platform/feature-api/communication/port-authority/src/tests/universal/procedure.test.ts
+++ b/platform/feature-api/communication/port-authority/src/tests/universal/procedure.test.ts
@@ -2,7 +2,7 @@ import { loopbackLifecycle, procedureLiftedLifecycle } from "../_lifecycles";
 import { procedureSpec } from "../../specs/procedure";
 
 describe("Universal/Procedure", () => {
-    describe("lift", () => {
-        procedureSpec(procedureLiftedLifecycle(loopbackLifecycle));
-    });
+  describe("lift", () => {
+    procedureSpec(procedureLiftedLifecycle(loopbackLifecycle));
+  });
 });

--- a/platform/feature-api/communication/port-authority/src/util.ts
+++ b/platform/feature-api/communication/port-authority/src/util.ts
@@ -8,16 +8,16 @@
  * An interface representing a successful computation.
  */
 export interface Success<T> {
-    tag: "success";
-    value: T;
+  tag: "success";
+  value: T;
 }
 
 /**
  * An interface representing a failed computation.
  */
 export interface Failure {
-    tag: "failure";
-    err: unknown;
+  tag: "failure";
+  err: unknown;
 }
 
 /**
@@ -34,8 +34,8 @@ export type Try<T> = Success<T> | Failure;
  * See [[recoverPromise]] for the inverse operation.
  */
 export async function rethrowPromise<T>(t: Try<T>): Promise<T> {
-    if (t.tag === "success") return t.value;
-    else throw t.err;
+  if (t.tag === "success") return t.value;
+  else throw t.err;
 }
 
 /**
@@ -45,31 +45,31 @@ export async function rethrowPromise<T>(t: Try<T>): Promise<T> {
  * See [[rethrowPromise]] for the inverse operation.
  */
 export async function recoverPromise<T>(p: Promise<T>): Promise<Try<T>> {
-    try {
-        return {
-            tag: "success",
-            value: await p,
-        };
-    } catch (err) {
-        return {
-            tag: "failure",
-            err,
-        };
-    }
+  try {
+    return {
+      tag: "success",
+      value: await p,
+    };
+  } catch (err) {
+    return {
+      tag: "failure",
+      err,
+    };
+  }
 }
 
 /** @ignore */
 export interface Resource<T> {
-    value: T;
-    cleanup?: () => Promise<void>;
+  value: T;
+  cleanup?: () => Promise<void>;
 }
 
 /** @ignore */
 export function mapResource<T, U>(resource: Resource<T>, f: (t: T) => U): Resource<U> {
-    return {
-        value: f(resource.value),
-        cleanup: async () => {
-            if (resource.cleanup) await resource.cleanup();
-        },
-    };
+  return {
+    value: f(resource.value),
+    cleanup: async () => {
+      if (resource.cleanup) await resource.cleanup();
+    },
+  };
 }

--- a/platform/feature-api/communication/postoffice/.editorconfig
+++ b/platform/feature-api/communication/postoffice/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+max_line_length = 100

--- a/platform/feature-api/communication/postoffice/src/protocol.ts
+++ b/platform/feature-api/communication/postoffice/src/protocol.ts
@@ -15,9 +15,9 @@
  * A function call representing the name of a method (of type string) and an array of arguments (of any type).
  */
 export interface EndpointRequestPart {
-    readonly method: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readonly args: ReadonlyArray<any>;
+  readonly method: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly args: ReadonlyArray<any>;
 }
 
 /**

--- a/platform/feature-api/communication/postoffice/src/tests/rpc.test.ts
+++ b/platform/feature-api/communication/postoffice/src/tests/rpc.test.ts
@@ -2,46 +2,46 @@ import { endpointClient, endpointServer } from "../rpc";
 import { ClientOf, ObjectEndpointSpec, ServerOf, ValueEndpointSpec } from "../types";
 
 type SimpleEndpoint = ObjectEndpointSpec<{
-    test1(param1: string): ValueEndpointSpec<number>;
-    test2(param1: string): ValueEndpointSpec<number>;
-    test3(parama: boolean, ...paramb: number[]): ValueEndpointSpec<string>;
+  test1(param1: string): ValueEndpointSpec<number>;
+  test2(param1: string): ValueEndpointSpec<number>;
+  test3(parama: boolean, ...paramb: number[]): ValueEndpointSpec<string>;
 }>;
 
 const simpleEndpointImpl: ServerOf<SimpleEndpoint> = {
-    test1: (param1: string) => Promise.resolve(param1.length * 2),
-    test2: (param1: string) => param1.length * 2,
-    test3: (parama: boolean, ...paramb: number[]) =>
-        Promise.reject(new Error(`${parama}, ${paramb.join()}`)),
+  test1: (param1: string) => Promise.resolve(param1.length * 2),
+  test2: (param1: string) => param1.length * 2,
+  test3: (parama: boolean, ...paramb: number[]) =>
+    Promise.reject(new Error(`${parama}, ${paramb.join()}`)),
 };
 
 type ComplexEndpoint = ObjectEndpointSpec<{
-    simple(): SimpleEndpoint;
+  simple(): SimpleEndpoint;
 }>;
 
 const complexEndpointImpl: ServerOf<ComplexEndpoint> = {
-    simple: () => Promise.resolve(simpleEndpointImpl),
+  simple: () => Promise.resolve(simpleEndpointImpl),
 };
 
 describe("RPC", () => {
-    let rpcClient: ClientOf<ComplexEndpoint>;
+  let rpcClient: ClientOf<ComplexEndpoint>;
 
-    beforeEach(async () => {
-        rpcClient = endpointClient<ComplexEndpoint>(
-            endpointServer<ComplexEndpoint>(complexEndpointImpl)
-        );
-    });
+  beforeEach(async () => {
+    rpcClient = endpointClient<ComplexEndpoint>(
+      endpointServer<ComplexEndpoint>(complexEndpointImpl)
+    );
+  });
 
-    it("Succeeds (simple call)", async () => {
-        await expect(rpcClient.simple().test1("hi")()).resolves.toEqual(4);
-        await expect(rpcClient.simple().test2("hi")()).resolves.toEqual(4);
-    });
+  it("Succeeds (simple call)", async () => {
+    await expect(rpcClient.simple().test1("hi")()).resolves.toEqual(4);
+    await expect(rpcClient.simple().test2("hi")()).resolves.toEqual(4);
+  });
 
-    it("Succeeds (nested call)", async () => {
-        await expect(rpcClient.simple().test3(true, 0, 1)()).rejects.toThrowError("true, 0,1");
-    });
+  it("Succeeds (nested call)", async () => {
+    await expect(rpcClient.simple().test3(true, 0, 1)()).rejects.toThrowError("true, 0,1");
+  });
 
-    it("Fails (non-existent method)", async () => {
-        // @ts-ignore testing a non-existent method
-        await expect(rpcClient.whodis("lol")()).rejects.toThrowError(/not a function/);
-    });
+  it("Fails (non-existent method)", async () => {
+    // @ts-ignore testing a non-existent method
+    await expect(rpcClient.whodis("lol")()).rejects.toThrowError(/not a function/);
+  });
 });

--- a/platform/feature-api/communication/postoffice/src/tests/types.test.ts
+++ b/platform/feature-api/communication/postoffice/src/tests/types.test.ts
@@ -4,97 +4,97 @@ import { ClientOf, ObjectEndpointSpec, ServerOf, ValueEndpointSpec } from "../ty
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function check<T>(t: T): void {
-    /* intentionally left blank */
+  /* intentionally left blank */
 }
 
 declare const client1: ClientOf<ValueEndpointSpec<number>>;
 declare const client2: ClientOf<ValueEndpointSpec<Promise<number>>>;
 declare const client3: ClientOf<
-    ObjectEndpointSpec<{
-        test(): ValueEndpointSpec<number>;
-    }>
+  ObjectEndpointSpec<{
+    test(): ValueEndpointSpec<number>;
+  }>
 >;
 declare const client4: ClientOf<
-    ObjectEndpointSpec<{
-        test(): ObjectEndpointSpec<{
-            test2(): ValueEndpointSpec<number>;
-        }>;
-    }>
+  ObjectEndpointSpec<{
+    test(): ObjectEndpointSpec<{
+      test2(): ValueEndpointSpec<number>;
+    }>;
+  }>
 >;
 declare const server1: number;
 declare const server2: Promise<number>;
 declare const server3: {
-    test(): Promise<number>;
+  test(): Promise<number>;
 };
 declare const server4: {
-    test(): {
-        test2(): number;
-    };
+  test(): {
+    test2(): number;
+  };
 };
 declare const server5: {
-    test(): Promise<{
-        test2(): number;
-    }>;
+  test(): Promise<{
+    test2(): number;
+  }>;
 };
 declare const server6: {
-    test(): Promise<{
-        test2(): Promise<number>;
-    }>;
+  test(): Promise<{
+    test2(): Promise<number>;
+  }>;
 };
 
 it("Should work with complicated objects", () => {
-    expect(
-        check(() => {
-            check<Promise<number>>(client1());
+  expect(
+    check(() => {
+      check<Promise<number>>(client1());
 
-            check<Promise<number>>(client2());
+      check<Promise<number>>(client2());
 
-            check<ClientOf<ValueEndpointSpec<number>>>(client3.test());
-            check<Promise<number>>(client3.test()());
+      check<ClientOf<ValueEndpointSpec<number>>>(client3.test());
+      check<Promise<number>>(client3.test()());
 
-            check<Promise<number>>(client4.test().test2()());
+      check<Promise<number>>(client4.test().test2()());
 
-            check<ServerOf<ValueEndpointSpec<number>>>(server1);
+      check<ServerOf<ValueEndpointSpec<number>>>(server1);
 
-            check<ServerOf<ValueEndpointSpec<number>>>(server2);
+      check<ServerOf<ValueEndpointSpec<number>>>(server2);
 
-            check<
-                ServerOf<
-                    ObjectEndpointSpec<{
-                        test(): ValueEndpointSpec<number>;
-                    }>
-                >
-            >(server3);
+      check<
+        ServerOf<
+          ObjectEndpointSpec<{
+            test(): ValueEndpointSpec<number>;
+          }>
+        >
+      >(server3);
 
-            check<
-                ServerOf<
-                    ObjectEndpointSpec<{
-                        test(): ObjectEndpointSpec<{
-                            test2(): ValueEndpointSpec<number>;
-                        }>;
-                    }>
-                >
-            >(server4);
+      check<
+        ServerOf<
+          ObjectEndpointSpec<{
+            test(): ObjectEndpointSpec<{
+              test2(): ValueEndpointSpec<number>;
+            }>;
+          }>
+        >
+      >(server4);
 
-            check<
-                ServerOf<
-                    ObjectEndpointSpec<{
-                        test(): ObjectEndpointSpec<{
-                            test2(): ValueEndpointSpec<number>;
-                        }>;
-                    }>
-                >
-            >(server5);
+      check<
+        ServerOf<
+          ObjectEndpointSpec<{
+            test(): ObjectEndpointSpec<{
+              test2(): ValueEndpointSpec<number>;
+            }>;
+          }>
+        >
+      >(server5);
 
-            check<
-                ServerOf<
-                    ObjectEndpointSpec<{
-                        test(): ObjectEndpointSpec<{
-                            test2(): ValueEndpointSpec<number>;
-                        }>;
-                    }>
-                >
-            >(server6);
-        })
-    ).toBeUndefined();
+      check<
+        ServerOf<
+          ObjectEndpointSpec<{
+            test(): ObjectEndpointSpec<{
+              test2(): ValueEndpointSpec<number>;
+            }>;
+          }>
+        >
+      >(server6);
+    })
+  ).toBeUndefined();
 });

--- a/platform/feature-api/communication/postoffice/src/types.ts
+++ b/platform/feature-api/communication/postoffice/src/types.ts
@@ -16,8 +16,8 @@
  * virtual and no instances are generated.
  */
 export interface ValueEndpointSpec<T> {
-    endpointType: "value";
-    value: T;
+  endpointType: "value";
+  value: T;
 }
 
 /**
@@ -26,8 +26,8 @@ export interface ValueEndpointSpec<T> {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface ObjectEndpointSpec<T extends Record<string, (...args: any[]) => EndpointSpec>> {
-    endpointType: "object";
-    methods: T;
+  endpointType: "object";
+  methods: T;
 }
 
 /**
@@ -104,16 +104,16 @@ export type MaybePromise<T> = T | ForcePromise<T>;
  * `Promise<number>`.
  */
 export type ServerOf<Spec extends EndpointSpec> = Spec extends ValueEndpointSpec<infer T>
-    ? MaybePromise<T>
-    : Spec extends ObjectEndpointSpec<infer T>
-    ? {
-          [P in keyof T]: T[P] extends (...args: infer Args) => infer Return
-              ? Return extends EndpointSpec
-                  ? (...args: Args) => MaybePromise<ServerOf<Return>>
-                  : never
-              : never;
-      }
-    : never;
+  ? MaybePromise<T>
+  : Spec extends ObjectEndpointSpec<infer T>
+  ? {
+      [P in keyof T]: T[P] extends (...args: infer Args) => infer Return
+        ? Return extends EndpointSpec
+          ? (...args: Args) => MaybePromise<ServerOf<Return>>
+          : never
+        : never;
+    }
+  : never;
 
 /**
  * This alias denotes the “end” of a call chain. It is a function taking no
@@ -162,13 +162,13 @@ export type Callable<T> = () => ForcePromise<T>;
  * mirrors the shape of the proxy.
  */
 export type ClientOf<Spec extends EndpointSpec> = Spec extends ValueEndpointSpec<infer T>
-    ? Callable<T>
-    : Spec extends ObjectEndpointSpec<infer T>
-    ? {
-          [P in keyof T]: T[P] extends (...args: infer Args) => infer Return
-              ? Return extends EndpointSpec
-                  ? (...args: Args) => ClientOf<Return>
-                  : never
-              : never;
-      }
-    : never;
+  ? Callable<T>
+  : Spec extends ObjectEndpointSpec<infer T>
+  ? {
+      [P in keyof T]: T[P] extends (...args: infer Args) => infer Return
+        ? Return extends EndpointSpec
+          ? (...args: Args) => ClientOf<Return>
+          : never
+        : never;
+    }
+  : never;

--- a/platform/feature-api/communication/remote-pod/.editorconfig
+++ b/platform/feature-api/communication/remote-pod/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+max_line_length = 100

--- a/platform/feature-api/communication/remote-pod/src/async.ts
+++ b/platform/feature-api/communication/remote-pod/src/async.ts
@@ -1,154 +1,154 @@
 import {
-    Pod,
-    PolyOut,
-    PolyLifecycle,
-    PolyIn,
-    PolyNav,
-    ExternalFile,
-    EncodingOptions,
-    Entry,
-    Matcher,
-    Network,
-    Stats,
-    Info,
+  Pod,
+  PolyOut,
+  PolyLifecycle,
+  PolyIn,
+  PolyNav,
+  ExternalFile,
+  EncodingOptions,
+  Entry,
+  Matcher,
+  Network,
+  Stats,
+  Info,
 } from "@polypoly-eu/pod-api";
 import type { RequestInit, Response } from "@polypoly-eu/fetch-spec";
 import { DataFactory, Quad } from "rdf-js";
 
 class AsyncPolyOut implements PolyOut {
-    constructor(private readonly promise: Promise<PolyOut>) {}
+  constructor(private readonly promise: Promise<PolyOut>) {}
 
-    async fetch(input: string, init?: RequestInit): Promise<Response> {
-        return (await this.promise).fetch(input, init);
-    }
+  async fetch(input: string, init?: RequestInit): Promise<Response> {
+    return (await this.promise).fetch(input, init);
+  }
 
-    readFile(path: string, options: EncodingOptions): Promise<string>;
-    readFile(path: string): Promise<Uint8Array>;
-    async readFile(path: string, options?: EncodingOptions): Promise<string | Uint8Array> {
-        if (options) return (await this.promise).readFile(path, options);
-        else return (await this.promise).readFile(path);
-    }
+  readFile(path: string, options: EncodingOptions): Promise<string>;
+  readFile(path: string): Promise<Uint8Array>;
+  async readFile(path: string, options?: EncodingOptions): Promise<string | Uint8Array> {
+    if (options) return (await this.promise).readFile(path, options);
+    else return (await this.promise).readFile(path);
+  }
 
-    async writeFile(path: string, content: string, options: EncodingOptions): Promise<void> {
-        return (await this.promise).writeFile(path, content, options);
-    }
-    async stat(path: string): Promise<Stats> {
-        return (await this.promise).stat(path);
-    }
-    async readDir(path: string): Promise<Entry[]> {
-        return (await this.promise).readDir(path);
-    }
+  async writeFile(path: string, content: string, options: EncodingOptions): Promise<void> {
+    return (await this.promise).writeFile(path, content, options);
+  }
+  async stat(path: string): Promise<Stats> {
+    return (await this.promise).stat(path);
+  }
+  async readDir(path: string): Promise<Entry[]> {
+    return (await this.promise).readDir(path);
+  }
 
-    async importArchive(url: string): Promise<string> {
-        return (await this.promise).importArchive(url);
-    }
+  async importArchive(url: string): Promise<string> {
+    return (await this.promise).importArchive(url);
+  }
 
-    async removeArchive(fileId: string): Promise<void> {
-        return (await this.promise).removeArchive(fileId);
-    }
+  async removeArchive(fileId: string): Promise<void> {
+    return (await this.promise).removeArchive(fileId);
+  }
 }
 
 class AsyncPolyIn implements PolyIn {
-    constructor(private readonly promise: Promise<PolyIn>) {}
+  constructor(private readonly promise: Promise<PolyIn>) {}
 
-    async match(matcher: Partial<Matcher>): Promise<Quad[]> {
-        return (await this.promise).match(matcher);
-    }
+  async match(matcher: Partial<Matcher>): Promise<Quad[]> {
+    return (await this.promise).match(matcher);
+  }
 
-    async select(matcher: Partial<Matcher>): Promise<Quad[]> {
-        return (await this.promise).select(matcher);
-    }
+  async select(matcher: Partial<Matcher>): Promise<Quad[]> {
+    return (await this.promise).select(matcher);
+  }
 
-    async add(...quads: Quad[]): Promise<void> {
-        return (await this.promise).add(...quads);
-    }
+  async add(...quads: Quad[]): Promise<void> {
+    return (await this.promise).add(...quads);
+  }
 
-    async delete(...quads: Quad[]): Promise<void> {
-        return (await this.promise).delete(...quads);
-    }
+  async delete(...quads: Quad[]): Promise<void> {
+    return (await this.promise).delete(...quads);
+  }
 
-    async has(...quads: Quad[]): Promise<boolean> {
-        return (await this.promise).has(...quads);
-    }
+  async has(...quads: Quad[]): Promise<boolean> {
+    return (await this.promise).has(...quads);
+  }
 }
 
 class AsyncPolyNav implements PolyNav {
-    constructor(private readonly promise: Promise<PolyNav>) {}
+  constructor(private readonly promise: Promise<PolyNav>) {}
 
-    async openUrl(url: string): Promise<void> {
-        return (await this.promise).openUrl(url);
-    }
+  async openUrl(url: string): Promise<void> {
+    return (await this.promise).openUrl(url);
+  }
 
-    async setActiveActions(actions: string[]): Promise<void> {
-        return (await this.promise).setActiveActions(actions);
-    }
+  async setActiveActions(actions: string[]): Promise<void> {
+    return (await this.promise).setActiveActions(actions);
+  }
 
-    async setTitle(title: string): Promise<void> {
-        return (await this.promise).setTitle(title);
-    }
+  async setTitle(title: string): Promise<void> {
+    return (await this.promise).setTitle(title);
+  }
 
-    async pickFile(type?: string): Promise<ExternalFile | null> {
-        return (await this.promise).pickFile(type);
-    }
+  async pickFile(type?: string): Promise<ExternalFile | null> {
+    return (await this.promise).pickFile(type);
+  }
 }
 
 class AsyncInfo implements Info {
-    constructor(private readonly promise: Promise<Info>) {}
+  constructor(private readonly promise: Promise<Info>) {}
 
-    async getRuntime(): Promise<string> {
-        return (await this.promise).getRuntime();
-    }
+  async getRuntime(): Promise<string> {
+    return (await this.promise).getRuntime();
+  }
 
-    async getVersion(): Promise<string> {
-        return (await this.promise).getVersion();
-    }
+  async getVersion(): Promise<string> {
+    return (await this.promise).getVersion();
+  }
 }
 
 class AsyncNetwork implements Network {
-    constructor(private readonly promise: Promise<Network>) {}
+  constructor(private readonly promise: Promise<Network>) {}
 
-    async httpPost(
-        url: string,
-        body: string,
-        contentType?: string,
-        authorization?: string
-    ): Promise<string | undefined> {
-        return (await this.promise).httpPost(url, body, contentType, authorization);
-    }
+  async httpPost(
+    url: string,
+    body: string,
+    contentType?: string,
+    authorization?: string
+  ): Promise<string | undefined> {
+    return (await this.promise).httpPost(url, body, contentType, authorization);
+  }
 }
 
 class AsyncPolyLifecycle implements PolyLifecycle {
-    constructor(private readonly promise: Promise<PolyLifecycle | undefined>) {}
+  constructor(private readonly promise: Promise<PolyLifecycle | undefined>) {}
 
-    private async force(): Promise<PolyLifecycle> {
-        const lifecycle = await this.promise;
-        if (lifecycle) return lifecycle;
-        throw new Error("Lifecycle is not implemented");
-    }
+  private async force(): Promise<PolyLifecycle> {
+    const lifecycle = await this.promise;
+    if (lifecycle) return lifecycle;
+    throw new Error("Lifecycle is not implemented");
+  }
 
-    async listFeatures(): Promise<Record<string, boolean>> {
-        return (await this.force()).listFeatures();
-    }
+  async listFeatures(): Promise<Record<string, boolean>> {
+    return (await this.force()).listFeatures();
+  }
 
-    async startFeature(id: string, background: boolean): Promise<void> {
-        return (await this.force()).startFeature(id, background);
-    }
+  async startFeature(id: string, background: boolean): Promise<void> {
+    return (await this.force()).startFeature(id, background);
+  }
 }
 
 export class AsyncPod implements Pod {
-    readonly polyOut: PolyOut;
-    readonly polyIn: PolyIn;
-    readonly polyNav: PolyNav;
-    readonly info: Info;
-    readonly network: Network;
-    readonly polyLifecycle: PolyLifecycle;
+  readonly polyOut: PolyOut;
+  readonly polyIn: PolyIn;
+  readonly polyNav: PolyNav;
+  readonly info: Info;
+  readonly network: Network;
+  readonly polyLifecycle: PolyLifecycle;
 
-    constructor(private readonly promise: Promise<Pod>, public readonly dataFactory: DataFactory) {
-        this.polyOut = new AsyncPolyOut(promise.then((pod) => pod.polyOut));
-        this.polyIn = new AsyncPolyIn(promise.then((pod) => pod.polyIn));
-        this.polyNav = new AsyncPolyNav(promise.then((pod) => pod.polyNav));
-        this.info = new AsyncInfo(promise.then((pod) => pod.info));
-        this.network = new AsyncNetwork(promise.then((pod) => pod.network));
-        this.polyLifecycle = new AsyncPolyLifecycle(promise.then((pod) => pod.polyLifecycle));
-    }
+  constructor(private readonly promise: Promise<Pod>, public readonly dataFactory: DataFactory) {
+    this.polyOut = new AsyncPolyOut(promise.then((pod) => pod.polyOut));
+    this.polyIn = new AsyncPolyIn(promise.then((pod) => pod.polyIn));
+    this.polyNav = new AsyncPolyNav(promise.then((pod) => pod.polyNav));
+    this.info = new AsyncInfo(promise.then((pod) => pod.info));
+    this.network = new AsyncNetwork(promise.then((pod) => pod.network));
+    this.polyLifecycle = new AsyncPolyLifecycle(promise.then((pod) => pod.polyLifecycle));
+  }
 }

--- a/platform/feature-api/communication/remote-pod/src/bootstrap.ts
+++ b/platform/feature-api/communication/remote-pod/src/bootstrap.ts
@@ -4,6 +4,6 @@ import { RemoteClientPod } from "./remote";
 import { AsyncPod } from "./async";
 
 window.pod = new AsyncPod(
-    iframeInnerPort("").then((pod) => RemoteClientPod.fromRawPort(pod)),
-    new DataFactory(false)
+  iframeInnerPort("").then((pod) => RemoteClientPod.fromRawPort(pod)),
+  new DataFactory(false)
 );

--- a/platform/feature-api/communication/remote-pod/src/remote.ts
+++ b/platform/feature-api/communication/remote-pod/src/remote.ts
@@ -1,387 +1,385 @@
 import {
-    Pod,
-    PolyLifecycle,
-    PolyIn,
-    PolyOut,
-    PolyNav,
-    EncodingOptions,
-    ExternalFile,
-    Stats,
-    Matcher,
-    Network,
-    Info,
-    Entry,
+  Pod,
+  PolyLifecycle,
+  PolyIn,
+  PolyOut,
+  PolyNav,
+  EncodingOptions,
+  ExternalFile,
+  Stats,
+  Matcher,
+  Network,
+  Info,
+  Entry,
 } from "@polypoly-eu/pod-api";
 import type { RequestInit, Response } from "@polypoly-eu/fetch-spec";
 import { DataFactory, Quad } from "rdf-js";
 import {
-    endpointClient,
-    ClientOf,
-    ServerOf,
-    EndpointRequest,
-    EndpointResponse,
-    endpointServer,
-    ObjectEndpointSpec,
-    ValueEndpointSpec,
+  endpointClient,
+  ClientOf,
+  ServerOf,
+  EndpointRequest,
+  EndpointResponse,
+  endpointServer,
+  ObjectEndpointSpec,
+  ValueEndpointSpec,
 } from "@polypoly-eu/postoffice";
 import {
-    ResponsePort,
-    liftServer,
-    server,
-    bubblewrapFetchPort,
-    RequestPort,
-    client,
-    Port,
-    liftClient,
-    mapPort,
+  ResponsePort,
+  liftServer,
+  server,
+  bubblewrapFetchPort,
+  RequestPort,
+  client,
+  Port,
+  liftClient,
+  mapPort,
 } from "@polypoly-eu/port-authority";
 import { RequestListener } from "http";
 import * as RDF from "@polypoly-eu/rdf";
 import { Bubblewrap, Classes } from "@polypoly-eu/bubblewrap";
 
 type PolyInEndpoint = ObjectEndpointSpec<{
-    select(matcher: Partial<Matcher>): ValueEndpointSpec<Quad[]>;
-    match(matcher: Partial<Matcher>): ValueEndpointSpec<Quad[]>;
-    add(...quads: Quad[]): ValueEndpointSpec<void>;
-    delete(...quads: Quad[]): ValueEndpointSpec<void>;
-    has(...quads: Quad[]): ValueEndpointSpec<boolean>;
+  select(matcher: Partial<Matcher>): ValueEndpointSpec<Quad[]>;
+  match(matcher: Partial<Matcher>): ValueEndpointSpec<Quad[]>;
+  add(...quads: Quad[]): ValueEndpointSpec<void>;
+  delete(...quads: Quad[]): ValueEndpointSpec<void>;
+  has(...quads: Quad[]): ValueEndpointSpec<boolean>;
 }>;
 
 type PolyOutEndpoint = ObjectEndpointSpec<{
-    readDir(path: string): ValueEndpointSpec<Entry[]>;
-    readFile(path: string, options?: EncodingOptions): ValueEndpointSpec<string | Uint8Array>;
-    writeFile(path: string, content: string, options: EncodingOptions): ValueEndpointSpec<void>;
-    stat(path: string): ValueEndpointSpec<Stats>;
-    fetch(input: string, init: RequestInit): ValueEndpointSpec<Response>;
-    importArchive(url: string): ValueEndpointSpec<string>;
-    removeArchive(fileId: string): ValueEndpointSpec<void>;
+  readDir(path: string): ValueEndpointSpec<Entry[]>;
+  readFile(path: string, options?: EncodingOptions): ValueEndpointSpec<string | Uint8Array>;
+  writeFile(path: string, content: string, options: EncodingOptions): ValueEndpointSpec<void>;
+  stat(path: string): ValueEndpointSpec<Stats>;
+  fetch(input: string, init: RequestInit): ValueEndpointSpec<Response>;
+  importArchive(url: string): ValueEndpointSpec<string>;
+  removeArchive(fileId: string): ValueEndpointSpec<void>;
 }>;
 
 type PolyLifecycleEndpoint = ObjectEndpointSpec<{
-    listFeatures(): ValueEndpointSpec<Record<string, boolean>>;
-    startFeature(id: string, background: boolean): ValueEndpointSpec<void>;
+  listFeatures(): ValueEndpointSpec<Record<string, boolean>>;
+  startFeature(id: string, background: boolean): ValueEndpointSpec<void>;
 }>;
 
 type PolyNavEndpoint = ObjectEndpointSpec<{
-    openUrl(url: string): ValueEndpointSpec<void>;
-    setActiveActions(actions: string[]): ValueEndpointSpec<void>;
-    setTitle(title: string): ValueEndpointSpec<void>;
-    pickFile(type?: string): ValueEndpointSpec<ExternalFile | null>;
+  openUrl(url: string): ValueEndpointSpec<void>;
+  setActiveActions(actions: string[]): ValueEndpointSpec<void>;
+  setTitle(title: string): ValueEndpointSpec<void>;
+  pickFile(type?: string): ValueEndpointSpec<ExternalFile | null>;
 }>;
 
 type InfoEndpoint = ObjectEndpointSpec<{
-    getRuntime(): ValueEndpointSpec<string>;
-    getVersion(): ValueEndpointSpec<string>;
+  getRuntime(): ValueEndpointSpec<string>;
+  getVersion(): ValueEndpointSpec<string>;
 }>;
 
 type NetworkEndpoint = ObjectEndpointSpec<{
-    httpPost(
-        url: string,
-        body: string,
-        contentType?: string,
-        authorization?: string
-    ): ValueEndpointSpec<string | undefined>;
+  httpPost(
+    url: string,
+    body: string,
+    contentType?: string,
+    authorization?: string
+  ): ValueEndpointSpec<string | undefined>;
 }>;
 
 type PodEndpoint = ObjectEndpointSpec<{
-    polyIn(): PolyInEndpoint;
-    polyOut(): PolyOutEndpoint;
-    polyLifecycle(): PolyLifecycleEndpoint;
-    polyNav(): PolyNavEndpoint;
-    info(): InfoEndpoint;
-    network(): NetworkEndpoint;
+  polyIn(): PolyInEndpoint;
+  polyOut(): PolyOutEndpoint;
+  polyLifecycle(): PolyLifecycleEndpoint;
+  polyNav(): PolyNavEndpoint;
+  info(): InfoEndpoint;
+  network(): NetworkEndpoint;
 }>;
 
 class FetchResponse implements Response {
-    readonly ok: boolean;
-    readonly redirected: boolean;
-    readonly status: number;
-    readonly statusText: string;
-    readonly type: ResponseType;
-    readonly url: string;
+  readonly ok: boolean;
+  readonly redirected: boolean;
+  readonly status: number;
+  readonly statusText: string;
+  readonly type: ResponseType;
+  readonly url: string;
 
-    static async of(response: Response): Promise<FetchResponse> {
-        return new FetchResponse(response, await response.text());
-    }
+  static async of(response: Response): Promise<FetchResponse> {
+    return new FetchResponse(response, await response.text());
+  }
 
-    constructor(response: Response, private readonly bufferedText: string) {
-        this.ok = response.ok;
-        this.redirected = response.redirected;
-        this.status = response.status;
-        this.statusText = response.statusText;
-        this.type = response.type;
-        this.url = response.url;
-    }
+  constructor(response: Response, private readonly bufferedText: string) {
+    this.ok = response.ok;
+    this.redirected = response.redirected;
+    this.status = response.status;
+    this.statusText = response.statusText;
+    this.type = response.type;
+    this.url = response.url;
+  }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async json(): Promise<any> {
-        // JSON parse error must be asynchronous (i.e. rejected promise)
-        return JSON.parse(this.bufferedText);
-    }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async json(): Promise<any> {
+    // JSON parse error must be asynchronous (i.e. rejected promise)
+    return JSON.parse(this.bufferedText);
+  }
 
-    text(): Promise<string> {
-        return Promise.resolve(this.bufferedText);
-    }
+  text(): Promise<string> {
+    return Promise.resolve(this.bufferedText);
+  }
 }
 
 class FileStats implements Stats {
-    static of(stats: Stats): FileStats {
-        if (
-            stats.getSize !== undefined &&
-            stats.getName !== undefined &&
-            stats.getTime !== undefined &&
-            stats.getId !== undefined
-        ) {
-            return new FileStats(
-                stats.isFile(),
-                stats.isDirectory(),
-                stats.getTime(),
-                stats.getSize(),
-                stats.getName(),
-                stats.getId()
-            );
-        } else {
-            return new FileStats(stats.isFile(), stats.isDirectory(), "", 0, "", "");
-        }
+  static of(stats: Stats): FileStats {
+    if (
+      stats.getSize !== undefined &&
+      stats.getName !== undefined &&
+      stats.getTime !== undefined &&
+      stats.getId !== undefined
+    ) {
+      return new FileStats(
+        stats.isFile(),
+        stats.isDirectory(),
+        stats.getTime(),
+        stats.getSize(),
+        stats.getName(),
+        stats.getId()
+      );
+    } else {
+      return new FileStats(stats.isFile(), stats.isDirectory(), "", 0, "", "");
     }
+  }
 
-    constructor(
-        readonly file: boolean,
-        readonly directory: boolean,
-        readonly time: string,
-        readonly size: number,
-        readonly name: string,
-        readonly id: string
-    ) {}
-    isFile(): boolean {
-        return this.file;
-    }
-    isDirectory(): boolean {
-        return this.directory;
-    }
-    getTime(): string {
-        return this.time;
-    }
-    getSize(): number {
-        return this.size;
-    }
-    getName(): string {
-        return this.name;
-    }
-    getId(): string {
-        return this.id;
-    }
+  constructor(
+    readonly file: boolean,
+    readonly directory: boolean,
+    readonly time: string,
+    readonly size: number,
+    readonly name: string,
+    readonly id: string
+  ) {}
+  isFile(): boolean {
+    return this.file;
+  }
+  isDirectory(): boolean {
+    return this.directory;
+  }
+  getTime(): string {
+    return this.time;
+  }
+  getSize(): number {
+    return this.size;
+  }
+  getName(): string {
+    return this.name;
+  }
+  getId(): string {
+    return this.id;
+  }
 }
 
 export const podBubblewrapClasses: Classes = {
-    "@polypoly-eu/remote-pod.FetchResponse": FetchResponse,
-    "@polypoly-eu/remote-pod.FileStats": FileStats,
-    "@polypoly-eu/rdf.NamedNode": RDF.NamedNode,
-    "@polypoly-eu/rdf.BlankNode": RDF.BlankNode,
-    "@polypoly-eu/rdf.Literal": RDF.Literal,
-    "@polypoly-eu/rdf.Variable": RDF.Variable,
-    "@polypoly-eu/rdf.DefaultGraph": RDF.DefaultGraph,
-    "@polypoly-eu/rdf.Quad": RDF.Quad,
+  "@polypoly-eu/remote-pod.FetchResponse": FetchResponse,
+  "@polypoly-eu/remote-pod.FileStats": FileStats,
+  "@polypoly-eu/rdf.NamedNode": RDF.NamedNode,
+  "@polypoly-eu/rdf.BlankNode": RDF.BlankNode,
+  "@polypoly-eu/rdf.Literal": RDF.Literal,
+  "@polypoly-eu/rdf.Variable": RDF.Variable,
+  "@polypoly-eu/rdf.DefaultGraph": RDF.DefaultGraph,
+  "@polypoly-eu/rdf.Quad": RDF.Quad,
 };
 
 function bubblewrapPort(rawPort: Port<Uint8Array, Uint8Array>): Port<Uint8Array, Uint8Array> {
-    const podBubblewrap = Bubblewrap.create(podBubblewrapClasses);
-    return mapPort(
-        rawPort,
-        (buf) => podBubblewrap.decode(buf),
-        (data) => podBubblewrap.encode(data)
-    );
+  const podBubblewrap = Bubblewrap.create(podBubblewrapClasses);
+  return mapPort(
+    rawPort,
+    (buf) => podBubblewrap.decode(buf),
+    (data) => podBubblewrap.encode(data)
+  );
 }
 
 export class RemoteClientPod implements Pod {
-    private readonly rpcClient: ClientOf<PodEndpoint>;
+  private readonly rpcClient: ClientOf<PodEndpoint>;
 
-    static fromFetch(url: string, fetch: typeof window.fetch = window.fetch): RemoteClientPod {
-        const port = bubblewrapFetchPort(url, Bubblewrap.create(podBubblewrapClasses), fetch);
+  static fromFetch(url: string, fetch: typeof window.fetch = window.fetch): RemoteClientPod {
+    const port = bubblewrapFetchPort(url, Bubblewrap.create(podBubblewrapClasses), fetch);
 
-        return new RemoteClientPod(port);
-    }
+    return new RemoteClientPod(port);
+  }
 
-    static fromRawPort(rawPort: Port<Uint8Array, Uint8Array>): RemoteClientPod {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const wrappedPort = bubblewrapPort(rawPort) as Port<any, any>;
-        return new RemoteClientPod(liftClient(wrappedPort));
-    }
+  static fromRawPort(rawPort: Port<Uint8Array, Uint8Array>): RemoteClientPod {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wrappedPort = bubblewrapPort(rawPort) as Port<any, any>;
+    return new RemoteClientPod(liftClient(wrappedPort));
+  }
 
-    constructor(
-        private clientPort: RequestPort<EndpointRequest, EndpointResponse>,
-        public readonly dataFactory: DataFactory = RDF.dataFactory
-    ) {
-        this.rpcClient = endpointClient<PodEndpoint>(client(clientPort));
-    }
+  constructor(
+    private clientPort: RequestPort<EndpointRequest, EndpointResponse>,
+    public readonly dataFactory: DataFactory = RDF.dataFactory
+  ) {
+    this.rpcClient = endpointClient<PodEndpoint>(client(clientPort));
+  }
 
-    get polyIn(): PolyIn {
-        return {
-            add: (...quads) => this.rpcClient.polyIn().add(...quads)(),
-            match: (matcher) => this.rpcClient.polyIn().match(matcher)(),
-            select: (matcher) => this.rpcClient.polyIn().select(matcher)(),
-            delete: (...quads) => this.rpcClient.polyIn().delete(...quads)(),
-            has: (...quads) => this.rpcClient.polyIn().has(...quads)(),
-        };
-    }
+  get polyIn(): PolyIn {
+    return {
+      add: (...quads) => this.rpcClient.polyIn().add(...quads)(),
+      match: (matcher) => this.rpcClient.polyIn().match(matcher)(),
+      select: (matcher) => this.rpcClient.polyIn().select(matcher)(),
+      delete: (...quads) => this.rpcClient.polyIn().delete(...quads)(),
+      has: (...quads) => this.rpcClient.polyIn().has(...quads)(),
+    };
+  }
 
-    get polyOut(): PolyOut {
-        const { rpcClient } = this;
+  get polyOut(): PolyOut {
+    const { rpcClient } = this;
 
-        return new (class implements PolyOut {
-            fetch(input: string, init?: RequestInit): Promise<Response> {
-                return rpcClient.polyOut().fetch(input, init || {})();
-            }
+    return new (class implements PolyOut {
+      fetch(input: string, init?: RequestInit): Promise<Response> {
+        return rpcClient.polyOut().fetch(input, init || {})();
+      }
 
-            readFile(path: string, options: EncodingOptions): Promise<string>;
-            readFile(path: string): Promise<Uint8Array>;
-            readFile(path: string, options?: EncodingOptions): Promise<string | Uint8Array> {
-                if (options) return rpcClient.polyOut().readFile(path, options)();
-                else if (typeof fetch === "undefined") return rpcClient.polyOut().readFile(path)();
-                else
-                    return new Promise<Uint8Array>((resolve, reject) => {
-                        fetch(path)
-                            .then((res) => res.arrayBuffer())
-                            .then((arrBuf) => resolve(new Uint8Array(arrBuf)))
-                            .catch((err) => reject(err));
-                    });
-            }
+      readFile(path: string, options: EncodingOptions): Promise<string>;
+      readFile(path: string): Promise<Uint8Array>;
+      readFile(path: string, options?: EncodingOptions): Promise<string | Uint8Array> {
+        if (options) return rpcClient.polyOut().readFile(path, options)();
+        else if (typeof fetch === "undefined") return rpcClient.polyOut().readFile(path)();
+        else
+          return new Promise<Uint8Array>((resolve, reject) => {
+            fetch(path)
+              .then((res) => res.arrayBuffer())
+              .then((arrBuf) => resolve(new Uint8Array(arrBuf)))
+              .catch((err) => reject(err));
+          });
+      }
 
-            readDir(path: string): Promise<Entry[]> {
-                return rpcClient.polyOut().readDir(path)();
-            }
+      readDir(path: string): Promise<Entry[]> {
+        return rpcClient.polyOut().readDir(path)();
+      }
 
-            stat(path: string): Promise<Stats> {
-                return rpcClient.polyOut().stat(path)();
-            }
+      stat(path: string): Promise<Stats> {
+        return rpcClient.polyOut().stat(path)();
+      }
 
-            writeFile(path: string, content: string, options: EncodingOptions): Promise<void> {
-                return rpcClient.polyOut().writeFile(path, content, options)();
-            }
+      writeFile(path: string, content: string, options: EncodingOptions): Promise<void> {
+        return rpcClient.polyOut().writeFile(path, content, options)();
+      }
 
-            importArchive(url: string): Promise<string> {
-                return rpcClient.polyOut().importArchive(url)();
-            }
+      importArchive(url: string): Promise<string> {
+        return rpcClient.polyOut().importArchive(url)();
+      }
 
-            removeArchive(fileId: string): Promise<void> {
-                return rpcClient.polyOut().removeArchive(fileId)();
-            }
-        })();
-    }
+      removeArchive(fileId: string): Promise<void> {
+        return rpcClient.polyOut().removeArchive(fileId)();
+      }
+    })();
+  }
 
-    get polyLifecycle(): PolyLifecycle {
-        return {
-            listFeatures: () => this.rpcClient.polyLifecycle().listFeatures()(),
-            startFeature: (id, background) =>
-                this.rpcClient.polyLifecycle().startFeature(id, background)(),
-        };
-    }
+  get polyLifecycle(): PolyLifecycle {
+    return {
+      listFeatures: () => this.rpcClient.polyLifecycle().listFeatures()(),
+      startFeature: (id, background) =>
+        this.rpcClient.polyLifecycle().startFeature(id, background)(),
+    };
+  }
 
-    get polyNav(): PolyNav {
-        return {
-            openUrl: (url: string) => this.rpcClient.polyNav().openUrl(url)(),
-            setActiveActions: (actions: string[]) =>
-                this.rpcClient.polyNav().setActiveActions(actions)(),
-            setTitle: (title: string) => this.rpcClient.polyNav().setTitle(title)(),
-            pickFile: (type?: string) => this.rpcClient.polyNav().pickFile(type)(),
-        };
-    }
+  get polyNav(): PolyNav {
+    return {
+      openUrl: (url: string) => this.rpcClient.polyNav().openUrl(url)(),
+      setActiveActions: (actions: string[]) => this.rpcClient.polyNav().setActiveActions(actions)(),
+      setTitle: (title: string) => this.rpcClient.polyNav().setTitle(title)(),
+      pickFile: (type?: string) => this.rpcClient.polyNav().pickFile(type)(),
+    };
+  }
 
-    get info(): Info {
-        return {
-            getRuntime: () => this.rpcClient.info().getRuntime()(),
-            getVersion: () => this.rpcClient.info().getVersion()(),
-        };
-    }
+  get info(): Info {
+    return {
+      getRuntime: () => this.rpcClient.info().getRuntime()(),
+      getVersion: () => this.rpcClient.info().getVersion()(),
+    };
+  }
 
-    get network(): Network {
-        return {
-            httpPost: (url: string, body: string, contentType?: string, authorization?: string) =>
-                this.rpcClient.network().httpPost(url, body, contentType, authorization)(),
-        };
-    }
+  get network(): Network {
+    return {
+      httpPost: (url: string, body: string, contentType?: string, authorization?: string) =>
+        this.rpcClient.network().httpPost(url, body, contentType, authorization)(),
+    };
+  }
 }
 
 // TODO move to pod-api?
 // TODO should this throw instead?
 class DummyPolyLifecycle implements PolyLifecycle {
-    async listFeatures(): Promise<Record<string, boolean>> {
-        return {};
-    }
+  async listFeatures(): Promise<Record<string, boolean>> {
+    return {};
+  }
 
-    async startFeature(): Promise<void> {
-        return;
-    }
+  async startFeature(): Promise<void> {
+    return;
+  }
 }
 
 export class RemoteServerPod implements ServerOf<PodEndpoint> {
-    constructor(private readonly pod: Pod) {}
+  constructor(private readonly pod: Pod) {}
 
-    listen(port: ResponsePort<EndpointRequest, EndpointResponse>): void {
-        server(port, endpointServer<PodEndpoint>(this));
-    }
+  listen(port: ResponsePort<EndpointRequest, EndpointResponse>): void {
+    server(port, endpointServer<PodEndpoint>(this));
+  }
 
-    listenOnRaw(rawPort: Port<Uint8Array, Uint8Array>): void {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const wrappedPort = bubblewrapPort(rawPort) as Port<any, any>;
-        this.listen(liftServer<EndpointRequest, EndpointResponse>(wrappedPort));
-    }
+  listenOnRaw(rawPort: Port<Uint8Array, Uint8Array>): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wrappedPort = bubblewrapPort(rawPort) as Port<any, any>;
+    this.listen(liftServer<EndpointRequest, EndpointResponse>(wrappedPort));
+  }
 
-    async listenOnMiddleware(): Promise<RequestListener> {
-        const { bubblewrapMiddlewarePort } = await import("@polypoly-eu/port-authority/dist/node");
-        const [middleware, port] = bubblewrapMiddlewarePort(
-            Bubblewrap.create(podBubblewrapClasses),
-            { limit: "10mb" }
-        );
-        this.listen(port);
-        return middleware;
-    }
+  async listenOnMiddleware(): Promise<RequestListener> {
+    const { bubblewrapMiddlewarePort } = await import("@polypoly-eu/port-authority/dist/node");
+    const [middleware, port] = bubblewrapMiddlewarePort(Bubblewrap.create(podBubblewrapClasses), {
+      limit: "10mb",
+    });
+    this.listen(port);
+    return middleware;
+  }
 
-    polyOut(): ServerOf<PolyOutEndpoint> {
-        const polyOut = this.pod.polyOut;
+  polyOut(): ServerOf<PolyOutEndpoint> {
+    const polyOut = this.pod.polyOut;
 
-        // the following implementation delegates strictly to the pod that has been provided to the constructor
-        // the only difference is that `fetch` needs to return a slightly modified response
+    // the following implementation delegates strictly to the pod that has been provided to the constructor
+    // the only difference is that `fetch` needs to return a slightly modified response
 
-        return {
-            fetch: async (input, init) => {
-                const response = await polyOut.fetch(input, init);
-                return FetchResponse.of(response);
-            },
-            readFile: (path, options?) => {
-                if (options === undefined) return polyOut.readFile(path);
-                else return polyOut.readFile(path, options);
-            },
-            readDir: (path) => polyOut.readDir(path),
-            stat: async (path) => {
-                const stats = await polyOut.stat(path);
-                return FileStats.of(stats);
-            },
-            writeFile: (path, content, options) => polyOut.writeFile(path, content, options),
-            importArchive: (url) => polyOut.importArchive(url),
-            removeArchive: (fileId) => polyOut.removeArchive(fileId),
-        };
-    }
+    return {
+      fetch: async (input, init) => {
+        const response = await polyOut.fetch(input, init);
+        return FetchResponse.of(response);
+      },
+      readFile: (path, options?) => {
+        if (options === undefined) return polyOut.readFile(path);
+        else return polyOut.readFile(path, options);
+      },
+      readDir: (path) => polyOut.readDir(path),
+      stat: async (path) => {
+        const stats = await polyOut.stat(path);
+        return FileStats.of(stats);
+      },
+      writeFile: (path, content, options) => polyOut.writeFile(path, content, options),
+      importArchive: (url) => polyOut.importArchive(url),
+      removeArchive: (fileId) => polyOut.removeArchive(fileId),
+    };
+  }
 
-    polyIn(): ServerOf<PolyInEndpoint> {
-        return this.pod.polyIn;
-    }
+  polyIn(): ServerOf<PolyInEndpoint> {
+    return this.pod.polyIn;
+  }
 
-    polyLifecycle(): ServerOf<PolyLifecycleEndpoint> {
-        if (this.pod.polyLifecycle) return this.pod.polyLifecycle;
+  polyLifecycle(): ServerOf<PolyLifecycleEndpoint> {
+    if (this.pod.polyLifecycle) return this.pod.polyLifecycle;
 
-        return new DummyPolyLifecycle();
-    }
+    return new DummyPolyLifecycle();
+  }
 
-    polyNav(): ServerOf<PolyNavEndpoint> {
-        return this.pod.polyNav;
-    }
+  polyNav(): ServerOf<PolyNavEndpoint> {
+    return this.pod.polyNav;
+  }
 
-    info(): ServerOf<InfoEndpoint> {
-        return this.pod.info;
-    }
+  info(): ServerOf<InfoEndpoint> {
+    return this.pod.info;
+  }
 
-    network(): ServerOf<NetworkEndpoint> {
-        return this.pod.network;
-    }
+  network(): ServerOf<NetworkEndpoint> {
+    return this.pod.network;
+  }
 }

--- a/platform/feature-api/communication/remote-pod/src/tests/electron/bootstrap.test.ts
+++ b/platform/feature-api/communication/remote-pod/src/tests/electron/bootstrap.test.ts
@@ -13,42 +13,42 @@ import createServer from "connect";
 import { join } from "path";
 
 function assertPod(pod: DefaultPod): void {
-    const expectedQuad = dataFactory.quad(
-        dataFactory.namedNode("http://example.org/s"),
-        dataFactory.namedNode("http://example.org/p"),
-        dataFactory.namedNode("http://example.org/o")
-    );
+  const expectedQuad = dataFactory.quad(
+    dataFactory.namedNode("http://example.org/s"),
+    dataFactory.namedNode("http://example.org/p"),
+    dataFactory.namedNode("http://example.org/o")
+  );
 
-    assert.equal(pod.store.size, 1);
-    assert.isTrue(pod.store.has(expectedQuad));
+  assert.equal(pod.store.size, 1);
+  assert.isTrue(pod.store.has(expectedQuad));
 }
 
 function completion(_window: Window): Promise<void> {
-    return new Promise((resolve) => {
-        _window.addEventListener("message", (event) => {
-            if (event.data === "completed") resolve();
-        });
+  return new Promise((resolve) => {
+    _window.addEventListener("message", (event) => {
+      if (event.data === "completed") resolve();
     });
+  });
 }
 
 function assets(): RequestListener {
-    const app = createServer();
-    app.use("/feature.js", async (request: IncomingMessage, response: ServerResponse) => {
-        response.setHeader("Content-Type", "text/javascript");
-        response.writeHead(200);
-        response.write(await fs.readFile(join(__dirname, "../data/feature.js")));
-        response.end();
-    });
-    app.use("/pod.js", async (request: IncomingMessage, response: ServerResponse) => {
-        response.setHeader("Content-Type", "text/javascript");
-        response.writeHead(200);
-        response.write(await fs.readFile(join(__dirname, "../../../dist/bootstrap.js")));
-        response.end();
-    });
-    app.use("/index.html", (request: IncomingMessage, response: ServerResponse) => {
-        response.setHeader("Content-Type", "text/html");
-        response.writeHead(200);
-        response.write(`
+  const app = createServer();
+  app.use("/feature.js", async (request: IncomingMessage, response: ServerResponse) => {
+    response.setHeader("Content-Type", "text/javascript");
+    response.writeHead(200);
+    response.write(await fs.readFile(join(__dirname, "../data/feature.js")));
+    response.end();
+  });
+  app.use("/pod.js", async (request: IncomingMessage, response: ServerResponse) => {
+    response.setHeader("Content-Type", "text/javascript");
+    response.writeHead(200);
+    response.write(await fs.readFile(join(__dirname, "../../../dist/bootstrap.js")));
+    response.end();
+  });
+  app.use("/index.html", (request: IncomingMessage, response: ServerResponse) => {
+    response.setHeader("Content-Type", "text/html");
+    response.writeHead(200);
+    response.write(`
             <!DOCTYPE HTML>
             <html>
                 <body>
@@ -57,48 +57,48 @@ function assets(): RequestListener {
                 </body>
             </html>
         `);
-        response.end();
-    });
-    return app;
+    response.end();
+  });
+  return app;
 }
 
 describe("Bootstrap (Electron)", () => {
-    const port = 12345;
+  const port = 12345;
 
-    let pod: DefaultPod;
-    let server: Server;
+  let pod: DefaultPod;
+  let server: Server;
 
-    beforeEach(async () => {
-        pod = new DefaultPod(dataset(), fs as unknown as FS, fetch);
-        const app = assets();
+  beforeEach(async () => {
+    pod = new DefaultPod(dataset(), fs as unknown as FS, fetch);
+    const app = assets();
 
-        server = http.createServer(app);
-        server.listen(port);
-        await once(server, "listening");
-    });
+    server = http.createServer(app);
+    server.listen(port);
+    await once(server, "listening");
+  });
 
-    afterEach(() => {
-        server.close();
-    });
+  afterEach(() => {
+    server.close();
+  });
 
-    it("iframe", async function () {
-        this.timeout(10000);
+  it("iframe", async function () {
+    this.timeout(10000);
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const body = document.querySelector("body")!;
-        const iframe = document.createElement("iframe");
-        iframe.setAttribute("sandbox", "allow-scripts");
-        iframe.setAttribute("src", `http://localhost:${port}/index.html`);
-        iframe.onload = () => {
-            new RemoteServerPod(pod).listenOnRaw(iframeOuterPort("", iframe));
-        };
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const body = document.querySelector("body")!;
+    const iframe = document.createElement("iframe");
+    iframe.setAttribute("sandbox", "allow-scripts");
+    iframe.setAttribute("src", `http://localhost:${port}/index.html`);
+    iframe.onload = () => {
+      new RemoteServerPod(pod).listenOnRaw(iframeOuterPort("", iframe));
+    };
 
-        const finished = completion(window);
+    const finished = completion(window);
 
-        body.appendChild(iframe);
+    body.appendChild(iframe);
 
-        await finished;
+    await finished;
 
-        assertPod(pod);
-    });
+    assertPod(pod);
+  });
 });

--- a/platform/feature-api/communication/remote-pod/src/tests/node/async.test.ts
+++ b/platform/feature-api/communication/remote-pod/src/tests/node/async.test.ts
@@ -12,57 +12,57 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 
 describe("Async pod", () => {
-    const fs = new Volume().promises as unknown as FS;
-    const underlying = new DefaultPod(dataset(), fs, fetch);
+  const fs = new Volume().promises as unknown as FS;
+  const underlying = new DefaultPod(dataset(), fs, fetch);
 
-    describe("Resolved promise", () => {
-        podSpec(
-            new AsyncPod(Promise.resolve(underlying), new DataFactory(false)),
-            "/",
-            getHttpbinUrl()
-        );
+  describe("Resolved promise", () => {
+    podSpec(
+      new AsyncPod(Promise.resolve(underlying), new DataFactory(false)),
+      "/",
+      getHttpbinUrl()
+    );
+  });
+
+  describe("Delayed promise", () => {
+    const delayed = new Promise<Pod>((resolve) => {
+      setTimeout(() => resolve(underlying), 500);
     });
 
-    describe("Delayed promise", () => {
-        const delayed = new Promise<Pod>((resolve) => {
-            setTimeout(() => resolve(underlying), 500);
-        });
+    podSpec(new AsyncPod(delayed, new DataFactory(false)), "/", getHttpbinUrl());
+  });
 
-        podSpec(new AsyncPod(delayed, new DataFactory(false)), "/", getHttpbinUrl());
+  // TODO move to api, duplicated code
+  describe("Lifecycle", () => {
+    let pod: Pod;
+    let log: Array<(string | boolean)[]>;
+
+    beforeEach(() => {
+      log = [];
+      const polyLifecycle: PolyLifecycle = {
+        startFeature: async (...args) => {
+          log.push(args);
+        },
+        listFeatures: async () => ({ "test-on": true, "test-off": false }),
+      };
+      Object.assign(underlying, { polyLifecycle });
+      pod = new AsyncPod(Promise.resolve(underlying), new DataFactory(false));
     });
 
-    // TODO move to api, duplicated code
-    describe("Lifecycle", () => {
-        let pod: Pod;
-        let log: Array<(string | boolean)[]>;
-
-        beforeEach(() => {
-            log = [];
-            const polyLifecycle: PolyLifecycle = {
-                startFeature: async (...args) => {
-                    log.push(args);
-                },
-                listFeatures: async () => ({ "test-on": true, "test-off": false }),
-            };
-            Object.assign(underlying, { polyLifecycle });
-            pod = new AsyncPod(Promise.resolve(underlying), new DataFactory(false));
-        });
-
-        it("Lists features", async () => {
-            await assert.eventually.deepEqual(pod.polyLifecycle?.listFeatures(), {
-                "test-on": true,
-                "test-off": false,
-            });
-        });
-
-        it("Starts feature", async () => {
-            await pod.polyLifecycle?.startFeature("hi", false);
-            await pod.polyLifecycle?.startFeature("yo", true);
-
-            assert.deepEqual(log, [
-                ["hi", false],
-                ["yo", true],
-            ]);
-        });
+    it("Lists features", async () => {
+      await assert.eventually.deepEqual(pod.polyLifecycle?.listFeatures(), {
+        "test-on": true,
+        "test-off": false,
+      });
     });
+
+    it("Starts feature", async () => {
+      await pod.polyLifecycle?.startFeature("hi", false);
+      await pod.polyLifecycle?.startFeature("yo", true);
+
+      assert.deepEqual(log, [
+        ["hi", false],
+        ["yo", true],
+      ]);
+    });
+  });
 });

--- a/platform/podjs/.editorconfig
+++ b/platform/podjs/.editorconfig
@@ -1,4 +1,1 @@
-[*.ts]
-# Set to 100 for TypeScript code in the repository root, to support linting the
-# legacy code.
-max_line_length = 80
+


### PR DESCRIPTION
Here we
- modify eslint to set a global `max_line_length` to 80
- removed `editorconfig` of `podjs`  that was already set to `max_line_length` to 80 as it can use the global one from now on
- add  `.editorconfig` files on `feature-api/` packages to set the old code to remain to length 100
- apply `eslint --fix` to whole codebase (brought many whitespaces changes, but no line breakings - apart from one file on `test` package)

Note:
if you face conflicts after this PR with your work, choose your changes and re-apply `eslint-fix` rule globally and should work like a charm :)



