### PR TITLE
Refactor the iOS Makefile a bit

### DIFF
--- a/.github/workflows/upload_app_store.yml
+++ b/.github/workflows/upload_app_store.yml
@@ -23,7 +23,7 @@ jobs:
   build_test_upload:
     name: Build, test, and upload to App Store
     runs-on: macos-11
-    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') == true }}
+    #if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') == true }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/upload_app_store.yml
+++ b/.github/workflows/upload_app_store.yml
@@ -23,7 +23,7 @@ jobs:
   build_test_upload:
     name: Build, test, and upload to App Store
     runs-on: macos-11
-    #if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') == true }}
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') == true }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -4,6 +4,8 @@ project_path = PolyPodApp/PolyPod.xcodeproj
 scheme_name = PolyPod
 export_options_plist = exportOptions.plist
 destination = 15.2
+appstore_api_key_id = $(POLYPOD_APPLE_IOS_APPSTORE_API_KEY_ID)
+appstore_api_issuer_id = $(POLYPOD_APPLE_IOS_APPSTORE_API_ISSUER_ID)
 
 ifneq ($(shell which xcpretty),)
 xcodebuild := set -o pipefail && xcodebuild
@@ -15,10 +17,6 @@ endif
 .PHONY := build
 lockxcodeversion:
 	sudo xcode-select -switch /Applications/Xcode_13.2.1.app
-
-# Github secrets
-APPSTORE_API_KEY_ID = $POLYPOD_APPLE_IOS_APPSTORE_API_KEY_ID
-APPSTORE_API_ISSUER_ID = $POLYPOD_APPLE_IOS_APPSTORE_API_ISSUER_ID
 
 .PHONY := build
 build:
@@ -59,14 +57,14 @@ upload_ipa: export_ipa
 	xcrun altool --validate-app \
 		-f $(ipa_path) \
 		-t ios \
-		--apiKey $(value APPSTORE_API_KEY_ID) \
-		--apiIssuer $(value APPSTORE_API_ISSUER_ID)
+		--apiKey $(appstore_api_key_id) \
+		--apiIssuer $(appstore_api_issuer_id)
 
 	xcrun altool --upload-app \
 		-f $(ipa_path) \
 		-t ios \
-		--apiKey $(value APPSTORE_API_KEY_ID) \
-		--apiIssuer $(value APPSTORE_API_ISSUER_ID)
+		--apiKey $(appstore_api_key_id) \
+		--apiIssuer $(appstore_api_issuer_id)
 
 .PHONY := install_distribution_prerequisites
 install_distribution_prerequisites:
@@ -91,4 +89,4 @@ install_distribution_prerequisites:
 	mkdir -p ~/private_keys
 	@echo $(POLYPOD_APPLE_IOS_APPSTORE_API_PRIVATE_KEY_BASE64) \
 		| base64 --decode > \
-		~/private_keys/AuthKey_$(value APPSTORE_API_KEY_ID).p8
+		~/private_keys/AuthKey_$(appstore_api_key_id).p8

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -12,6 +12,7 @@ else
 xcodebuild := xcodebuild
 endif
 
+.PHONY := build
 lockxcodeversion:
 	sudo xcode-select -switch /Applications/Xcode_13.2.1.app
 
@@ -23,12 +24,14 @@ APPSTORE_CONNECT_API_KEY = $POLYPOD_APPLE_IOS_APPSTORE_API_PRIVATE_KEY_BASE64
 APPSTORE_API_KEY_ID = $POLYPOD_APPLE_IOS_APPSTORE_API_KEY_ID
 APPSTORE_API_ISSUER_ID = $POLYPOD_APPLE_IOS_APPSTORE_API_ISSUER_ID
 
+.PHONY := build
 build:
 	$(xcodebuild) clean build \
 		-project $(project_path) \
 		-scheme $(scheme_name) \
 		$(xcpretty)
 
+.PHONY := test
 test:
 	$(xcodebuild) clean test \
 		-project $(project_path) \
@@ -36,6 +39,7 @@ test:
 		-destination "platform=iOS Simulator,name=iPhone 11,OS=${destination}" \
 		$(xcpretty)
 
+.PHONY := archive
 archive:
 	rm -rf $(archive_path)
 	$(xcodebuild) clean archive \
@@ -44,6 +48,7 @@ archive:
 		-archivePath $(archive_path) \
 		$(xcpretty)
 
+.PHONY := export_ipa
 export_ipa: archive
 	$(xcodebuild) \
 		-exportArchive \
@@ -52,6 +57,7 @@ export_ipa: archive
 		-exportOptionsPlist exportOptions.plist \
 		$(xcpretty)
 
+.PHONY := upload_ipa
 upload_ipa: export_ipa
 	# Validate the app before uploading, to catch any possible issues.
 	xcrun altool --validate-app \
@@ -66,6 +72,7 @@ upload_ipa: export_ipa
 		--apiKey $(value APPSTORE_API_KEY_ID) \
 		--apiIssuer $(value APPSTORE_API_ISSUER_ID)
 
+.PHONY := install_distribution_prerequisites
 install_distribution_prerequisites:
 	# 1. Install Distribution certificate. xcodebuild will automatically extract the app certificate from the keychain.
 	@echo $(value DISTRIBUTION_CERTIFICATE) | base64 --decode > Certificate.p12

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -17,10 +17,6 @@ lockxcodeversion:
 	sudo xcode-select -switch /Applications/Xcode_13.2.1.app
 
 # Github secrets
-DISTRIBUTION_CERTIFICATE = $POLYPOD_APPLE_IOS_APPSTORE_P12_FILE_BASE64
-DISTRIBUTION_CERTIFICATE_PWD = $POLYPOD_APPLE_IOS_APPSTORE_P12_PASS
-DISTRIBUTION_PROVISIONING_PROFILE = $POLYPOD_APPLE_IOS_APPSTORE_PROVISION_PROFILE_BASE64
-APPSTORE_CONNECT_API_KEY = $POLYPOD_APPLE_IOS_APPSTORE_API_PRIVATE_KEY_BASE64
 APPSTORE_API_KEY_ID = $POLYPOD_APPLE_IOS_APPSTORE_API_KEY_ID
 APPSTORE_API_ISSUER_ID = $POLYPOD_APPLE_IOS_APPSTORE_API_ISSUER_ID
 
@@ -75,9 +71,11 @@ upload_ipa: export_ipa
 .PHONY := install_distribution_prerequisites
 install_distribution_prerequisites:
 	# 1. Install Distribution certificate. xcodebuild will automatically extract the app certificate from the keychain.
-	@echo $(value DISTRIBUTION_CERTIFICATE) | base64 --decode > Certificate.p12
+	@echo $(POLYPOD_APPLE_IOS_APPSTORE_P12_FILE_BASE64) | base64 --decode > Certificate.p12
 	security create-keychain -p "" build.keychain
-	security import Certificate.p12 -t agg -k ~/Library/Keychains/build.keychain -P $(value DISTRIBUTION_CERTIFICATE_PWD) -A
+	security import Certificate.p12 \
+		-t agg -k ~/Library/Keychains/build.keychain \
+		-P $(POLYPOD_APPLE_IOS_APPSTORE_P12_PASS) -A
 	security list-keychains -s ~/Library/Keychains/build.keychain
 	security default-keychain -s ~/Library/Keychains/build.keychain
 	security unlock-keychain -p "" ~/Library/Keychains/build.keychain
@@ -85,8 +83,12 @@ install_distribution_prerequisites:
 
 	# 2. Install Distribution provisioning profile. xcodebuild will automatically extract the profile from the Provisioning Profiles directory
 	mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-	@echo $(value DISTRIBUTION_PROVISIONING_PROFILE) | base64 --decode > ~/Library/MobileDevice/Provisioning\ Profiles/cooppolypolypolypod__iOS_App_Store_Distribution.mobileprovision
+	@echo $(POLYPOD_APPLE_IOS_APPSTORE_PROVISION_PROFILE_BASE64) \
+		| base64 --decode > \
+		~/Library/MobileDevice/Provisioning\ Profiles/cooppolypolypolypod__iOS_App_Store_Distribution.mobileprovision
 
 	# 3. App Store Connect API Key. altool will automatically use the private key from the private_keys folder.
 	mkdir -p ~/private_keys
-	@echo $(value APPSTORE_CONNECT_API_KEY) | base64 --decode > ~/private_keys/AuthKey_$(value APPSTORE_API_KEY_ID).p8
+	@echo $(POLYPOD_APPLE_IOS_APPSTORE_API_PRIVATE_KEY_BASE64) \
+		| base64 --decode > \
+		~/private_keys/AuthKey_$(value APPSTORE_API_KEY_ID).p8

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -54,7 +54,7 @@ export_ipa: archive
 		-exportArchive \
 		-archivePath $(archive_path) \
 		-exportPath ./build \
-		-exportOptionsPlist exportOptions.plist \
+		-exportOptionsPlist $(export_options_plist) \
 		$(xcpretty)
 
 .PHONY := upload_ipa

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -6,6 +6,8 @@ export_options_plist = exportOptions.plist
 destination = 15.2
 appstore_api_key_id = $(POLYPOD_APPLE_IOS_APPSTORE_API_KEY_ID)
 appstore_api_issuer_id = $(POLYPOD_APPLE_IOS_APPSTORE_API_ISSUER_ID)
+provisioning_profile_dir := ~/Library/MobileDevice/Provisioning\ Profiles
+provisioning_profile_file := cooppolypolypolypod__iOS_App_Store_Distribution.mobileprovision
 
 ifneq ($(shell which xcpretty),)
 xcodebuild := set -o pipefail && xcodebuild
@@ -68,8 +70,10 @@ upload_ipa: export_ipa
 
 .PHONY := install_distribution_prerequisites
 install_distribution_prerequisites:
-	# 1. Install Distribution certificate. xcodebuild will automatically extract the app certificate from the keychain.
-	@echo $(POLYPOD_APPLE_IOS_APPSTORE_P12_FILE_BASE64) | base64 --decode > Certificate.p12
+	# 1. Install Distribution certificate. xcodebuild will automatically
+	#    extract the app certificate from the keychain.
+	@echo $(POLYPOD_APPLE_IOS_APPSTORE_P12_FILE_BASE64) \
+		| base64 --decode > Certificate.p12
 	security create-keychain -p "" build.keychain
 	security import Certificate.p12 \
 		-t agg -k ~/Library/Keychains/build.keychain \
@@ -77,16 +81,19 @@ install_distribution_prerequisites:
 	security list-keychains -s ~/Library/Keychains/build.keychain
 	security default-keychain -s ~/Library/Keychains/build.keychain
 	security unlock-keychain -p "" ~/Library/Keychains/build.keychain
-	security set-key-partition-list -S apple-tool:,apple: -s -k "" ~/Library/Keychains/build.keychain
+	security set-key-partition-list -S apple-tool:,apple: -s -k "" \
+		~/Library/Keychains/build.keychain
 
-	# 2. Install Distribution provisioning profile. xcodebuild will automatically extract the profile from the Provisioning Profiles directory
-	mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+	# 2. Install Distribution provisioning profile. xcodebuild will
+	#    automatically extract the profile from the Provisioning Profiles
+	#    directory
+	mkdir -p $(provisioning_profile_dir)
 	@echo $(POLYPOD_APPLE_IOS_APPSTORE_PROVISION_PROFILE_BASE64) \
 		| base64 --decode > \
-		~/Library/MobileDevice/Provisioning\ Profiles/cooppolypolypolypod__iOS_App_Store_Distribution.mobileprovision
+		$(provisioning_profile_dir)/$(provisioning_profile_file)
 
-	# 3. App Store Connect API Key. altool will automatically use the private key from the private_keys folder.
+	# 3. App Store Connect API Key. altool will automatically use the private
+	#    key from the private_keys folder.
 	mkdir -p ~/private_keys
 	@echo $(POLYPOD_APPLE_IOS_APPSTORE_API_PRIVATE_KEY_BASE64) \
-		| base64 --decode > \
-		~/private_keys/AuthKey_$(appstore_api_key_id).p8
+		| base64 --decode > ~/private_keys/AuthKey_$(appstore_api_key_id).p8

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -16,18 +16,18 @@ else
 xcodebuild := xcodebuild
 endif
 
-.PHONY := build
+.PHONY: build
 lockxcodeversion:
 	sudo xcode-select -switch /Applications/Xcode_13.2.1.app
 
-.PHONY := build
+.PHONY: build
 build:
 	$(xcodebuild) clean build \
 		-project $(project_path) \
 		-scheme $(scheme_name) \
 		$(xcpretty)
 
-.PHONY := test
+.PHONY: test
 test:
 	$(xcodebuild) clean test \
 		-project $(project_path) \
@@ -35,7 +35,7 @@ test:
 		-destination "platform=iOS Simulator,name=iPhone 11,OS=${destination}" \
 		$(xcpretty)
 
-.PHONY := archive
+.PHONY: archive
 archive:
 	rm -rf $(archive_path)
 	$(xcodebuild) clean archive \
@@ -44,7 +44,7 @@ archive:
 		-archivePath $(archive_path) \
 		$(xcpretty)
 
-.PHONY := export_ipa
+.PHONY: export_ipa
 export_ipa: archive
 	$(xcodebuild) \
 		-exportArchive \
@@ -53,7 +53,7 @@ export_ipa: archive
 		-exportOptionsPlist $(export_options_plist) \
 		$(xcpretty)
 
-.PHONY := upload_ipa
+.PHONY: upload_ipa
 upload_ipa: export_ipa
 	# Validate the app before uploading, to catch any possible issues.
 	xcrun altool --validate-app \
@@ -68,7 +68,7 @@ upload_ipa: export_ipa
 		--apiKey $(appstore_api_key_id) \
 		--apiIssuer $(appstore_api_issuer_id)
 
-.PHONY := install_distribution_prerequisites
+.PHONY: install_distribution_prerequisites
 install_distribution_prerequisites:
 	# 1. Install Distribution certificate. xcodebuild will automatically
 	#    extract the app certificate from the keychain.

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -16,7 +16,7 @@ else
 xcodebuild := xcodebuild
 endif
 
-.PHONY: build
+.PHONY: lockxcodeversion
 lockxcodeversion:
 	sudo xcode-select -switch /Applications/Xcode_13.2.1.app
 

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -72,7 +72,7 @@ upload_ipa: export_ipa
 install_distribution_prerequisites:
 	# 1. Install Distribution certificate. xcodebuild will automatically
 	#    extract the app certificate from the keychain.
-	@echo $(POLYPOD_APPLE_IOS_APPSTORE_P12_FILE_BASE64) \
+	@printf "$$POLYPOD_APPLE_IOS_APPSTORE_P12_FILE_BASE64" \
 		| base64 --decode > Certificate.p12
 	security create-keychain -p "" build.keychain
 	security import Certificate.p12 \
@@ -88,12 +88,12 @@ install_distribution_prerequisites:
 	#    automatically extract the profile from the Provisioning Profiles
 	#    directory
 	mkdir -p $(provisioning_profile_dir)
-	@echo $(POLYPOD_APPLE_IOS_APPSTORE_PROVISION_PROFILE_BASE64) \
+	@printf "$$POLYPOD_APPLE_IOS_APPSTORE_PROVISION_PROFILE_BASE64" \
 		| base64 --decode > \
 		$(provisioning_profile_dir)/$(provisioning_profile_file)
 
 	# 3. App Store Connect API Key. altool will automatically use the private
 	#    key from the private_keys folder.
 	mkdir -p ~/private_keys
-	@echo $(POLYPOD_APPLE_IOS_APPSTORE_API_PRIVATE_KEY_BASE64) \
+	@printf "$$POLYPOD_APPLE_IOS_APPSTORE_API_PRIVATE_KEY_BASE64" \
 		| base64 --decode > ~/private_keys/AuthKey_$(appstore_api_key_id).p8


### PR DESCRIPTION
1. Eliminate `$(value)` workaround for reading secrets from env variables
2. Replace `echo` with `printf` to support multi line secrets (though we don't have any at the moment)
3. Make local variables defined by us lower case
4. Mark all phony targets as phony
5. Wrap at 80 columns