### PR TITLE
Prod4 pod 1462 rename backend endpoint

### DIFF
--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.DataOutputStream
 import java.net.HttpURLConnection
+import java.net.MalformedURLException
 import java.net.URL
 import java.nio.charset.StandardCharsets
 
@@ -85,7 +86,13 @@ open class Network(val context: Context) {
         authToken: String?,
     ): HttpURLConnection? {
         var connection: HttpURLConnection
-        val requestURL = URL(url)
+        var requestURL: URL
+        try {
+            requestURL = URL(url)
+        } catch (e: MalformedURLException) {
+            logger.error(e.toString())
+            return null
+        }
         if (requestURL.protocol != "https") {
             logger.error("network.$type failed, URL is not secure (https)")
             return null

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
@@ -85,8 +85,13 @@ open class Network(val context: Context) {
         authToken: String?,
     ): HttpURLConnection? {
         var connection: HttpURLConnection
+        val requestURL = URL(url)
+        if (requestURL.protocol != "https") {
+            logger.error("network.$type failed, URL is not secure (https)")
+            return null
+        }
         try {
-            connection = URL(url).openConnection() as HttpURLConnection
+            connection = requestURL.openConnection() as HttpURLConnection
         } catch (exception: Exception) {
             logger.error("network connection failed $exception")
             return null

--- a/platform/feature-api/communication/postoffice/README.md
+++ b/platform/feature-api/communication/postoffice/README.md
@@ -5,13 +5,13 @@ RPC library for TypeScript
 ## Overview
 
 This library allows transparent function calls on objects that may reside in a
-different process.  This works by capturing these calls, translating them into a
+different process. This works by capturing these calls, translating them into a
 particular protocol, sending it over a wire, and finally executing it on the
-other side.  The response is sent back similarly.  Encoding and error handling
+other side. The response is sent back similarly. Encoding and error handling
 is assumed to be dealt with by the transport layer, for example
 [port-authority](../port-authority/).
 
-We leverage TypeScript's type system to enable type-safe remote calls.  Client
+We leverage TypeScript's type system to enable type-safe remote calls. Client
 and server share a _specification_ of an API that can be called remotely.
 Servers can implement this specification and have it listen on some port.
 Clients can automatically obtain a callable object from the same specification.
@@ -22,22 +22,28 @@ The type specification for a simple API can be expressed using standard
 TypeScript techniques:
 
 ```typescript
-import {ObjectEndpointSpec, ValueEndpointSpec} from "@polypoly-eu/postoffice";
+import {
+    ObjectBackendEndpointSpec,
+    ValueBackendEndpointSpec,
+} from "@polypoly-eu/postoffice";
 
-type SimpleEndpoint = ObjectEndpointSpec<{
-    test1(param1: string): ValueEndpointSpec<number>;
-    test2(param1: string): ValueEndpointSpec<number>;
-    test3(parama: boolean, ...paramb: number[]): ValueEndpointSpec<string>;
-}>
+type SimpleEndpoint = ObjectBackendEndpointSpec<{
+    test1(param1: string): ValueBackendEndpointSpec<number>;
+    test2(param1: string): ValueBackendEndpointSpec<number>;
+    test3(
+        parama: boolean,
+        ...paramb: number[]
+    ): ValueBackendEndpointSpec<string>;
+}>;
 ```
 
-By convention, these specifications are called “endpoints”.
+By convention, these specifications are called “backend endpoints”.
 
 Servers can implement this endpoint specification and may choose to use `async`
-methods at any point.  We assume port-authority as a transport layer.
+methods at any point. We assume port-authority as a transport layer.
 
 ```typescript
-import {endpointServer, ServerOf} from "@polypoly-eu/postoffice";
+import {backendEndpointServer, ServerOf} from "@polypoly-eu/postoffice";
 import {server} from "@polypoly-eu/port-authority";
 
 const simpleEndpointImpl: ServerOf<SimpleEndpoint> = {
@@ -49,7 +55,7 @@ const simpleEndpointImpl: ServerOf<SimpleEndpoint> = {
         throw new Error(`${parama}, ${paramb.join()}`)
 };
 
-server(serverPort, endpointServer(simpleEndpointImpl));
+server(serverPort, backendEndpointServer(simpleEndpointImpl));
 ```
 
 The implementation can be served on any port by leveraging the `port-authority`
@@ -58,10 +64,10 @@ module, including via HTTP or `MessagePort`s.
 On the other side, clients can obtain a callable object:
 
 ```typescript
-import {endpointClient, ClientOf} from "@polypoly-eu/postoffice";
-import {client} from "@polypoly-eu/port-authority";
+import { backendEndpointClient, ClientOf } from "@polypoly-eu/postoffice";
+import { client } from "@polypoly-eu/port-authority";
 
-const rpcClient: ClientOf<SimpleEndpoint> = endpointClient(client(clientPort));
+const rpcClient: ClientOf<SimpleEndpoint> = backendEndpointClient(client(clientPort));
 
 const numberResult: number = await rpcClient.test1("Hello")();
 
@@ -70,31 +76,31 @@ console.log(numberResult);
 
 The callable object does not have exactly the same shape as the API
 specification; function call chains need to be terminated by an empty function
-call to “force” evaluation.  Type inference and checking works as expected: the
+call to “force” evaluation. Type inference and checking works as expected: the
 argument and result types are checked like in regular function calls.
 
 ## Structure
 
 This repository is structured as a TypeScript library with the following modules:
 
-* `types` contains the meta-specification types for endpoints
-* `protocol` defines the underlying protocol that are used for representing
-  function calls and arguments
-* `rpc` converts specifications into clients and servers
+-   `types` contains the meta-specification types for endpoints
+-   `protocol` defines the underlying protocol that are used for representing
+    function calls and arguments
+-   `rpc` converts specifications into clients and servers
 
 ## Security
 
 This library performs no run-time checking of method names, parameter types or
-method visibility.  In particular, clients that use JavaScript or circumvent
+method visibility. In particular, clients that use JavaScript or circumvent
 type checking by other means may call methods that are present in the
-implementation but not in the endpoint spec.  General security best practices
+implementation but not in the endpoint spec. General security best practices
 apply: assume that any invocation of your server implementation is potentially
 malevolent and treat client requests as untrusted.
 
 A reasonable protection mechanism is to wrap the actual logic into an object
 that performs validation using e.g. [io-ts](https://github.com/gcanti/io-ts).
 Unfortunately, TypeScript's type system will not help when annotating the
-parameters with the expected types.  Instead, we recommend relaxing all types to
+parameters with the expected types. Instead, we recommend relaxing all types to
 `unknown | undefined` and performing full manual validation:
 
 ```typescript
@@ -108,6 +114,6 @@ const simpleEndpointImpl: ServerOf<SimpleEndpoint> = {
     },
     test3: async (parama?: unknown, ...paramb: unknown[]) => {
         // ...
-    }
+    },
 };
 ```

--- a/platform/feature-api/communication/postoffice/src/protocol.ts
+++ b/platform/feature-api/communication/postoffice/src/protocol.ts
@@ -2,11 +2,11 @@
  * This module defines the protocol used for translating function calls into bare objects. Users rarely need to use this
  * module directly.
  *
- * The [[endpointClient]] and [[endpointServer]] functions speak a simple protocol:
+ * The [[backendEndpointClient]] and [[backendEndpointServer]] functions speak a simple protocol:
  *
- * - each call is represented as an [[EndpointRequestPart]]
- * - a chain of calls is represented as an [[EndpointRequest]]
- * - a response is any kind of value ([[EndpointResponse]])
+ * - each call is represented as an [[BackendEndpointRequestPart]]
+ * - a chain of calls is represented as an [[BackendEndpointRequest]]
+ * - a response is any kind of value ([[BackendEndpointResponse]])
  *
  * @packageDocumentation
  */
@@ -14,7 +14,7 @@
 /**
  * A function call representing the name of a method (of type string) and an array of arguments (of any type).
  */
-export interface EndpointRequestPart {
+export interface BackendEndpointRequestPart {
     readonly method: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly args: ReadonlyArray<any>;
@@ -23,15 +23,17 @@ export interface EndpointRequestPart {
 /**
  * A request comprising a chain of function calls.
  */
-export type EndpointRequest = EndpointRequestPart[];
+export type BackendEndpointRequest = BackendEndpointRequestPart[];
 
 /**
  * A response representing the return value of a function call.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type EndpointResponse = any;
+export type BackendEndpointResponse = any;
 
 /**
- * Function type representing the protocol: [[EndpointRequest]] comes in, [[EndpointResponse]] goes out.
+ * Function type representing the protocol: [[BackendEndpointRequest]] comes in, [[BackendEndpointResponse]] goes out.
  */
-export type EndpointProcedure = (req: EndpointRequest) => Promise<EndpointResponse>;
+export type BackendEndpointProcedure = (
+    req: BackendEndpointRequest
+) => Promise<BackendEndpointResponse>;

--- a/platform/feature-api/communication/postoffice/src/rpc.ts
+++ b/platform/feature-api/communication/postoffice/src/rpc.ts
@@ -1,18 +1,18 @@
 /**
  * This module implements the mapping of function calls on a proxy to the
- * underlying protocol ([[EndpointProcedure]]), and back to function calls on
+ * underlying protocol ([[BackendEndpointProcedure]]), and back to function calls on
  * the real object.
  *
- * Servers can use [[endpointServer]] to turn the implementation of an endpoint
+ * Servers can use [[backendEndpointServer]] to turn the implementation of an backend endpoint
  * specification ([[ServerOf]]) into a plain function. Clients can use
- * [[endpointClient]] to turn a plain function into a proxy object
+ * [[backendEndpointClient]] to turn a plain function into a proxy object
  * ([[ClientOf]]).
  *
- * In the simplest case, [[endpointServer]] and [[endpointClient]] can be
+ * In the simplest case, [[backendEndpointServer]] and [[backendEndpointClient]] can be
  * composed as follows:
  *
  * ```
- * const rpcClient: ClientOf<Spec> = endpointClient(endpointServer(specImpl));
+ * const rpcClient: ClientOf<Spec> = backendEndpointClient(backendEndpointServer(specImpl));
  * ```
  *
  * This is a “loopback” connection where both client and server reside in the
@@ -28,25 +28,34 @@
  *
  * declare serverPort: ResponsePort<EndpointRequest, EndpointResponse>;
  *
- * server(serverPort, endpointServer(specImpl));
+ * server(serverPort, backendEndpointServer(specImpl));
  *
- * declare clientPort: RequestPort<EndpointRequest, EndpointResponse>;
+ * declare clientPort: RequestPort<BackendEndpointRequest, BackendEndpointResponse>;
  *
- * const rpcClient: ClientOf<Spec> = endpointClient(client(clientPort));
+ * const rpcClient: ClientOf<Spec> = backendEndpointClient(client(clientPort));
  * ```
  *
  * @packageDocumentation
  */
 
-import { EndpointSpec, ServerOf, ClientOf, Callable } from "./types";
-import { EndpointProcedure, EndpointRequestPart, EndpointRequest } from "./protocol";
+import { BackendEndpointSpec, ServerOf, ClientOf, Callable } from "./types";
+import {
+    BackendEndpointProcedure,
+    BackendEndpointRequestPart,
+    BackendEndpointRequest,
+} from "./protocol";
 
 /**
- * Turns the implementation of an endpoint specification into a plain function.
+ * Turns the implementation of an backend endpoint specification into a plain function.
  */
-export function endpointServer<Spec extends EndpointSpec>(impl: ServerOf<Spec>): EndpointProcedure {
+export function backendEndpointServer<Spec extends BackendEndpointSpec>(
+    impl: ServerOf<Spec>
+): BackendEndpointProcedure {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async function process(impl: any, parts: ReadonlyArray<EndpointRequestPart>): Promise<any> {
+    async function process(
+        impl: any,
+        parts: ReadonlyArray<BackendEndpointRequestPart>
+    ): Promise<any> {
         if (parts.length === 0) return impl;
 
         const [{ method, args }, ...rest] = parts;
@@ -70,7 +79,10 @@ type RequestBuilder = Callable<any> & Record<string, (...args: any[]) => Request
 /**
  * @hidden
  */
-function requestBuilder(client: EndpointProcedure, state: EndpointRequest): RequestBuilder {
+function requestBuilder(
+    client: BackendEndpointProcedure,
+    state: BackendEndpointRequest
+): RequestBuilder {
     return new Proxy<RequestBuilder>(new Function() as RequestBuilder, {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         apply(target, thisArg, argArray): Promise<any> {
@@ -96,8 +108,8 @@ function requestBuilder(client: EndpointProcedure, state: EndpointRequest): Requ
 /**
  * Constructs a proxy object that turns a function call chain into a plain function call.
  */
-export function endpointClient<Spec extends EndpointSpec>(
-    client: EndpointProcedure
+export function backendEndpointClient<Spec extends BackendEndpointSpec>(
+    client: BackendEndpointProcedure
 ): ClientOf<Spec> {
     return requestBuilder(client, []) as ClientOf<Spec>;
 }

--- a/platform/feature-api/communication/postoffice/src/tests/rpc.test.ts
+++ b/platform/feature-api/communication/postoffice/src/tests/rpc.test.ts
@@ -1,10 +1,10 @@
-import { endpointClient, endpointServer } from "../rpc";
-import { ClientOf, ObjectEndpointSpec, ServerOf, ValueEndpointSpec } from "../types";
+import { backendEndpointClient, backendEndpointServer } from "../rpc";
+import { ClientOf, ObjectBackendEndpointSpec, ServerOf, ValueBackendEndpointSpec } from "../types";
 
-type SimpleEndpoint = ObjectEndpointSpec<{
-    test1(param1: string): ValueEndpointSpec<number>;
-    test2(param1: string): ValueEndpointSpec<number>;
-    test3(parama: boolean, ...paramb: number[]): ValueEndpointSpec<string>;
+type SimpleEndpoint = ObjectBackendEndpointSpec<{
+    test1(param1: string): ValueBackendEndpointSpec<number>;
+    test2(param1: string): ValueBackendEndpointSpec<number>;
+    test3(parama: boolean, ...paramb: number[]): ValueBackendEndpointSpec<string>;
 }>;
 
 const simpleEndpointImpl: ServerOf<SimpleEndpoint> = {
@@ -14,7 +14,7 @@ const simpleEndpointImpl: ServerOf<SimpleEndpoint> = {
         Promise.reject(new Error(`${parama}, ${paramb.join()}`)),
 };
 
-type ComplexEndpoint = ObjectEndpointSpec<{
+type ComplexEndpoint = ObjectBackendEndpointSpec<{
     simple(): SimpleEndpoint;
 }>;
 
@@ -26,8 +26,8 @@ describe("RPC", () => {
     let rpcClient: ClientOf<ComplexEndpoint>;
 
     beforeEach(async () => {
-        rpcClient = endpointClient<ComplexEndpoint>(
-            endpointServer<ComplexEndpoint>(complexEndpointImpl)
+        rpcClient = backendEndpointClient<ComplexEndpoint>(
+            backendEndpointServer<ComplexEndpoint>(complexEndpointImpl)
         );
     });
 

--- a/platform/feature-api/communication/postoffice/src/tests/types.test.ts
+++ b/platform/feature-api/communication/postoffice/src/tests/types.test.ts
@@ -1,4 +1,4 @@
-import { ClientOf, ObjectEndpointSpec, ServerOf, ValueEndpointSpec } from "../types";
+import { ClientOf, ObjectBackendEndpointSpec, ServerOf, ValueBackendEndpointSpec } from "../types";
 
 // compilation tests
 
@@ -7,17 +7,17 @@ function check<T>(t: T): void {
     /* intentionally left blank */
 }
 
-declare const client1: ClientOf<ValueEndpointSpec<number>>;
-declare const client2: ClientOf<ValueEndpointSpec<Promise<number>>>;
+declare const client1: ClientOf<ValueBackendEndpointSpec<number>>;
+declare const client2: ClientOf<ValueBackendEndpointSpec<Promise<number>>>;
 declare const client3: ClientOf<
-    ObjectEndpointSpec<{
-        test(): ValueEndpointSpec<number>;
+    ObjectBackendEndpointSpec<{
+        test(): ValueBackendEndpointSpec<number>;
     }>
 >;
 declare const client4: ClientOf<
-    ObjectEndpointSpec<{
-        test(): ObjectEndpointSpec<{
-            test2(): ValueEndpointSpec<number>;
+    ObjectBackendEndpointSpec<{
+        test(): ObjectBackendEndpointSpec<{
+            test2(): ValueBackendEndpointSpec<number>;
         }>;
     }>
 >;
@@ -49,28 +49,28 @@ it("Should work with complicated objects", () => {
 
             check<Promise<number>>(client2());
 
-            check<ClientOf<ValueEndpointSpec<number>>>(client3.test());
+            check<ClientOf<ValueBackendEndpointSpec<number>>>(client3.test());
             check<Promise<number>>(client3.test()());
 
             check<Promise<number>>(client4.test().test2()());
 
-            check<ServerOf<ValueEndpointSpec<number>>>(server1);
+            check<ServerOf<ValueBackendEndpointSpec<number>>>(server1);
 
-            check<ServerOf<ValueEndpointSpec<number>>>(server2);
+            check<ServerOf<ValueBackendEndpointSpec<number>>>(server2);
 
             check<
                 ServerOf<
-                    ObjectEndpointSpec<{
-                        test(): ValueEndpointSpec<number>;
+                    ObjectBackendEndpointSpec<{
+                        test(): ValueBackendEndpointSpec<number>;
                     }>
                 >
             >(server3);
 
             check<
                 ServerOf<
-                    ObjectEndpointSpec<{
-                        test(): ObjectEndpointSpec<{
-                            test2(): ValueEndpointSpec<number>;
+                    ObjectBackendEndpointSpec<{
+                        test(): ObjectBackendEndpointSpec<{
+                            test2(): ValueBackendEndpointSpec<number>;
                         }>;
                     }>
                 >
@@ -78,9 +78,9 @@ it("Should work with complicated objects", () => {
 
             check<
                 ServerOf<
-                    ObjectEndpointSpec<{
-                        test(): ObjectEndpointSpec<{
-                            test2(): ValueEndpointSpec<number>;
+                    ObjectBackendEndpointSpec<{
+                        test(): ObjectBackendEndpointSpec<{
+                            test2(): ValueBackendEndpointSpec<number>;
                         }>;
                     }>
                 >
@@ -88,9 +88,9 @@ it("Should work with complicated objects", () => {
 
             check<
                 ServerOf<
-                    ObjectEndpointSpec<{
-                        test(): ObjectEndpointSpec<{
-                            test2(): ValueEndpointSpec<number>;
+                    ObjectBackendEndpointSpec<{
+                        test(): ObjectBackendEndpointSpec<{
+                            test2(): ValueBackendEndpointSpec<number>;
                         }>;
                     }>
                 >

--- a/platform/ios/PolyPodApp/PodApi/Endpoint/Endpoint.swift
+++ b/platform/ios/PolyPodApp/PodApi/Endpoint/Endpoint.swift
@@ -12,7 +12,7 @@ protocol EndpointDelegate {
 
 struct EndpointInfo: Decodable {
     let url: String
-    let auth: String
+    let auth: String?
 }
 
 final class Endpoint: EndpointProtocol {
@@ -50,7 +50,8 @@ final class Endpoint: EndpointProtocol {
             }
             let response = self.network.httpPost(url: endpointInfo.url, body: payload, contentType: contentType, authToken: endpointInfo.auth)
             switch response {
-            case .failure(_):
+            case .failure(let error):
+                Log.error(error.localizedDescription)
                 completionHandler(PodApiError.endpointError("send"))
             case .success(_):
                 completionHandler(nil)
@@ -72,7 +73,8 @@ final class Endpoint: EndpointProtocol {
             }
             let response = self.network.httpGet(url: endpointInfo.url, contentType: contentType, authToken: endpointInfo.auth)
             switch response {
-            case .failure(_):
+            case .failure(let error):
+                Log.error(error.localizedDescription)
                 completionHandler(nil, PodApiError.endpointError("get"))
             case .success(let responseData):
                 completionHandler(String(data: responseData, encoding: .utf8)!, nil)

--- a/platform/ios/PolyPodApp/PodApi/Network/Network.swift
+++ b/platform/ios/PolyPodApp/PodApi/Network/Network.swift
@@ -39,7 +39,11 @@ final class Network: NetworkProtocol {
         body: String?,
         contentType: String?,
         authToken: String?) -> Result<Data, PodApiError>  {
-            var request = URLRequest(url: URL(string: url)!)
+            let requestURL = URL(string: url)!
+            if (!(requestURL.scheme == "https")) {
+                return .failure(PodApiError.networkSecurityError(type))
+            }
+            var request = URLRequest(url: requestURL)
             request.httpMethod = type
             if (body != nil) {
                 request.httpBody = body!.data(using: .utf8)
@@ -88,10 +92,7 @@ final class Network: NetworkProtocol {
             if (responseData == nil && fetchError == nil) {
                 fetchError = PodApiError.networkError("http\(type)", responseCode: "400")
             }
-            
-            if (fetchError != nil) {
-                Log.error(fetchError!.localizedDescription)
-            }
+        
             return fetchError == nil ? .success(responseData!) : .failure(fetchError!)
     }
 }

--- a/platform/ios/PolyPodApp/PodApi/PodApiError.swift
+++ b/platform/ios/PolyPodApp/PodApi/PodApiError.swift
@@ -12,6 +12,7 @@ enum PodApiError: Error {
     case failedToReadGraph(_ type: String)
     case badData(_ data: Any)
     case networkError(_ fetchType: String, responseCode: String)
+    case networkSecurityError(_ fetchType: String)
     case endpointError(_ fetchType: String)
 }
 
@@ -40,6 +41,8 @@ extension PodApiError: LocalizedError {
             return "Bad data: \(data)"
         case .networkError(let fetchType, let responseCode):
             return "network.\(fetchType) failed, Response Code: \(responseCode)"
+        case .networkSecurityError(let fetchType):
+            return "network.\(fetchType) failed, URL is not secure (https)"
         case .endpointError(let fetchType):
             return "endpoint.\(fetchType) failed"
         }

--- a/platform/ios/PolyPodApp/PodApi/PodApiError.swift
+++ b/platform/ios/PolyPodApp/PodApi/PodApiError.swift
@@ -11,7 +11,7 @@ enum PodApiError: Error {
     case badArgumentType(_ arg: Any, type: String)
     case failedToReadGraph(_ type: String)
     case badData(_ data: Any)
-    case networkError(_ fetchType: String, responseCode: String)
+    case networkError(_ fetchType: String, message: String)
     case networkSecurityError(_ fetchType: String)
     case endpointError(_ fetchType: String)
 }
@@ -39,8 +39,8 @@ extension PodApiError: LocalizedError {
             return "Failed to read graph: \(type)"
         case .badData(let data):
             return "Bad data: \(data)"
-        case .networkError(let fetchType, let responseCode):
-            return "network.\(fetchType) failed, Response Code: \(responseCode)"
+        case .networkError(let fetchType, let message):
+            return "network.\(fetchType) failed, \(message)"
         case .networkSecurityError(let fetchType):
             return "network.\(fetchType) failed, URL is not secure (https)"
         case .endpointError(let fetchType):

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -363,8 +363,19 @@ class BrowserNetwork {
                 fetchResponse.error = `Network error`;
                 resolve(fetchResponse);
             };
-
+            let urlObject; 
+            try{
+                urlObject = new URL(url)
+            }catch(e){
+                fetchResponse.error = `Bad URL`
+                resolve(fetchResponse)
+            }
+            if (urlObject?.protocol != "https"){
+                fetchResponse.error = `Not a secure protocol`
+                resolve(fetchResponse)
+            }
             request.open(type, url);
+
             if (contentType)
                 request.setRequestHeader("Content-Type", contentType);
             if (authToken)
@@ -411,12 +422,15 @@ class BrowserEndpoint implements Endpoint {
         if (!endpointURL) {
             throw endpointErrorMessage("send", "Endpoint URL not set");
         }
-        await this.endpointNetwork.httpPost(
+        const NetworkResponse = await this.endpointNetwork.httpPost(
             endpointURL,
             payload,
             contentType,
             authToken
         );
+        if (NetworkResponse.error){
+            throw endpointErrorMessage("send", NetworkResponse.error)
+        }
     }
     async get(
         endpointId: string,

--- a/platform/utils/endpoints-generator/index.js
+++ b/platform/utils/endpoints-generator/index.js
@@ -1,7 +1,7 @@
 import endpoints from "./endpoints.js";
 import fs from "fs";
 
-const fallbackURL = "http://localhost:8000";
+const fallbackURL = "https://localhost:8000";
 const fallbackAuth = null;
 
 const configPath = "../../../../polyPod-config";


### PR DESCRIPTION
to avoid weird naming and confusion with the endpoint API, the existing Endpoint was renamed to BackendEndpoint as to signify that it is within the pod and not an external endpoint