### PR TITLE
🐛 minimist part deux

### DIFF
--- a/feature-utils/poly-look/storybook/package-lock.json
+++ b/feature-utils/poly-look/storybook/package-lock.json
@@ -2362,9 +2362,9 @@
       "dev": true
     },
     "node_modules/@mdjs/core": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@mdjs/core/-/core-0.9.2.tgz",
-      "integrity": "sha512-FhqqJmRl2WRLWCjV84xfiUaEjVJ6Zantsw4CbUEc7TAEqxVHg65AUVkW39OOHctJqqb6CQeMd8lr1d3DvzA2MA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@mdjs/core/-/core-0.9.4.tgz",
+      "integrity": "sha512-1xuogj/TSMwvSjwnAR7ssfaq8y4VACVAt16ALnmuFVAZbi0ldpRPAEgDjLbK3vTBPHrA7r8XhocLcH9hf8F7jw==",
       "dev": true,
       "dependencies": {
         "@mdjs/mdjs-preview": "^0.5.3",
@@ -2374,7 +2374,7 @@
         "github-markdown-css": "^4.0.0",
         "plugins-manager": "^0.3.0",
         "rehype-autolink-headings": "^5.0.1",
-        "rehype-prism-template": "^0.4.1",
+        "rehype-prism": "^1.0.0",
         "rehype-raw": "^5.0.0",
         "rehype-slug": "^4.0.1",
         "rehype-stringify": "^8.0.0",
@@ -5025,6 +5025,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz",
       "integrity": "sha512-VjID5MJb1eGKthz2qUerWT8+R4b9N+CHvGCzg9fn4kWZgaF9AhdYikQio3R7wV8YY1NsQKPaCwKz1Yff+aHNUQ==",
+      "dev": true
+    },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
+      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -7756,18 +7762,6 @@
         "colors": "1.4.0"
       }
     },
-    "node_modules/clipboard": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.10.tgz",
-      "integrity": "sha512-cz3m2YVwFz95qSEbCDi2fzLN/epEN9zXBvfgAoGkvGOJZATMl9gtTDVOtBYkx2ODUJl2kvmud7n32sV2BpYR4g==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -8820,6 +8814,12 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-selector-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
+      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==",
+      "dev": true
+    },
     "node_modules/css-what": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
@@ -8972,13 +8972,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -11136,16 +11129,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "delegate": "^3.1.2"
       }
     },
     "node_modules/graceful-fs": {
@@ -14003,9 +13986,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/minipass": {
@@ -16327,97 +16310,91 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/rehype-prism-template": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/rehype-prism-template/-/rehype-prism-template-0.4.1.tgz",
-      "integrity": "sha512-A/3ZJ2Lj4q9DjKDwJaVNJdr1Sqkjlh4z52tHM/a0eBrSst9h3QbTG/cSb+umY16IcbsvJOtTap3kZlFVyQ2JUg==",
+    "node_modules/rehype-parse": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-7.0.1.tgz",
+      "integrity": "sha512-fOiR9a9xH+Le19i4fGzIEowAbwG7idy2Jzs4mOrFWBSJ0sNUgy0ev871dwWnbOo371SjgjG4pwzrbgSVrKxecw==",
       "dev": true,
       "dependencies": {
-        "hast-util-to-string": "^1.0.0",
-        "refractor": "^2.6.2",
-        "underscore": "^1.9.1",
-        "unist-util-visit": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/rehype-prism-template/node_modules/hastscript": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
-      "dev": true,
-      "dependencies": {
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0"
+        "hast-util-from-parse5": "^6.0.0",
+        "parse5": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/rehype-prism-template/node_modules/parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+    "node_modules/rehype-prism": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-prism/-/rehype-prism-1.0.2.tgz",
+      "integrity": "sha512-+asp8vJJoF4nHkQgjytnXi3ZuHuy1xGWaKMxHOakH8Ax9qva8GcSGVEM+VRavIQHpMUtKtqaLlG2asTsMz3Akw==",
       "dev": true,
       "dependencies": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
-    "node_modules/rehype-prism-template/node_modules/prismjs": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-      "dev": true,
-      "optionalDependencies": {
-        "clipboard": "^2.0.0"
-      }
-    },
-    "node_modules/rehype-prism-template/node_modules/refractor": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
-      "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
-      "dev": true,
-      "dependencies": {
-        "hastscript": "^5.0.0",
-        "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
+        "@types/node": "^14.14.31",
+        "@types/prismjs": "^1.16.6",
+        "prismjs": "^1.24.1",
+        "rehype-parse": "^7.0.1",
+        "unist-util-is": "^4.1.0",
+        "unist-util-select": "^4.0.0",
+        "unist-util-visit": "^3.1.0"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
+      "peerDependencies": {
+        "unified": "^9 || ^10"
       }
     },
-    "node_modules/rehype-prism-template/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+    "node_modules/rehype-prism/node_modules/@types/node": {
+      "version": "14.18.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
+      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
       "dev": true
     },
-    "node_modules/rehype-prism-template/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+    "node_modules/rehype-prism/node_modules/unist-util-visit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-3.1.0.tgz",
+      "integrity": "sha512-Szoh+R/Ll68QWAyQyZZpQzZQm2UPbxibDvaY8Xc9SUtYgPsDzx5AWSk++UUt2hJuow8mvwR+rG+LQLw+KsuAKA==",
       "dev": true,
       "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/rehype-prism-template/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+    "node_modules/rehype-prism/node_modules/unist-util-visit-parents": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-4.1.1.tgz",
+      "integrity": "sha512-1xAFJXAKpnnJl8G7K5KgU7FY55y3GcLIXqkzUj5QF/QVP7biUm0K0O2oqVkYsdjzJKifYeWn9+o6piAK2hGSHw==",
       "dev": true,
       "dependencies": {
-        "unist-util-is": "^3.0.0"
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-prism/node_modules/unist-util-visit-parents/node_modules/unist-util-is": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+      "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-prism/node_modules/unist-util-visit/node_modules/unist-util-is": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+      "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-raw": {
@@ -17344,13 +17321,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true,
-      "optional": true
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -18867,13 +18837,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -19146,12 +19109,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
-      "dev": true
-    },
     "node_modules/unfetch": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
@@ -19336,6 +19293,43 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-select": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-4.0.1.tgz",
+      "integrity": "sha512-zPozyEo5vr1csbHf1TqlQrnuLVJ0tNMo63og3HrnINh2+OIDAgQpqHVr+0BMw1DIVHJV8ft/e6BZqtvD1Y5enw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "css-selector-parser": "^1.0.0",
+        "nth-check": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-select/node_modules/unist-util-is": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+      "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-select/node_modules/zwitch": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz",
+      "integrity": "sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/unist-util-stringify-position": {
@@ -22550,9 +22544,9 @@
       "dev": true
     },
     "@mdjs/core": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@mdjs/core/-/core-0.9.2.tgz",
-      "integrity": "sha512-FhqqJmRl2WRLWCjV84xfiUaEjVJ6Zantsw4CbUEc7TAEqxVHg65AUVkW39OOHctJqqb6CQeMd8lr1d3DvzA2MA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@mdjs/core/-/core-0.9.4.tgz",
+      "integrity": "sha512-1xuogj/TSMwvSjwnAR7ssfaq8y4VACVAt16ALnmuFVAZbi0ldpRPAEgDjLbK3vTBPHrA7r8XhocLcH9hf8F7jw==",
       "dev": true,
       "requires": {
         "@mdjs/mdjs-preview": "^0.5.3",
@@ -22562,7 +22556,7 @@
         "github-markdown-css": "^4.0.0",
         "plugins-manager": "^0.3.0",
         "rehype-autolink-headings": "^5.0.1",
-        "rehype-prism-template": "^0.4.1",
+        "rehype-prism": "^1.0.0",
         "rehype-raw": "^5.0.0",
         "rehype-slug": "^4.0.1",
         "rehype-stringify": "^8.0.0",
@@ -24485,6 +24479,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz",
       "integrity": "sha512-VjID5MJb1eGKthz2qUerWT8+R4b9N+CHvGCzg9fn4kWZgaF9AhdYikQio3R7wV8YY1NsQKPaCwKz1Yff+aHNUQ==",
+      "dev": true
+    },
+    "@types/prismjs": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
+      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==",
       "dev": true
     },
     "@types/prop-types": {
@@ -26677,18 +26677,6 @@
         "string-width": "^4.2.0"
       }
     },
-    "clipboard": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.10.tgz",
-      "integrity": "sha512-cz3m2YVwFz95qSEbCDi2fzLN/epEN9zXBvfgAoGkvGOJZATMl9gtTDVOtBYkx2ODUJl2kvmud7n32sV2BpYR4g==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -27546,6 +27534,12 @@
         "nth-check": "^2.0.1"
       }
     },
+    "css-selector-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
+      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==",
+      "dev": true
+    },
     "css-what": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
@@ -27657,13 +27651,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true,
-      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -29439,16 +29426,6 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
-      }
-    },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -31606,9 +31583,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minipass": {
@@ -33454,86 +33431,72 @@
         "unist-util-visit": "^2.0.0"
       }
     },
-    "rehype-prism-template": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/rehype-prism-template/-/rehype-prism-template-0.4.1.tgz",
-      "integrity": "sha512-A/3ZJ2Lj4q9DjKDwJaVNJdr1Sqkjlh4z52tHM/a0eBrSst9h3QbTG/cSb+umY16IcbsvJOtTap3kZlFVyQ2JUg==",
+    "rehype-parse": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-7.0.1.tgz",
+      "integrity": "sha512-fOiR9a9xH+Le19i4fGzIEowAbwG7idy2Jzs4mOrFWBSJ0sNUgy0ev871dwWnbOo371SjgjG4pwzrbgSVrKxecw==",
       "dev": true,
       "requires": {
-        "hast-util-to-string": "^1.0.0",
-        "refractor": "^2.6.2",
-        "underscore": "^1.9.1",
-        "unist-util-visit": "^1.1.3"
+        "hast-util-from-parse5": "^6.0.0",
+        "parse5": "^6.0.0"
+      }
+    },
+    "rehype-prism": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-prism/-/rehype-prism-1.0.2.tgz",
+      "integrity": "sha512-+asp8vJJoF4nHkQgjytnXi3ZuHuy1xGWaKMxHOakH8Ax9qva8GcSGVEM+VRavIQHpMUtKtqaLlG2asTsMz3Akw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^14.14.31",
+        "@types/prismjs": "^1.16.6",
+        "prismjs": "^1.24.1",
+        "rehype-parse": "^7.0.1",
+        "unist-util-is": "^4.1.0",
+        "unist-util-select": "^4.0.0",
+        "unist-util-visit": "^3.1.0"
       },
       "dependencies": {
-        "hastscript": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-          "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
-          "dev": true,
-          "requires": {
-            "comma-separated-tokens": "^1.0.0",
-            "hast-util-parse-selector": "^2.0.0",
-            "property-information": "^5.0.0",
-            "space-separated-tokens": "^1.0.0"
-          }
-        },
-        "parse-entities": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-          "dev": true,
-          "requires": {
-            "character-entities": "^1.0.0",
-            "character-entities-legacy": "^1.0.0",
-            "character-reference-invalid": "^1.0.0",
-            "is-alphanumerical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-hexadecimal": "^1.0.0"
-          }
-        },
-        "prismjs": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-          "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
-        },
-        "refractor": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
-          "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
-          "dev": true,
-          "requires": {
-            "hastscript": "^5.0.0",
-            "parse-entities": "^1.1.2",
-            "prismjs": "~1.17.0"
-          }
-        },
-        "unist-util-is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+        "@types/node": {
+          "version": "14.18.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
+          "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
           "dev": true
         },
         "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-3.1.0.tgz",
+          "integrity": "sha512-Szoh+R/Ll68QWAyQyZZpQzZQm2UPbxibDvaY8Xc9SUtYgPsDzx5AWSk++UUt2hJuow8mvwR+rG+LQLw+KsuAKA==",
           "dev": true,
           "requires": {
-            "unist-util-visit-parents": "^2.0.0"
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0",
+            "unist-util-visit-parents": "^4.0.0"
+          },
+          "dependencies": {
+            "unist-util-is": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+              "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
+              "dev": true
+            }
           }
         },
         "unist-util-visit-parents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-4.1.1.tgz",
+          "integrity": "sha512-1xAFJXAKpnnJl8G7K5KgU7FY55y3GcLIXqkzUj5QF/QVP7biUm0K0O2oqVkYsdjzJKifYeWn9+o6piAK2hGSHw==",
           "dev": true,
           "requires": {
-            "unist-util-is": "^3.0.0"
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
+          },
+          "dependencies": {
+            "unist-util-is": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+              "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
+              "dev": true
+            }
           }
         }
       }
@@ -34270,13 +34233,6 @@
         "ajv": "^6.12.5",
         "ajv-keywords": "^3.5.2"
       }
-    },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true,
-      "optional": true
     },
     "semver": {
       "version": "6.3.0",
@@ -35528,13 +35484,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true,
-      "optional": true
-    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -35738,12 +35687,6 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
-    "underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
-      "dev": true
-    },
     "unfetch": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
@@ -35880,6 +35823,33 @@
       "dev": true,
       "requires": {
         "unist-util-visit": "^2.0.0"
+      }
+    },
+    "unist-util-select": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-4.0.1.tgz",
+      "integrity": "sha512-zPozyEo5vr1csbHf1TqlQrnuLVJ0tNMo63og3HrnINh2+OIDAgQpqHVr+0BMw1DIVHJV8ft/e6BZqtvD1Y5enw==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "css-selector-parser": "^1.0.0",
+        "nth-check": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+          "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
+          "dev": true
+        },
+        "zwitch": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz",
+          "integrity": "sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==",
+          "dev": true
+        }
       }
     },
     "unist-util-stringify-position": {

--- a/features/polyPreview/package-lock.json
+++ b/features/polyPreview/package-lock.json
@@ -1135,9 +1135,10 @@
       }
     },
     "../../dev-utils/dummy-server/node_modules/minimist": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "../../dev-utils/dummy-server/node_modules/ms": {
       "version": "2.1.2",
@@ -2107,6 +2108,7 @@
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-react": "^7.16.7",
         "@open-wc/testing": "^3.0.3",
+        "@polypoly-eu/rollup-plugin-copy-watch": "file:../../dev-utils/rollup-plugin-copy-watch",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
@@ -7032,9 +7034,10 @@
       }
     },
     "../../feature-utils/poly-look/node_modules/minimist": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "../../feature-utils/poly-look/node_modules/mkdirp": {
       "version": "1.0.4",
@@ -8859,7 +8862,7 @@
         "fast-check": "^2.2.1"
       },
       "devDependencies": {
-        "@graphy/core.data.factory": "^4.3.3",
+        "@graphy/core.data.factory": "^4.3.4",
         "@graphy/memory.dataset.fast": "^4.3.3",
         "@rdfjs/data-model": "^1.1.3",
         "@rdfjs/dataset": "^1.0.1",
@@ -9204,6 +9207,8 @@
         "@polypoly-eu/pod-api": "file:../feature-api/api/pod-api",
         "@polypoly-eu/rdf": "file:../feature-api/api/rdf",
         "@zip.js/zip.js": "2.3.7",
+        "fp-ts": "^2.8.2",
+        "io-ts": "^2.2.16",
         "rdf-js": "^4.0.2"
       },
       "devDependencies": {
@@ -9590,6 +9595,8 @@
         "@zip.js/zip.js": "2.3.7",
         "body-parser": "^1.19.0",
         "fast-check": "^2.11.0",
+        "fp-ts": "^2.8.2",
+        "io-ts": "^2.2.16",
         "rdf-js": "^4.0.2"
       },
       "dependencies": {
@@ -10415,7 +10422,9 @@
                   }
                 },
                 "minimist": {
-                  "version": "1.2.5",
+                  "version": "1.2.6",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+                  "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
                   "dev": true
                 },
                 "ms": {
@@ -10816,7 +10825,7 @@
                 "@polypoly-eu/rdf-spec": {
                   "version": "file:../../platform/feature-api/api/rdf-spec",
                   "requires": {
-                    "@graphy/core.data.factory": "^4.3.3",
+                    "@graphy/core.data.factory": "^4.3.4",
                     "@graphy/memory.dataset.fast": "^4.3.3",
                     "@rdfjs/data-model": "^1.1.3",
                     "@rdfjs/dataset": "^1.0.1",
@@ -11038,7 +11047,7 @@
             "@polypoly-eu/rdf-spec": {
               "version": "file:../../platform/feature-api/api/rdf-spec",
               "requires": {
-                "@graphy/core.data.factory": "^4.3.3",
+                "@graphy/core.data.factory": "^4.3.4",
                 "@graphy/memory.dataset.fast": "^4.3.3",
                 "@rdfjs/data-model": "^1.1.3",
                 "@rdfjs/dataset": "^1.0.1",
@@ -11436,7 +11445,7 @@
             "@polypoly-eu/rdf-spec": {
               "version": "file:../../platform/feature-api/api/rdf-spec",
               "requires": {
-                "@graphy/core.data.factory": "^4.3.3",
+                "@graphy/core.data.factory": "^4.3.4",
                 "@graphy/memory.dataset.fast": "^4.3.3",
                 "@rdfjs/data-model": "^1.1.3",
                 "@rdfjs/dataset": "^1.0.1",
@@ -11658,7 +11667,7 @@
         "@polypoly-eu/rdf-spec": {
           "version": "file:../../platform/feature-api/api/rdf-spec",
           "requires": {
-            "@graphy/core.data.factory": "^4.3.3",
+            "@graphy/core.data.factory": "^4.3.4",
             "@graphy/memory.dataset.fast": "^4.3.3",
             "@rdfjs/data-model": "^1.1.3",
             "@rdfjs/dataset": "^1.0.1",
@@ -12063,6 +12072,7 @@
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-react": "^7.16.7",
         "@open-wc/testing": "^3.0.3",
+        "@polypoly-eu/rollup-plugin-copy-watch": "file:../../dev-utils/rollup-plugin-copy-watch",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
@@ -15270,7 +15280,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.5",
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
           "dev": true
         },
         "mkdirp": {


### PR DESCRIPTION
Upgrades minimist to 1.2.6 via `npm audit fix`. These two were left over in #766.