### PR TITLE
Fix → The rust linter was always firing

### DIFF
--- a/.github/workflows/rust_kernel_tests.yml
+++ b/.github/workflows/rust_kernel_tests.yml
@@ -2,11 +2,11 @@ name: Lint and Test Rust code
 on:
   push:
     paths:
-      - platform/core/**
+      - 'platform/core/**'
   pull_request:
     types: [assigned, opened, ready_for_review]
     paths:
-      - platform/core/**
+      - 'platform/core/**'
 
 jobs:
   test:


### PR DESCRIPTION
[Syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) was apparently incorrect, you can avoid single quotes only with whole words.