### PR TITLE
Fixes ⚠ by defining externals and context

### DIFF
--- a/platform/podjs/rollup.config.js
+++ b/platform/podjs/rollup.config.js
@@ -18,18 +18,13 @@ export default [
         ],
         plugins: [
             json(),
+            resolve(),
             sucrase({
                 exclude: ["node_modules/**"],
                 transforms: ["typescript"],
             }),
         ],
-        external: [
-            "@polypoly-eu/rdf",
-            "@zip.js/zip.js",
-            "io-ts/Decoder",
-            "fp-ts/Either",
-            "fp-ts/function",
-        ],
+        context: "window",
     },
     {
         input: "src/pod.ts",

--- a/platform/podjs/rollup.config.js
+++ b/platform/podjs/rollup.config.js
@@ -23,7 +23,13 @@ export default [
                 transforms: ["typescript"],
             }),
         ],
-        external: ["@polypoly-eu/rdf", "@zip.js/zip.js"],
+        external: [
+            "@polypoly-eu/rdf",
+            "@zip.js/zip.js",
+            "io-ts/Decoder",
+            "fp-ts/Either",
+            "fp-ts/function",
+        ],
     },
     {
         input: "src/pod.ts",
@@ -42,5 +48,6 @@ export default [
                 transforms: ["typescript"],
             }),
         ],
+        context: "window",
     },
 ];


### PR DESCRIPTION
This was a `rollup` warning appearing everywhere, for instance [here](https://github.com/polypoly-eu/polyPod/runs/5766280202?check_suite_focus=true)
![Captura de pantalla de 2022-03-31 08-48-26](https://user-images.githubusercontent.com/500/160993532-1a4b7d4e-7a35-4d78-9be2-4de018eeb5aa.png)
By upgrading the configuration, it's been eliminated without affecting functionality.