### PR TITLE
Limit Java setup in iOS/Android instrumentation tests to same conditions as instrumentation tsts.

### DIFF
--- a/.github/workflows/ios-android-test.yml
+++ b/.github/workflows/ios-android-test.yml
@@ -37,6 +37,9 @@ jobs:
               working-directory: platform/ios
               run: make test
             - uses: actions/setup-java@v2
+              if: |
+                !github.head_ref
+                && ( github.ref == 'refs/heads/release' || github.ref == 'refs/heads/main' )
               with:
                   distribution: 'zulu'
                   java-version: 11


### PR DESCRIPTION
This was taking more than two minutes too. And it's not needed if you are not doing android instrumentation tests.