### PR TITLE
Maintenance esLint configuration

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,8 +33,6 @@ module.exports = {
         "**/node_modules/*",
         "data/",
         ".eslintrc.*",
-        "**/public/build/*",
-        "**/bubblewrap/build/*",
         "**/build/*",
         "PolyPodApp/",
     ],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -35,8 +35,6 @@ module.exports = {
         ".eslintrc.*",
         "**/public/build/*",
         "**/bubblewrap/build/*",
-        "**/storybook-static/*",
-        "podApi/",
         "**/build/*",
         "PolyPodApp/",
     ],

--- a/platform/feature-api/api/rdf-spec/.eslintrc.js
+++ b/platform/feature-api/api/rdf-spec/.eslintrc.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/platform/feature-api/api/rdf/.eslintrc.js
+++ b/platform/feature-api/api/rdf/.eslintrc.js
@@ -1,1 +1,0 @@
-module.exports = {};


### PR DESCRIPTION
To be honest, this was caused mainly by the sudden occurrence of linting errors when modules in the `feature-api` directory are moved around, for instance [here](https://github.com/polypoly-eu/polyPod/actions/runs/2088708981). There are many errors there that were, apparently, ignored for some reason I can't fathom.
That happened also in #763, so I took to revise the configuration. I still don't know why it fails, but I found nonetheless directories that no longer existed, and some configuration files that are not really used.