### PR TITLE
Eliminate unused dependency

### DIFF
--- a/feature-utils/poly-look/package-lock.json
+++ b/feature-utils/poly-look/package-lock.json
@@ -24,7 +24,6 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
-        "@web/test-runner-chrome": "^0.10.5",
         "identity-obj-proxy": "^3.0.0"
       }
     },

--- a/feature-utils/poly-look/package.json
+++ b/feature-utils/poly-look/package.json
@@ -31,7 +31,6 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@web/test-runner": "^0.13.22",
-    "@web/test-runner-chrome": "^0.10.5",
     "identity-obj-proxy": "^3.0.0"
   },
   "jest": {


### PR DESCRIPTION
Which was left there for apparently no reason. The existing `@web/test-runner` apparently uses Chrome (or whatever is available) seamlessly

> TBH, I just wanted to grab PR #800 :man_shrugging: Do I get a poly-lolly-pop or something?