### PR TITLE
statResults keys are now file.id

### DIFF
--- a/feature-utils/poly-import/src/storage.js
+++ b/feature-utils/poly-import/src/storage.js
@@ -14,7 +14,7 @@ export class FeatureFileStorage {
         const files = await polyOut.readDir("");
         const statResults = {};
         for (let file of files) {
-            statResults[file] = await polyOut.stat(file.id);
+            statResults[file.id] = await polyOut.stat(file.id);
         }
         this._files = statResults;
         return files;


### PR DESCRIPTION
The refresh files function is currently placing an incorrect key to the object that stores all the directories in side of the statResults object which then becomes the Features files. This correction is meant to help correctly store the Feature files using a valid key such as the file id. 
before #560 this was the file id&path conjugated string. 