### PR TITLE
fix ts config to read external JSON files in podjs

### DIFF
--- a/.github/workflows/upload_all.yml
+++ b/.github/workflows/upload_all.yml
@@ -7,9 +7,9 @@ on:
         type: choice
         description: Where to upload
         options:
-        - all
-        - google-play
-        - app-store
+          - all
+          - google-play
+          - app-store
       draft:
         type: boolean
         description: Upload, but don't publish
@@ -61,7 +61,7 @@ jobs:
       - name: API and features - Build
         env:
           POLYPOD_POLYPEDIA_REPORT_URL: ${{ secrets.POLYPOD_POLYPEDIA_REPORT_URL }}
-          POLYPOD_POLYPEDIA_REPORT_AUTHORIZATION: ${{ secrets.POLYPOD_POLYPEDIA_REPORT_AUTHORIZATION }}
+          POLYPOD_POLYPEDIA_REPORT_AUTHORIZATION: ${{ secrets.POLYPOD_POLYPEDIA_REPORT_AUTHORIZATION }} || ""
         run: ./build.js
       - name: Android - Test
         working-directory: platform/android
@@ -116,7 +116,7 @@ jobs:
       - name: API and features - Build
         env:
           POLYPOD_POLYPEDIA_REPORT_URL: ${{ secrets.POLYPOD_POLYPEDIA_REPORT_URL }}
-          POLYPOD_POLYPEDIA_REPORT_AUTHORIZATION: ${{ secrets.POLYPOD_POLYPEDIA_REPORT_AUTHORIZATION }}
+          POLYPOD_POLYPEDIA_REPORT_AUTHORIZATION: ${{ secrets.POLYPOD_POLYPEDIA_REPORT_AUTHORIZATION }} || ""
         run: ./build.js
       - name: iOS - Lock Xcode version
         working-directory: platform/ios

--- a/features/facebookImport/rollup.config.js
+++ b/features/facebookImport/rollup.config.js
@@ -71,7 +71,7 @@ export default (commandLineArgs) => {
                     JSON.stringify(
                         process.env.POLYPOD_POLYPEDIA_REPORT_AUTHORIZATION ||
                             fallbackAuthorization
-                    ),
+                    ) || "",
             }),
             commonjs({
                 include: /node_modules/,

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -398,7 +398,7 @@ class BrowserNetwork {
 
 interface EndpointInfo {
     url: string;
-    auth: null; // TODO: change this to an actual type when it's needed. It's null now on endpoints.json
+    auth: string;
     allowInsecure: boolean;
 }
 

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -428,14 +428,14 @@ function endpointErrorMessage(fetchType: string, errorlog: string): string {
 class BrowserEndpoint implements Endpoint {
     endpointNetwork = new BrowserNetwork();
     async send(
-        endpointId: string,
+        endpointId: EndpointKeyId,
         payload: string,
         contentType?: string,
         authToken?: string
     ): Promise<void> {
         if (!approveEndpointFetch(endpointId))
             throw endpointErrorMessage("send", "User denied request");
-        const endpoint = getEndpoint(endpointId as EndpointKeyId);
+        const endpoint = getEndpoint(endpointId);
         if (!endpoint) {
             throw endpointErrorMessage("send", "Endpoint URL not set");
         }
@@ -452,13 +452,13 @@ class BrowserEndpoint implements Endpoint {
     }
 
     async get(
-        endpointId: string,
+        endpointId: EndpointKeyId,
         contentType?: string,
         authToken?: string
     ): Promise<string> {
         if (!approveEndpointFetch(endpointId))
             throw endpointErrorMessage("get", "User denied request");
-        const endpoint = getEndpoint(endpointId as EndpointKeyId);
+        const endpoint = getEndpoint(endpointId);
         if (!endpoint)
             throw endpointErrorMessage("get", "Endpoint URL not set");
         const NetworkResponse = await this.endpointNetwork.httpGet(

--- a/platform/podjs/src/json-typings.d.ts
+++ b/platform/podjs/src/json-typings.d.ts
@@ -1,0 +1,5 @@
+//  So, typescript can read json files
+declare module "*.json" {
+    const value: any;
+    export default value;
+}

--- a/platform/podjs/src/json-typings.d.ts
+++ b/platform/podjs/src/json-typings.d.ts
@@ -1,5 +1,6 @@
 //  So, typescript can read json files
 declare module "*.json" {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const value: any;
     export default value;
 }

--- a/platform/podjs/tsconfig.json
+++ b/platform/podjs/tsconfig.json
@@ -6,11 +6,14 @@
     ],
     "target": "es6",
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDirs": ["./src",  "../../../polyPod-config/*.json"],
     "module": "commonjs",
     "declaration": true,
     "strict": true,
     "moduleResolution": "node",
-    "esModuleInterop": true
-  }
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/platform/utils/endpoints-generator/endpoints.js
+++ b/platform/utils/endpoints-generator/endpoints.js
@@ -1,7 +1,7 @@
 export default {
     polyPediaReport: {
         url: process.env.POLYPOD_POLYPEDIA_REPORT_URL,
-        auth: process.env.POLYPOD_POLYPEDIA_REPORT_AUTHORIZATION,
+        auth: process.env.POLYPOD_POLYPEDIA_REPORT_AUTHORIZATION || "",
     },
     demoTest: {
         url: "",

--- a/platform/utils/endpoints-generator/index.js
+++ b/platform/utils/endpoints-generator/index.js
@@ -2,7 +2,7 @@ import endpoints from "./endpoints.js";
 import fs from "fs";
 
 const fallbackURL = "https://localhost:8000";
-const fallbackAuth = null;
+const fallbackAuth = "";
 
 const configPath = "../../../../polyPod-config";
 


### PR DESCRIPTION
On this PR, we enable `podjs` to read external JSON files by setting the flag `--resolveJsonModule` in `tsconfig` and adding a  `typings.d.ts` on `src` root, which enables TS to actually read the imported JSON file without complaining.

This way, we don't need to "hack" anymore the import of "endpoints.json" by setting ts to "ignore" this import.

Grabbing the chance, we introduce a stricter type `EndpointJSON` for the endpoints Json format so we make sure that `getEndpoint()` retrieves back the correct object as now the passed arg can only be a key of this JSON (aka either `polyPediaReport` or `demoTest`)

Thank you 🌷 
