### PR TITLE
[Fix] {PROD4POD-1518} Eliminate code that was deprecated 7 months ago: select

### DIFF
--- a/features/example/src/index.jsx
+++ b/features/example/src/index.jsx
@@ -43,15 +43,15 @@ const quad = dataFactory.quad(
 
 (async () => {
     await polyIn.add(quad);
-    const selected = await polyIn.select({});
+    const matching = await polyIn.match({});
 
     ReactDOM.render(
-        <Quads quads={selected} />,
+        <Quads quads={matching} />,
         document.getElementById("feature")
     );
 
     if (window.testCompleted)
         window.testCompleted({
-            failures: selected.length === 1 ? 0 : 1,
+            failures: matching.length === 1 ? 0 : 1,
         });
 })();

--- a/features/facebookImport/src/views/import/import.jsx
+++ b/features/facebookImport/src/views/import/import.jsx
@@ -33,7 +33,7 @@ const maxFileSizeSupported = {
 //from storage
 async function readImportStatus(pod) {
     const { dataFactory } = pod;
-    const statusQuads = await pod.polyIn.select({
+    const statusQuads = await pod.polyIn.match({
         subject: dataFactory.namedNode(`${FBIMPORT_NAMESPACE}facebookImporter`),
         predicate: dataFactory.namedNode(`${FBIMPORT_NAMESPACE}importStatus`),
     });
@@ -44,7 +44,7 @@ async function readImportStatus(pod) {
 async function writeImportStatus(pod, status) {
     const { dataFactory, polyIn } = pod;
     const existingQuad = (
-        await pod.polyIn.select({
+        await pod.polyIn.match({
             subject: dataFactory.namedNode(
                 `${FBIMPORT_NAMESPACE}facebookImporter`
             ),

--- a/features/polyExplorer/src/context/explorer-context.jsx
+++ b/features/polyExplorer/src/context/explorer-context.jsx
@@ -21,7 +21,7 @@ export const ExplorerContext = React.createContext();
 const namespace = "http://polypoly.coop/schema/polyExplorer/#";
 
 async function readFirstRun() {
-    const quads = await pod.polyIn.select({});
+    const quads = await pod.polyIn.match({});
     return !quads.some(
         ({ subject, predicate, object }) =>
             subject.value === `${namespace}polyExplorer` &&

--- a/features/polyPinion/src/util/async-storage.ts
+++ b/features/polyPinion/src/util/async-storage.ts
@@ -6,7 +6,7 @@ const { dataFactory, polyIn } = window.pod;
 const AsyncStorage = {
     async getItem(key: string): Promise<string | null> {
         // use non empty matcher when implemented in pod.js
-        const quads = await polyIn.select({});
+        const quads = await polyIn.match({});
         return (
             quads.find(
                 ({ subject, predicate }) =>
@@ -28,7 +28,7 @@ const AsyncStorage = {
     //I really don't like this, needs some refactoring
     async getRecentAnswers(key: string): Promise<string | null> {
         // use non empty matcher when implemented in pod.js
-        const quads = (await polyIn.select({})).filter(
+        const quads = (await polyIn.match({})).filter(
             ({ subject, predicate }) =>
                 subject.value === `${namespace}${key}` &&
                 predicate.value === `${namespace}${questionnairePredicate}`
@@ -38,7 +38,7 @@ const AsyncStorage = {
 
     async getIndex(key: string): Promise<string | null> {
         // use non empty matcher when implemented in pod.js
-        const quads = await polyIn.select({});
+        const quads = await polyIn.match({});
         return (
             quads.find(
                 ({ subject, predicate }) =>

--- a/features/test/src/index.html
+++ b/features/test/src/index.html
@@ -137,10 +137,10 @@
             comm.polyIn.add.quad_with_blank_node_graph
         </button>
         <button
-            id="comm.polyIn.select.pass_empty_matcher"
-            onclick="testFeature.execute(() => testFeature.canPassEmptyMatcherToPolyInSelect())"
+            id="comm.polyIn.match.pass_empty_matcher"
+            onclick="testFeature.execute(() => testFeature.canPassEmptyMatcherToPolyInMatch())"
         >
-            comm.polyIn.select.pass_empty_matcher
+            comm.polyIn.match.pass_empty_matcher
         </button>
         <button
             id="comm.polyIn.add.quad_with_default_graph"
@@ -149,94 +149,94 @@
             comm.polyIn.add.quad_with_default_graph
         </button>
         <button
-            id="comm.polyIn.select.pass_matcher_with_subject"
-            onclick="testFeature.execute(() => testFeature.canPassMatcherWithSubjectToPolyInSelect())"
+            id="comm.polyIn.match.pass_matcher_with_subject"
+            onclick="testFeature.execute(() => testFeature.canPassMatcherWithSubjectToPolyInMatch())"
         >
-            comm.polyIn.select.pass_matcher_with_subject
+            comm.polyIn.match.pass_matcher_with_subject
         </button>
         <button
-            id="comm.polyIn.select.pass_matcher_with_predicate"
-            onclick="testFeature.execute(() => testFeature.canPassMatcherWithPredicateToPolyInSelect())"
+            id="comm.polyIn.match.pass_matcher_with_predicate"
+            onclick="testFeature.execute(() => testFeature.canPassMatcherWithPredicateToPolyInMatch())"
         >
-            comm.polyIn.select.pass_matcher_with_predicate
+            comm.polyIn.match.pass_matcher_with_predicate
         </button>
         <button
-            id="comm.polyIn.select.pass_matcher_with_object"
-            onclick="testFeature.execute(() => testFeature.canPassMatcherWithObjectToPolyInSelect())"
+            id="comm.polyIn.match.pass_matcher_with_object"
+            onclick="testFeature.execute(() => testFeature.canPassMatcherWithObjectToPolyInMatch())"
         >
-            comm.polyIn.select.pass_matcher_with_object
+            comm.polyIn.match.pass_matcher_with_object
         </button>
         <button
-            id="comm.polyIn.select.pass_matcher_with_all_three_fields"
-            onclick="testFeature.execute(() => testFeature.canPassMatcherWithAllThreeFieldsToPolyInSelect())"
+            id="comm.polyIn.match.pass_matcher_with_all_three_fields"
+            onclick="testFeature.execute(() => testFeature.canPassMatcherWithAllThreeFieldsToPolyInMatch())"
         >
-            comm.polyIn.select.pass_matcher_with_all_three_fields
+            comm.polyIn.match.pass_matcher_with_all_three_fields
         </button>
         <button
-            id="comm.polyIn.select.get_empty_array"
-            onclick="testFeature.execute(() => testFeature.canGetEmptyArrayFromPolyInSelect())"
+            id="comm.polyIn.match.get_empty_array"
+            onclick="testFeature.execute(() => testFeature.canGetEmptyArrayFromPolyInMatch())"
         >
-            comm.polyIn.select.get_empty_array
+            comm.polyIn.match.get_empty_array
         </button>
         <button
-            id="comm.polyIn.select.get_array_with_single_quad"
-            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadFromPolyInSelect())"
+            id="comm.polyIn.match.get_array_with_single_quad"
+            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadFromPolyInMatch())"
         >
-            comm.polyIn.select.get_array_with_single_quad
+            comm.polyIn.match.get_array_with_single_quad
         </button>
         <button
-            id="comm.polyIn.select.get_array_with_single_quad_with_named_node_subject"
-            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithNamedNodeSubjectFromPolyInSelect())"
+            id="comm.polyIn.match.get_array_with_single_quad_with_named_node_subject"
+            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithNamedNodeSubjectFromPolyInMatch())"
         >
-            comm.polyIn.select.get_array_with_single_quad_with_named_node_subject
+            comm.polyIn.match.get_array_with_single_quad_with_named_node_subject
         </button>
         <button
-            id="comm.polyIn.select.get_array_with_single_quad_with_blank_node_subject"
-            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInSelect())"
+            id="comm.polyIn.match.get_array_with_single_quad_with_blank_node_subject"
+            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInMatch())"
         >
-            comm.polyIn.select.get_array_with_single_quad_with_blank_node_subject
+            comm.polyIn.match.get_array_with_single_quad_with_blank_node_subject
         </button>
         <button
-            id="comm.polyIn.select.get_array_with_single_quad_with_named_node_object"
-            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithNamedNodeObjectFromPolyInSelect())"
+            id="comm.polyIn.match.get_array_with_single_quad_with_named_node_object"
+            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithNamedNodeObjectFromPolyInMatch())"
         >
-            comm.polyIn.select.get_array_with_single_quad_with_named_node_object
+            comm.polyIn.match.get_array_with_single_quad_with_named_node_object
         </button>
         <button
-            id="comm.polyIn.select.get_array_with_single_quad_with_blank_node_object"
-            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInSelect())"
+            id="comm.polyIn.match.get_array_with_single_quad_with_blank_node_object"
+            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInMatch())"
         >
-            comm.polyIn.select.get_array_with_single_quad_with_blank_node_object
+            comm.polyIn.match.get_array_with_single_quad_with_blank_node_object
         </button>
         <button
-            id="comm.polyIn.select.get_array_with_single_quad_with_literal_object"
-            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithLiteralObjectFromPolyInSelect())"
+            id="comm.polyIn.match.get_array_with_single_quad_with_literal_object"
+            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithLiteralObjectFromPolyInMatch())"
         >
-            comm.polyIn.select.get_array_with_single_quad_with_literal_object
+            comm.polyIn.match.get_array_with_single_quad_with_literal_object
         </button>
         <button
-            id="comm.polyIn.select.get_array_with_single_quad_with_named_node_graph"
-            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithNamedNodeGraphFromPolyInSelect())"
+            id="comm.polyIn.match.get_array_with_single_quad_with_named_node_graph"
+            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithNamedNodeGraphFromPolyInMatch())"
         >
-            comm.polyIn.select.get_array_with_single_quad_with_named_node_graph
+            comm.polyIn.match.get_array_with_single_quad_with_named_node_graph
         </button>
         <button
-            id="comm.polyIn.select.get_array_with_single_quad_with_blank_node_graph"
-            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInSelect())"
+            id="comm.polyIn.match.get_array_with_single_quad_with_blank_node_graph"
+            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInMatch())"
         >
-            comm.polyIn.select.get_array_with_single_quad_with_blank_node_graph
+            comm.polyIn.match.get_array_with_single_quad_with_blank_node_graph
         </button>
         <button
-            id="comm.polyIn.select.get_array_with_single_quad_with_default_graph"
-            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithDefaultGraphFromPolyInSelect())"
+            id="comm.polyIn.match.get_array_with_single_quad_with_default_graph"
+            onclick="testFeature.execute(() => testFeature.canGetArrayWithSingleQuadWithDefaultGraphFromPolyInMatch())"
         >
-            comm.polyIn.select.get_array_with_single_quad_with_default_graph
+            comm.polyIn.match.get_array_with_single_quad_with_default_graph
         </button>
         <button
-            id="comm.polyIn.select.get_array_with_multiple_quads"
-            onclick="testFeature.execute(() => testFeature.canGetArrayWithMultipleQuadsFromPolyInSelect())"
+            id="comm.polyIn.match.get_array_with_multiple_quads"
+            onclick="testFeature.execute(() => testFeature.canGetArrayWithMultipleQuadsFromPolyInMatch())"
         >
-            comm.polyIn.select.get_array_with_multiple_quads
+            comm.polyIn.match.get_array_with_multiple_quads
         </button>
 
         <button

--- a/features/test/src/test.ts
+++ b/features/test/src/test.ts
@@ -94,34 +94,34 @@ export async function addSupportsQuadsWithDefaultGraph(): Promise<void> {
     await polyIn.add(quad);
 }
 
-export async function canPassEmptyMatcherToPolyInSelect(): Promise<void> {
-    console.log("canPassEmptyMatcherToPolyInSelect()");
+export async function canPassEmptyMatcherToPolyInMatch(): Promise<void> {
+    console.log("canPassEmptyMatcherToPolyInMatch()");
     await polyIn.match({});
 }
 
-export async function canPassMatcherWithSubjectToPolyInSelect(): Promise<void> {
-    console.log("canPassMatcherWithSubjectToPolyInSelect()");
+export async function canPassMatcherWithSubjectToPolyInMatch(): Promise<void> {
+    console.log("canPassMatcherWithSubjectToPolyInMatch()");
     const subject = getInput(1);
     const matcher = { subject: window.pod.dataFactory.namedNode(subject) };
     await polyIn.match(matcher);
 }
 
-export async function canPassMatcherWithPredicateToPolyInSelect(): Promise<void> {
-    console.log("canPassMatcherWithPredicateToPolyInSelect()");
+export async function canPassMatcherWithPredicateToPolyInMatch(): Promise<void> {
+    console.log("canPassMatcherWithPredicateToPolyInMatch()");
     const predicate = getInput(1);
     const matcher = { predicate: window.pod.dataFactory.namedNode(predicate) };
     await polyIn.match(matcher);
 }
 
-export async function canPassMatcherWithObjectToPolyInSelect(): Promise<void> {
-    console.log("canPassMatcherWithObjectToPolyInSelect()");
+export async function canPassMatcherWithObjectToPolyInMatch(): Promise<void> {
+    console.log("canPassMatcherWithObjectToPolyInMatch()");
     const object = getInput(1);
     const matcher = { object: window.pod.dataFactory.namedNode(object) };
     await polyIn.match(matcher);
 }
 
-export async function canPassMatcherWithAllThreeFieldsToPolyInSelect(): Promise<void> {
-    console.log("canPassMatcherWithAllThreeFieldsToPolyInSelect()");
+export async function canPassMatcherWithAllThreeFieldsToPolyInMatch(): Promise<void> {
+    console.log("canPassMatcherWithAllThreeFieldsToPolyInMatch()");
     const subject = getInput(1);
     const predicate = getInput(2);
     const object = getInput(3);
@@ -134,15 +134,15 @@ export async function canPassMatcherWithAllThreeFieldsToPolyInSelect(): Promise<
     await polyIn.match(matcher);
 }
 
-export async function canGetEmptyArrayFromPolyInSelect(): Promise<void> {
-    console.log("canGetEmptyArrayFromPolyInSelect()");
+export async function canGetEmptyArrayFromPolyInMatch(): Promise<void> {
+    console.log("canGetEmptyArrayFromPolyInMatch()");
     const result = await polyIn.match({});
     if (!Array.isArray(result) || result.length !== 0)
         throw Error(`Expected empty array, got '${JSON.stringify(result)}'`);
 }
 
-export async function canGetArrayWithSingleQuadFromPolyInSelect(): Promise<void> {
-    console.log("canGetArrayWithSingleQuadFromPolyInSelect()");
+export async function canGetArrayWithSingleQuadFromPolyInMatch(): Promise<void> {
+    console.log("canGetArrayWithSingleQuadFromPolyInMatch()");
     const expectedResult = QuadBuilder.fromQuad(quads[0]).build();
     const result = await polyIn.match({});
     if (result.length !== 1)
@@ -157,9 +157,9 @@ export async function canGetArrayWithSingleQuadFromPolyInSelect(): Promise<void>
         );
 }
 
-export async function canGetArrayWithSingleQuadWithNamedNodeSubjectFromPolyInSelect(): Promise<void> {
+export async function canGetArrayWithSingleQuadWithNamedNodeSubjectFromPolyInMatch(): Promise<void> {
     console.log(
-        "canGetArrayWithSingleQuadWithNamedNodeSubjectFromPolyInSelect()"
+        "canGetArrayWithSingleQuadWithNamedNodeSubjectFromPolyInMatch()"
     );
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withSubject(pod.dataFactory.namedNode(quads[0].subject.value))
@@ -177,9 +177,9 @@ export async function canGetArrayWithSingleQuadWithNamedNodeSubjectFromPolyInSel
         );
 }
 
-export async function canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInSelect(): Promise<void> {
+export async function canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInMatch(): Promise<void> {
     console.log(
-        "canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInSelect()"
+        "canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInMatch()"
     );
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withSubject(pod.dataFactory.blankNode(quads[0].subject.value))
@@ -197,9 +197,9 @@ export async function canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInSel
         );
 }
 
-export async function canGetArrayWithSingleQuadWithNamedNodeObjectFromPolyInSelect(): Promise<void> {
+export async function canGetArrayWithSingleQuadWithNamedNodeObjectFromPolyInMatch(): Promise<void> {
     console.log(
-        "canGetArrayWithSingleQuadWithNamedNodeObjectFromPolyInSelect()"
+        "canGetArrayWithSingleQuadWithNamedNodeObjectFromPolyInMatch()"
     );
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withObject(pod.dataFactory.namedNode(quads[0].object.value))
@@ -217,9 +217,9 @@ export async function canGetArrayWithSingleQuadWithNamedNodeObjectFromPolyInSele
         );
 }
 
-export async function canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInSelect(): Promise<void> {
+export async function canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInMatch(): Promise<void> {
     console.log(
-        "canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInSelect()"
+        "canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInMatch()"
     );
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withObject(pod.dataFactory.blankNode(quads[0].object.value))
@@ -237,8 +237,8 @@ export async function canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInSele
         );
 }
 
-export async function canGetArrayWithSingleQuadWithLiteralObjectFromPolyInSelect(): Promise<void> {
-    console.log("canGetArrayWithSingleQuadWithLiteralObjectFromPolyInSelect()");
+export async function canGetArrayWithSingleQuadWithLiteralObjectFromPolyInMatch(): Promise<void> {
+    console.log("canGetArrayWithSingleQuadWithLiteralObjectFromPolyInMatch()");
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withObject(pod.dataFactory.literal(quads[0].object.value))
         .build();
@@ -255,10 +255,8 @@ export async function canGetArrayWithSingleQuadWithLiteralObjectFromPolyInSelect
         );
 }
 
-export async function canGetArrayWithSingleQuadWithNamedNodeGraphFromPolyInSelect(): Promise<void> {
-    console.log(
-        "canGetArrayWithSingleQuadWithNamedNodeGraphFromPolyInSelect()"
-    );
+export async function canGetArrayWithSingleQuadWithNamedNodeGraphFromPolyInMatch(): Promise<void> {
+    console.log("canGetArrayWithSingleQuadWithNamedNodeGraphFromPolyInMatch()");
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withGraph(pod.dataFactory.namedNode(quads[0].graph.value))
         .build();
@@ -275,10 +273,8 @@ export async function canGetArrayWithSingleQuadWithNamedNodeGraphFromPolyInSelec
         );
 }
 
-export async function canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInSelect(): Promise<void> {
-    console.log(
-        "canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInSelect()"
-    );
+export async function canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInMatch(): Promise<void> {
+    console.log("canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInMatch()");
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withGraph(pod.dataFactory.blankNode(quads[0].graph.value))
         .build();
@@ -295,8 +291,8 @@ export async function canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInSelec
         );
 }
 
-export async function canGetArrayWithSingleQuadWithDefaultGraphFromPolyInSelect(): Promise<void> {
-    console.log("canGetArrayWithSingleQuadWithDefaultGraphFromPolyInSelect()");
+export async function canGetArrayWithSingleQuadWithDefaultGraphFromPolyInMatch(): Promise<void> {
+    console.log("canGetArrayWithSingleQuadWithDefaultGraphFromPolyInMatch()");
     const expectedResult = QuadBuilder.fromQuad(quads[0])
         .withGraph(pod.dataFactory.defaultGraph())
         .build();
@@ -313,8 +309,8 @@ export async function canGetArrayWithSingleQuadWithDefaultGraphFromPolyInSelect(
         );
 }
 
-export async function canGetArrayWithMultipleQuadsFromPolyInSelect(): Promise<void> {
-    console.log("canGetArrayWithMultipleQuadsFromPolyInSelect()");
+export async function canGetArrayWithMultipleQuadsFromPolyInMatch(): Promise<void> {
+    console.log("canGetArrayWithMultipleQuadsFromPolyInMatch()");
     const result = await polyIn.match({});
     if (result.length !== 2)
         throw Error(

--- a/platform/android/app/src/androidTest/kotlin/coop/polypoly/polypod/CommunicationThroughPodApiWorks.kt
+++ b/platform/android/app/src/androidTest/kotlin/coop/polypoly/polypod/CommunicationThroughPodApiWorks.kt
@@ -99,28 +99,28 @@ class CommunicationThroughPodApiWorks {
         execute { addSupportsQuadsWithIRIGraph() }
         execute { addSupportsQuadsWithBlankNodeGraph() }
         execute { addSupportsQuadsWithDefaultGraph() }
-        execute { canPassEmptyMatcherToPolyInSelect() }
-        execute { canPassMatcherWithSubjectToPolyInSelect() }
-        execute { canPassMatcherWithPredicateToPolyInSelect() }
-        execute { canPassMatcherWithObjectToPolyInSelect() }
-        execute { canPassMatcherWithAllThreeFieldsToPolyInSelect() }
-        execute { canGetEmptyArrayFromPolyInSelect() }
-        execute { canGetArrayWithSingleQuadFromPolyInSelect() }
-        execute { canGetArrayWithSingleQuadWithIRISubjectFromPolyInSelect() }
+        execute { canPassEmptyMatcherToPolyInMatch() }
+        execute { canPassMatcherWithSubjectToPolyInMatch() }
+        execute { canPassMatcherWithPredicateToPolyInMatch() }
+        execute { canPassMatcherWithObjectToPolyInMatch() }
+        execute { canPassMatcherWithAllThreeFieldsToPolyInMatch() }
+        execute { canGetEmptyArrayFromPolyInMatch() }
+        execute { canGetArrayWithSingleQuadFromPolyInMatch() }
+        execute { canGetArrayWithSingleQuadWithIRISubjectFromPolyInMatch() }
         execute {
-            canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInSelect()
+            canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInMatch()
         }
-        execute { canGetArrayWithSingleQuadWithIRIObjectFromPolyInSelect() }
+        execute { canGetArrayWithSingleQuadWithIRIObjectFromPolyInMatch() }
         execute {
-            canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInSelect()
+            canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInMatch()
         }
-        execute { canGetArrayWithSingleQuadWithLiteralObjectFromPolyInSelect() }
-        execute { canGetArrayWithSingleQuadWithIRIGraphFromPolyInSelect() }
+        execute { canGetArrayWithSingleQuadWithLiteralObjectFromPolyInMatch() }
+        execute { canGetArrayWithSingleQuadWithIRIGraphFromPolyInMatch() }
         execute {
-            canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInSelect()
+            canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInMatch()
         }
-        execute { canGetArrayWithSingleQuadWithDefaultGraphFromPolyInSelect() }
-        execute { canGetArrayWithMultipleQuadsFromPolyInSelect() }
+        execute { canGetArrayWithSingleQuadWithDefaultGraphFromPolyInMatch() }
+        execute { canGetArrayWithMultipleQuadsFromPolyInMatch() }
     }
 
     private fun whenCalledWithNoMethodSpecified_methodIsEmpty() {
@@ -458,122 +458,122 @@ class CommunicationThroughPodApiWorks {
         assertThat(polyIn.addParams!![0]).isEqualTo(quad)
     }
 
-    private fun canPassEmptyMatcherToPolyInSelect() {
-        clickButton("comm.polyIn.select.pass_empty_matcher")
+    private fun canPassEmptyMatcherToPolyInMatch() {
+        clickButton("comm.polyIn.match.pass_empty_matcher")
 
         waitUntil({
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
         })
-        assertThat(polyIn.selectWasCalled).isTrue()
-        val matcher = polyIn.selectMatcher
+        assertThat(polyIn.matchWasCalled).isTrue()
+        val matcher = polyIn.matchMatcher
         assertThat(matcher).isNotNull()
         assertThat(matcher!!.subject).isNull()
         assertThat(matcher.predicate).isNull()
         assertThat(matcher.`object`).isNull()
     }
 
-    private fun canPassMatcherWithSubjectToPolyInSelect() {
+    private fun canPassMatcherWithSubjectToPolyInMatch() {
         val subject = IRI("http://example.org/s")
         setInput(1, subject.iri)
 
-        clickButton("comm.polyIn.select.pass_matcher_with_subject")
+        clickButton("comm.polyIn.match.pass_matcher_with_subject")
 
         waitUntil({
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
         })
-        assertThat(polyIn.selectWasCalled).isTrue()
-        val matcher = polyIn.selectMatcher
+        assertThat(polyIn.matchWasCalled).isTrue()
+        val matcher = polyIn.matchMatcher
         assertThat(matcher).isNotNull()
         assertThat(matcher!!.subject).isEqualTo(subject)
         assertThat(matcher.predicate).isNull()
         assertThat(matcher.`object`).isNull()
     }
 
-    private fun canPassMatcherWithPredicateToPolyInSelect() {
+    private fun canPassMatcherWithPredicateToPolyInMatch() {
         val predicate = IRI("http://example.org/p")
         setInput(1, predicate.iri)
 
-        clickButton("comm.polyIn.select.pass_matcher_with_predicate")
+        clickButton("comm.polyIn.match.pass_matcher_with_predicate")
 
         waitUntil({
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
         })
-        assertThat(polyIn.selectWasCalled).isTrue()
-        val matcher = polyIn.selectMatcher
+        assertThat(polyIn.matchWasCalled).isTrue()
+        val matcher = polyIn.matchMatcher
         assertThat(matcher).isNotNull()
         assertThat(matcher!!.subject).isNull()
         assertThat(matcher.predicate).isEqualTo(predicate)
         assertThat(matcher.`object`).isNull()
     }
 
-    private fun canPassMatcherWithObjectToPolyInSelect() {
+    private fun canPassMatcherWithObjectToPolyInMatch() {
         val `object` = IRI("http://example.org/o")
         setInput(1, `object`.iri)
 
-        clickButton("comm.polyIn.select.pass_matcher_with_object")
+        clickButton("comm.polyIn.match.pass_matcher_with_object")
 
         waitUntil({
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
         })
-        assertThat(polyIn.selectWasCalled).isTrue()
-        val matcher = polyIn.selectMatcher
+        assertThat(polyIn.matchWasCalled).isTrue()
+        val matcher = polyIn.matchMatcher
         assertThat(matcher).isNotNull()
         assertThat(matcher!!.subject).isNull()
         assertThat(matcher.predicate).isNull()
         assertThat(matcher.`object`).isEqualTo(`object`)
     }
 
-    private fun canPassMatcherWithAllThreeFieldsToPolyInSelect() {
+    private fun canPassMatcherWithAllThreeFieldsToPolyInMatch() {
         val subject = IRI("http://example.org/s")
         val predicate = IRI("http://example.org/p")
         val `object` = IRI("http://example.org/o")
         setInputs(subject.iri, predicate.iri, `object`.iri)
 
-        clickButton("comm.polyIn.select.pass_matcher_with_all_three_fields")
+        clickButton("comm.polyIn.match.pass_matcher_with_all_three_fields")
 
         waitUntil({
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
         })
-        assertThat(polyIn.selectWasCalled).isTrue()
-        val matcher = polyIn.selectMatcher
+        assertThat(polyIn.matchWasCalled).isTrue()
+        val matcher = polyIn.matchMatcher
         assertThat(matcher).isNotNull()
         assertThat(matcher!!.subject).isEqualTo(subject)
         assertThat(matcher.predicate).isEqualTo(predicate)
         assertThat(matcher.`object`).isEqualTo(`object`)
     }
 
-    private fun canGetEmptyArrayFromPolyInSelect() {
-        polyIn.selectReturn = emptyList()
+    private fun canGetEmptyArrayFromPolyInMatch() {
+        polyIn.matchReturn = emptyList()
 
-        clickButton("comm.polyIn.select.get_empty_array")
+        clickButton("comm.polyIn.match.get_empty_array")
 
         waitUntil({
-            assertThat(polyIn.selectWasCalled).isTrue()
+            assertThat(polyIn.matchWasCalled).isTrue()
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
         })
     }
 
-    private fun canGetArrayWithSingleQuadFromPolyInSelect() {
+    private fun canGetArrayWithSingleQuadFromPolyInMatch() {
         val quad = Quad.builder.newDefault().build()
-        polyIn.selectReturn = listOf(quad)
+        polyIn.matchReturn = listOf(quad)
         addQuadToCollection(quad)
 
-        clickButton("comm.polyIn.select.get_array_with_single_quad")
+        clickButton("comm.polyIn.match.get_array_with_single_quad")
 
         waitUntil({
-            assertThat(polyIn.selectWasCalled).isTrue()
+            assertThat(polyIn.matchWasCalled).isTrue()
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
@@ -581,18 +581,18 @@ class CommunicationThroughPodApiWorks {
         })
     }
 
-    private fun canGetArrayWithSingleQuadWithIRISubjectFromPolyInSelect() {
+    private fun canGetArrayWithSingleQuadWithIRISubjectFromPolyInMatch() {
         val quad = Quad.builder.newDefault()
             .withSubject(IRI("http://example.com/s"))
             .build()
-        polyIn.selectReturn = listOf(quad)
+        polyIn.matchReturn = listOf(quad)
         addQuadToCollection(quad)
 
         /* ktlint-disable max-line-length */
-        clickButton("comm.polyIn.select.get_array_with_single_quad_with_named_node_subject")
+        clickButton("comm.polyIn.match.get_array_with_single_quad_with_named_node_subject")
 
         waitUntil({
-            assertThat(polyIn.selectWasCalled).isTrue()
+            assertThat(polyIn.matchWasCalled).isTrue()
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
@@ -600,18 +600,18 @@ class CommunicationThroughPodApiWorks {
         })
     }
 
-    private fun canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInSelect() {
+    private fun canGetArrayWithSingleQuadWithBlankNodeSubjectFromPolyInMatch() {
         val quad = Quad.builder.newDefault()
             .withSubject(BlankNode("subject"))
             .build()
-        polyIn.selectReturn = listOf(quad)
+        polyIn.matchReturn = listOf(quad)
         addQuadToCollection(quad)
 
         /* ktlint-disable max-line-length */
-        clickButton("comm.polyIn.select.get_array_with_single_quad_with_blank_node_subject")
+        clickButton("comm.polyIn.match.get_array_with_single_quad_with_blank_node_subject")
 
         waitUntil({
-            assertThat(polyIn.selectWasCalled).isTrue()
+            assertThat(polyIn.matchWasCalled).isTrue()
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
@@ -619,17 +619,17 @@ class CommunicationThroughPodApiWorks {
         })
     }
 
-    private fun canGetArrayWithSingleQuadWithIRIObjectFromPolyInSelect() {
+    private fun canGetArrayWithSingleQuadWithIRIObjectFromPolyInMatch() {
         val quad = Quad.builder.newDefault()
             .withObject(IRI("http://example.com/o"))
             .build()
-        polyIn.selectReturn = listOf(quad)
+        polyIn.matchReturn = listOf(quad)
         addQuadToCollection(quad)
 
-        clickButton("comm.polyIn.select.get_array_with_single_quad_with_named_node_object")
+        clickButton("comm.polyIn.match.get_array_with_single_quad_with_named_node_object")
 
         waitUntil({
-            assertThat(polyIn.selectWasCalled).isTrue()
+            assertThat(polyIn.matchWasCalled).isTrue()
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
@@ -637,17 +637,17 @@ class CommunicationThroughPodApiWorks {
         })
     }
 
-    private fun canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInSelect() {
+    private fun canGetArrayWithSingleQuadWithBlankNodeObjectFromPolyInMatch() {
         val quad = Quad.builder.newDefault()
             .withObject(BlankNode("object"))
             .build()
-        polyIn.selectReturn = listOf(quad)
+        polyIn.matchReturn = listOf(quad)
         addQuadToCollection(quad)
 
-        clickButton("comm.polyIn.select.get_array_with_single_quad_with_blank_node_object")
+        clickButton("comm.polyIn.match.get_array_with_single_quad_with_blank_node_object")
 
         waitUntil({
-            assertThat(polyIn.selectWasCalled).isTrue()
+            assertThat(polyIn.matchWasCalled).isTrue()
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
@@ -655,17 +655,17 @@ class CommunicationThroughPodApiWorks {
         })
     }
 
-    private fun canGetArrayWithSingleQuadWithLiteralObjectFromPolyInSelect() {
+    private fun canGetArrayWithSingleQuadWithLiteralObjectFromPolyInMatch() {
         val quad = Quad.builder.newDefault()
             .withObject(Literal("string"))
             .build()
-        polyIn.selectReturn = listOf(quad)
+        polyIn.matchReturn = listOf(quad)
         addQuadToCollection(quad)
 
-        clickButton("comm.polyIn.select.get_array_with_single_quad_with_literal_object")
+        clickButton("comm.polyIn.match.get_array_with_single_quad_with_literal_object")
 
         waitUntil({
-            assertThat(polyIn.selectWasCalled).isTrue()
+            assertThat(polyIn.matchWasCalled).isTrue()
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
@@ -673,17 +673,17 @@ class CommunicationThroughPodApiWorks {
         })
     }
 
-    private fun canGetArrayWithSingleQuadWithIRIGraphFromPolyInSelect() {
+    private fun canGetArrayWithSingleQuadWithIRIGraphFromPolyInMatch() {
         val quad = Quad.builder.newDefault()
             .withGraph(IRI("http://example.com/g"))
             .build()
-        polyIn.selectReturn = listOf(quad)
+        polyIn.matchReturn = listOf(quad)
         addQuadToCollection(quad)
 
-        clickButton("comm.polyIn.select.get_array_with_single_quad_with_named_node_graph")
+        clickButton("comm.polyIn.match.get_array_with_single_quad_with_named_node_graph")
 
         waitUntil({
-            assertThat(polyIn.selectWasCalled).isTrue()
+            assertThat(polyIn.matchWasCalled).isTrue()
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
@@ -691,17 +691,17 @@ class CommunicationThroughPodApiWorks {
         })
     }
 
-    private fun canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInSelect() {
+    private fun canGetArrayWithSingleQuadWithBlankNodeGraphFromPolyInMatch() {
         val quad = Quad.builder.newDefault()
             .withGraph(BlankNode("graph"))
             .build()
-        polyIn.selectReturn = listOf(quad)
+        polyIn.matchReturn = listOf(quad)
         addQuadToCollection(quad)
 
-        clickButton("comm.polyIn.select.get_array_with_single_quad_with_blank_node_graph")
+        clickButton("comm.polyIn.match.get_array_with_single_quad_with_blank_node_graph")
 
         waitUntil({
-            assertThat(polyIn.selectWasCalled).isTrue()
+            assertThat(polyIn.matchWasCalled).isTrue()
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
@@ -709,17 +709,17 @@ class CommunicationThroughPodApiWorks {
         })
     }
 
-    private fun canGetArrayWithSingleQuadWithDefaultGraphFromPolyInSelect() {
+    private fun canGetArrayWithSingleQuadWithDefaultGraphFromPolyInMatch() {
         val quad = Quad.builder.newDefault()
             .withDefaultGraph()
             .build()
-        polyIn.selectReturn = listOf(quad)
+        polyIn.matchReturn = listOf(quad)
         addQuadToCollection(quad)
 
-        clickButton("comm.polyIn.select.get_array_with_single_quad_with_default_graph")
+        clickButton("comm.polyIn.match.get_array_with_single_quad_with_default_graph")
 
         waitUntil({
-            assertThat(polyIn.selectWasCalled).isTrue()
+            assertThat(polyIn.matchWasCalled).isTrue()
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))
@@ -727,7 +727,7 @@ class CommunicationThroughPodApiWorks {
         })
     }
 
-    private fun canGetArrayWithMultipleQuadsFromPolyInSelect() {
+    private fun canGetArrayWithMultipleQuadsFromPolyInMatch() {
         val quad1 = Quad.builder.new()
             .withSubject(IRI("subject1"))
             .withPredicate(IRI("predicate1"))
@@ -740,14 +740,14 @@ class CommunicationThroughPodApiWorks {
             .withObject(IRI("object2"))
             .withGraph(IRI("graph2"))
             .build()
-        polyIn.selectReturn = listOf(quad1, quad2)
+        polyIn.matchReturn = listOf(quad1, quad2)
         addQuadToCollection(quad1)
         addQuadToCollection(quad2)
 
-        clickButton("comm.polyIn.select.get_array_with_multiple_quads")
+        clickButton("comm.polyIn.match.get_array_with_multiple_quads")
 
         waitUntil({
-            assertThat(polyIn.selectWasCalled).isTrue()
+            assertThat(polyIn.matchWasCalled).isTrue()
             onFeature()
                 .withElement(findElement(Locator.ID, "status"))
                 .check(webMatches(getText(), `is`("All OK")))

--- a/platform/android/app/src/androidTest/kotlin/coop/polypoly/polypod/polyIn/PolyInTestDouble.kt
+++ b/platform/android/app/src/androidTest/kotlin/coop/polypoly/polypod/polyIn/PolyInTestDouble.kt
@@ -7,9 +7,9 @@ class PolyInTestDouble : PolyIn(
     context =
     androidx.test.core.app.ApplicationProvider.getApplicationContext()
 ) {
-    var selectWasCalled = false
-    var selectMatcher: Matcher? = null
-    var selectReturn: List<Quad>? = null
+    var matchWasCalled = false
+    var matchMatcher: Matcher? = null
+    var matchReturn: List<Quad>? = null
     var addWasCalled = false
     var addParams: List<Quad>? = null
 
@@ -18,10 +18,10 @@ class PolyInTestDouble : PolyIn(
         addParams = null
     }
 
-    override suspend fun select(matcher: Matcher): List<Quad> {
-        selectWasCalled = true
-        selectMatcher = matcher
-        return selectReturn ?: emptyList()
+    override suspend fun match(matcher: Matcher): List<Quad> {
+        matchWasCalled = true
+        matchMatcher = matcher
+        return matchReturn ?: emptyList()
     }
 
     override suspend fun add(quads: List<Quad>) {

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/PodApi.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/PodApi.kt
@@ -57,8 +57,7 @@ open class PodApi(
             "polyIn" -> {
                 when (inner) {
                     "add" -> return handlePolyInAdd(args)
-                    "select" -> return handlePolyInSelect(args)
-                    "match" -> return handlePolyInSelect(args)
+                    "match" -> return handlePolyInMatch(args)
                     "delete" -> return handlePolyInDelete(args)
                     "has" -> return handlePolyInHas(args)
                 }
@@ -177,9 +176,9 @@ open class PodApi(
         return ValueFactory.newNil() // add() doesn't return anything
     }
 
-    private suspend fun handlePolyInSelect(args: List<Value>): Value {
-        logger.debug("dispatch() -> polyIn.select")
-        val result = polyIn.select(Matcher.codec.decode(args[0]))
+    private suspend fun handlePolyInMatch(args: List<Value>): Value {
+        logger.debug("dispatch() -> polyIn.match")
+        val result = polyIn.match(Matcher.codec.decode(args[0]))
         return ValueFactory.newArray(result.map { Quad.codec.encode(it) })
     }
 

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/polyIn/PolyIn.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/polyIn/PolyIn.kt
@@ -43,7 +43,7 @@ open class PolyIn(
         private val logger = LoggerFactory.getLogger(javaClass.enclosingClass)
     }
 
-    open suspend fun select(matcher: Matcher): List<Quad> {
+    open suspend fun match(matcher: Matcher): List<Quad> {
         val retList: MutableList<Quad> = mutableListOf()
 
         val stmtsIterator = model.listStatements(

--- a/platform/android/app/src/test/kotlin/coop/polypoly/polypod/polyin/PolyInTest.kt
+++ b/platform/android/app/src/test/kotlin/coop/polypoly/polypod/polyin/PolyInTest.kt
@@ -164,7 +164,7 @@ class PolyInTest {
             polyIn?.add(storageData)
         }
         val returnedData = runBlocking {
-            polyIn?.select(
+            polyIn?.match(
                 Matcher(null, null, null)
             )
         }
@@ -197,7 +197,7 @@ class PolyInTest {
             polyIn?.add(storageData)
         }
         val returnedData = runBlocking {
-            polyIn?.select(
+            polyIn?.match(
                 Matcher(
                     null,
                     IRI("https://polypoly.coop/justChecking"),
@@ -241,7 +241,7 @@ class PolyInTest {
             databaseName = TEST_DB_NAME
         ).let {
             runBlocking {
-                it.select(
+                it.match(
                     Matcher(null, null, null)
                 )
             }
@@ -305,7 +305,7 @@ class PolyInTest {
             polyIn?.delete(firstElement)
         }
         val returnedData = runBlocking {
-            polyIn?.select(
+            polyIn?.match(
                 Matcher(
                     null,
                     null,

--- a/platform/feature-api/api/pod-api/package.json
+++ b/platform/feature-api/api/pod-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polypoly-eu/pod-api",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Definitions, spec, and dummy implementation for the API of a Pod",
   "files": [
     "dist/*.js",

--- a/platform/feature-api/api/pod-api/src/api.ts
+++ b/platform/feature-api/api/pod-api/src/api.ts
@@ -77,16 +77,24 @@ export interface PolyIn {
      * example failure of synchronization across multiple devices.
      *
      * @param quads the triples that should be stored in the Pod
+     * @returns a Promise that will be resolved to void.
      */
     add(...quads: RDF.Quad[]): Promise<void>;
 
     /**
+     * Deletes the indicated triples
+     *
      * @param quads the triples that should be removed from the Pod
+     * @returns a Promise that will be resolved to void.
      */
     delete(...quads: RDF.Quad[]): Promise<void>;
 
     /**
+     * Checks whether the set of triples (called quads because they include the graph or namespace)
+     * are included in the pod. Returns true if they do.
+     *
      * @param quads the triples that should be removed from the Pod
+     * @returns a Promise that will be resolved to a boolean.
      */
     has(...quads: RDF.Quad[]): Promise<boolean>;
 }

--- a/platform/feature-api/api/pod-api/src/api.ts
+++ b/platform/feature-api/api/pod-api/src/api.ts
@@ -77,7 +77,6 @@ export interface PolyIn {
      * example failure of synchronization across multiple devices.
      *
      * @param quads the triples that should be stored in the Pod
-     * @returns a Promise that will be resolved to void.
      */
     add(...quads: RDF.Quad[]): Promise<void>;
 
@@ -85,7 +84,6 @@ export interface PolyIn {
      * Deletes the indicated triples
      *
      * @param quads the triples that should be removed from the Pod
-     * @returns a Promise that will be resolved to void.
      */
     delete(...quads: RDF.Quad[]): Promise<void>;
 

--- a/platform/feature-api/api/pod-api/src/api.ts
+++ b/platform/feature-api/api/pod-api/src/api.ts
@@ -40,8 +40,6 @@ export interface Matcher {
  */
 export interface PolyIn {
     /**
-     * @deprecated use `match()` instead.
-     *
      * Queries the Pod for triples matching the given filter. For each property ([[Matcher.subject]],
      * [[Matcher.predicate]], [[Matcher.object]]) that is specified in the argument, the result set is narrowed to only
      * contain triples that match the property exactly.
@@ -49,7 +47,7 @@ export interface PolyIn {
      * For example, when querying the store as follows:
      *
      * ```
-     * const results = await polyIn.select({
+     * const results = await polyIn.match({
      *     subject: factory.namedNode("http://example.org")
      * })
      * ```
@@ -58,16 +56,8 @@ export interface PolyIn {
      *
      * Features cannot rely on obtaining a complete view of the data using this method. The results may only reflect a
      * filtered subset due to e.g. access restrictions or incomplete synchronization across multiple machines.
-     *
      * @param matcher a [[Matcher]] where any property may be left unspecified
-     *
      * @returns a set of triples that conform to the specified [[Matcher]]
-     */
-    select(matcher: Partial<Matcher>): Promise<RDF.Quad[]>;
-
-    /**
-     * Queries the Pod for triples matching the given filter.
-     * @param matcher a [[Matcher]] where any property may be left unspecified
      */
     match(matcher: Partial<Matcher>): Promise<RDF.Quad[]>;
 

--- a/platform/feature-api/api/pod-api/src/default.ts
+++ b/platform/feature-api/api/pod-api/src/default.ts
@@ -52,15 +52,6 @@ export class DefaultPod implements Pod {
                         dataFactory.defaultGraph()
                     )
                 ),
-            select: async (matcher) =>
-                Array.from(
-                    this.store.match(
-                        matcher.subject,
-                        matcher.predicate,
-                        matcher.object,
-                        dataFactory.defaultGraph()
-                    )
-                ),
             add: async (...quads) =>
                 quads.forEach((quad) => {
                     this.checkQuad(quad);

--- a/platform/feature-api/api/pod-api/src/spec.ts
+++ b/platform/feature-api/api/pod-api/src/spec.ts
@@ -34,7 +34,11 @@ function encodeUtf8(string: string): Uint8Array {
  * access or provide a URI to a local httpbin service.
  */
 export class PodSpec {
-    constructor(private readonly pod: Pod, private readonly path: string) {
+    constructor(
+        private readonly pod: Pod,
+        private readonly path: string,
+        private readonly httpbinUrl: string
+    ) {
         chai.use(chaiAsPromised);
     }
 

--- a/platform/feature-api/api/pod-api/src/spec.ts
+++ b/platform/feature-api/api/pod-api/src/spec.ts
@@ -34,11 +34,7 @@ function encodeUtf8(string: string): Uint8Array {
  * access or provide a URI to a local httpbin service.
  */
 export class PodSpec {
-    constructor(
-        private readonly pod: Pod,
-        private readonly path: string,
-        private readonly httpbinUrl: string
-    ) {
+    constructor(private readonly pod: Pod, private readonly path: string) {
         chai.use(chaiAsPromised);
     }
 
@@ -62,7 +58,7 @@ export class PodSpec {
                 await assert.isRejected(polyIn.delete(quad), /default/);
             });
 
-            it("add/select", async () => {
+            it("add/match", async () => {
                 const { triple } = gens(dataFactory);
                 await fc.assert(
                     fc.asyncProperty(fc.array(triple), async (quads) => {

--- a/platform/feature-api/communication/remote-pod/src/async.ts
+++ b/platform/feature-api/communication/remote-pod/src/async.ts
@@ -50,10 +50,6 @@ class AsyncPolyIn implements PolyIn {
         return (await this.promise).match(matcher);
     }
 
-    async select(matcher: Partial<Matcher>): Promise<Quad[]> {
-        return (await this.promise).select(matcher);
-    }
-
     async add(...quads: Quad[]): Promise<void> {
         return (await this.promise).add(...quads);
     }

--- a/platform/feature-api/communication/remote-pod/src/remote.ts
+++ b/platform/feature-api/communication/remote-pod/src/remote.ts
@@ -38,7 +38,6 @@ import * as RDF from "@polypoly-eu/rdf";
 import { Bubblewrap, Classes } from "@polypoly-eu/bubblewrap";
 
 type PolyInBackend = ObjectBackendSpec<{
-    select(matcher: Partial<Matcher>): ValueBackendSpec<Quad[]>;
     match(matcher: Partial<Matcher>): ValueBackendSpec<Quad[]>;
     add(...quads: Quad[]): ValueBackendSpec<void>;
     delete(...quads: Quad[]): ValueBackendSpec<void>;
@@ -178,7 +177,6 @@ export class RemoteClientPod implements Pod {
         return {
             add: (...quads) => this.rpcClient.polyIn().add(...quads)(),
             match: (matcher) => this.rpcClient.polyIn().match(matcher)(),
-            select: (matcher) => this.rpcClient.polyIn().select(matcher)(),
             delete: (...quads) => this.rpcClient.polyIn().delete(...quads)(),
             has: (...quads) => this.rpcClient.polyIn().has(...quads)(),
         };

--- a/platform/ios/PolyPodApp/PodApi/PolyIn/CoreData+PolyIn.swift
+++ b/platform/ios/PolyPodApp/PodApi/PolyIn/CoreData+PolyIn.swift
@@ -21,10 +21,6 @@ extension CoreDataStack: PolyIn {
     }
     
     func matchQuads(matcher: ExtendedData, completionHandler: @escaping ([ExtendedData]?, Error?) -> Void) {
-        selectQuads(matcher: matcher, completionHandler: completionHandler)
-    }
-    
-    func selectQuads(matcher: ExtendedData, completionHandler: @escaping ([ExtendedData]?, Error?) -> Void) {
         let (predicate, filterOperation) = quadsPredicateAndFilter(matcher: matcher)
         perform { managedContext in
             do {

--- a/platform/ios/PolyPodApp/PodApi/PolyIn/PolyIn.swift
+++ b/platform/ios/PolyPodApp/PodApi/PolyIn/PolyIn.swift
@@ -3,7 +3,6 @@ import CoreData
 protocol PolyIn {
     func addQuads(quads: [ExtendedData], completionHandler: @escaping (Error?) -> Void)
     func matchQuads(matcher: ExtendedData, completionHandler: @escaping ([ExtendedData]?, Error?) -> Void)
-    func selectQuads(matcher: ExtendedData, completionHandler: @escaping ([ExtendedData]?, Error?) -> Void)
     func deleteQuads(quads: [ExtendedData], completionHandler: @escaping (Error?) -> Void)
     func hasQuads(quads: [ExtendedData], completionHandler: @escaping (Bool) -> Void)
 }

--- a/platform/ios/PolyPodApp/PodApi/PostOffice.swift
+++ b/platform/ios/PolyPodApp/PodApi/PostOffice.swift
@@ -95,10 +95,8 @@ extension PostOffice {
         switch method {
         case "add":
             handlePolyInAdd(args: args, completionHandler: completionHandler)
-        case "select":
-            handlePolyInSelect(args: args, completionHandler: completionHandler)
         case "match":
-            handlePolyInSelect(args: args, completionHandler: completionHandler)
+            handlePolyInMatch(args: args, completionHandler: completionHandler)
         case "delete":
             handlePolyInDelete(args: args, completionHandler: completionHandler)
         case "has":
@@ -149,12 +147,12 @@ extension PostOffice {
         }
     }
     
-    private func handlePolyInSelect(args: [Any], completionHandler: @escaping (MessagePackValue?, MessagePackValue?) -> Void) {
+    private func handlePolyInMatch(args: [Any], completionHandler: @escaping (MessagePackValue?, MessagePackValue?) -> Void) {
         guard let extendedData = extractMatcher(args[0]) else {
             completionHandler(nil, createErrorResponse(#function, PodApiError.badData(args[0])))
             return
         }
-        PodApi.shared.polyIn.selectQuads(matcher: extendedData) { quads, error in
+        PodApi.shared.polyIn.matchQuads(matcher: extendedData) { quads, error in
             if let error = error {
                 completionHandler(nil, createErrorResponse(#function, error))
                 return

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -41,22 +41,6 @@ class LocalStoragePolyIn implements PolyIn {
         });
     }
 
-    async select(matcher: Partial<Matcher>): Promise<RDF.Quad[]> {
-        return this.store.filter((quad: RDF.Quad) => {
-            if (!quad) return false;
-            if (matcher.subject && quad.subject.value != matcher.subject.value)
-                return false;
-            if (matcher.object && quad.object.value != matcher.object.value)
-                return false;
-            if (
-                matcher.predicate &&
-                quad.predicate.value != matcher.predicate.value
-            )
-                return false;
-            return true;
-        });
-    }
-
     async add(...quads: RDF.Quad[]): Promise<void> {
         this.store.push(...quads);
         localStorage.setItem(


### PR DESCRIPTION
It was substituted by match, and in fact all implementations were exactly the same. Since #810 is coming, there's no need to implement this too.