### PR TITLE
🐛 async redux

### DIFF
--- a/features/bundle/package-lock.json
+++ b/features/bundle/package-lock.json
@@ -2064,7 +2064,6 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
-        "@web/test-runner-chrome": "^0.10.5",
         "identity-obj-proxy": "^3.0.0"
       }
     },
@@ -4683,8 +4682,9 @@
       }
     },
     "../../feature-utils/poly-look/node_modules/async": {
-      "version": "2.6.3",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -9835,7 +9835,8 @@
       "name": "facebook-import-feature",
       "dev": true,
       "dependencies": {
-        "@polypoly-eu/feature-file-storage": "file:../../feature-utils/file-storage",
+        "@polypoly-eu/poly-analysis": "file:../../feature-utils/poly-analysis",
+        "@polypoly-eu/poly-import": "file:../../feature-utils/poly-import",
         "@polypoly-eu/silly-i18n": "file:../../feature-utils/silly-i18n",
         "d3": "^7.0.1",
         "react": "^17.0.2",
@@ -11411,10 +11412,11 @@
       }
     },
     "../google": {
+      "name": "google-feature",
       "dev": true,
       "dependencies": {
-        "@polypoly-eu/feature-file-storage": "file:../../feature-utils/file-storage",
         "@polypoly-eu/podjs": "file:../../platform/podjs",
+        "@polypoly-eu/poly-import": "file:../../feature-utils/poly-import",
         "@polypoly-eu/silly-i18n": "file:../../feature-utils/silly-i18n",
         "d3": "^7.0.1",
         "react": "^17.0.2",
@@ -16687,9 +16689,10 @@
       "version": "file:../facebookImport",
       "requires": {
         "@babel/preset-react": "^7.14.5",
-        "@polypoly-eu/feature-file-storage": "file:../../feature-utils/file-storage",
         "@polypoly-eu/pod-api": "file:../../platform/feature-api/api/pod-api",
         "@polypoly-eu/podjs": "file:../../platform/podjs",
+        "@polypoly-eu/poly-analysis": "file:../../feature-utils/poly-analysis",
+        "@polypoly-eu/poly-import": "file:../../feature-utils/poly-import",
         "@polypoly-eu/poly-look": "file:../../feature-utils/poly-look",
         "@polypoly-eu/rollup-plugin-copy-watch": "file:../../dev-utils/rollup-plugin-copy-watch",
         "@polypoly-eu/silly-i18n": "file:../../feature-utils/silly-i18n",
@@ -21684,7 +21687,6 @@
             "@testing-library/jest-dom": "^5.16.2",
             "@testing-library/react": "^12.1.3",
             "@web/test-runner": "^0.13.22",
-            "@web/test-runner-chrome": "^0.10.5",
             "d3": "^7.0.4",
             "d3-sankey": "^0.12.3",
             "identity-obj-proxy": "^3.0.0",
@@ -23640,8 +23642,9 @@
               "dev": true
             },
             "async": {
-              "version": "2.6.3",
-              "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+              "version": "2.6.4",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+              "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
               "dev": true,
               "requires": {
                 "lodash": "^4.17.14"
@@ -27408,9 +27411,9 @@
       "version": "file:../google",
       "requires": {
         "@babel/preset-react": "^7.14.5",
-        "@polypoly-eu/feature-file-storage": "file:../../feature-utils/file-storage",
         "@polypoly-eu/pod-api": "file:../../platform/feature-api/api/pod-api",
         "@polypoly-eu/podjs": "file:../../platform/podjs",
+        "@polypoly-eu/poly-import": "file:../../feature-utils/poly-import",
         "@polypoly-eu/poly-look": "file:../../feature-utils/poly-look",
         "@polypoly-eu/rollup-plugin-copy-watch": "file:../../dev-utils/rollup-plugin-copy-watch",
         "@polypoly-eu/silly-i18n": "file:../../feature-utils/silly-i18n",
@@ -30190,7 +30193,6 @@
             "@testing-library/jest-dom": "^5.16.2",
             "@testing-library/react": "^12.1.3",
             "@web/test-runner": "^0.13.22",
-            "@web/test-runner-chrome": "^0.10.5",
             "d3": "^7.0.4",
             "d3-sankey": "^0.12.3",
             "identity-obj-proxy": "^3.0.0",
@@ -32146,8 +32148,9 @@
               "dev": true
             },
             "async": {
-              "version": "2.6.3",
-              "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+              "version": "2.6.4",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+              "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
               "dev": true,
               "requires": {
                 "lodash": "^4.17.14"
@@ -38193,7 +38196,6 @@
             "@testing-library/jest-dom": "^5.16.2",
             "@testing-library/react": "^12.1.3",
             "@web/test-runner": "^0.13.22",
-            "@web/test-runner-chrome": "^0.10.5",
             "d3": "^7.0.4",
             "d3-sankey": "^0.12.3",
             "identity-obj-proxy": "^3.0.0",
@@ -40149,8 +40151,9 @@
               "dev": true
             },
             "async": {
-              "version": "2.6.3",
-              "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+              "version": "2.6.4",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+              "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
               "dev": true,
               "requires": {
                 "lodash": "^4.17.14"
@@ -46317,7 +46320,6 @@
             "@testing-library/jest-dom": "^5.16.2",
             "@testing-library/react": "^12.1.3",
             "@web/test-runner": "^0.13.22",
-            "@web/test-runner-chrome": "^0.10.5",
             "d3": "^7.0.4",
             "d3-sankey": "^0.12.3",
             "identity-obj-proxy": "^3.0.0",
@@ -48273,8 +48275,9 @@
               "dev": true
             },
             "async": {
-              "version": "2.6.3",
-              "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+              "version": "2.6.4",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+              "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
               "dev": true,
               "requires": {
                 "lodash": "^4.17.14"

--- a/features/facebookImport/package-lock.json
+++ b/features/facebookImport/package-lock.json
@@ -2204,7 +2204,6 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
-        "@web/test-runner-chrome": "^0.10.5",
         "identity-obj-proxy": "^3.0.0"
       }
     },
@@ -4827,9 +4826,10 @@
       }
     },
     "../../feature-utils/poly-look/node_modules/async": {
-      "version": "2.6.3",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -15559,7 +15559,6 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
-        "@web/test-runner-chrome": "^0.10.5",
         "d3": "^7.0.4",
         "d3-sankey": "^0.12.3",
         "identity-obj-proxy": "^3.0.0",
@@ -17591,7 +17590,9 @@
           "dev": true
         },
         "async": {
-          "version": "2.6.3",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "dev": true,
           "requires": {
             "lodash": "^4.17.14"

--- a/features/google/package-lock.json
+++ b/features/google/package-lock.json
@@ -2134,7 +2134,6 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
-        "@web/test-runner-chrome": "^0.10.5",
         "identity-obj-proxy": "^3.0.0"
       }
     },
@@ -4757,9 +4756,10 @@
       }
     },
     "../../feature-utils/poly-look/node_modules/async": {
-      "version": "2.6.3",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -15130,7 +15130,6 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
-        "@web/test-runner-chrome": "^0.10.5",
         "d3": "^7.0.4",
         "d3-sankey": "^0.12.3",
         "identity-obj-proxy": "^3.0.0",
@@ -17162,7 +17161,9 @@
           "dev": true
         },
         "async": {
-          "version": "2.6.3",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "dev": true,
           "requires": {
             "lodash": "^4.17.14"

--- a/features/lexicon/package-lock.json
+++ b/features/lexicon/package-lock.json
@@ -2120,7 +2120,6 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
-        "@web/test-runner-chrome": "^0.10.5",
         "identity-obj-proxy": "^3.0.0"
       }
     },
@@ -4743,9 +4742,10 @@
       }
     },
     "../../feature-utils/poly-look/node_modules/async": {
-      "version": "2.6.3",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -8349,100 +8349,9 @@
     "../../platform/feature-api/api/fetch-spec": {
       "name": "@polypoly-eu/fetch-spec",
       "version": "0.0.1",
-      "dev": true,
+      "extraneous": true,
       "devDependencies": {
         "ts-node": "^9.1.1"
-      }
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/arg": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/buffer-from": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/create-require": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/source-map": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/source-map-support": {
-      "version": "0.5.19",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/ts-node": {
-      "version": "9.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.7"
-      }
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/typescript": {
-      "version": "4.5.4",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/yn": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "../../platform/feature-api/api/pod-api": {
@@ -8450,12 +8359,12 @@
       "version": "0.7.2",
       "dev": true,
       "dependencies": {
-        "@polypoly-eu/fetch-spec": "file:../fetch-spec",
         "@polypoly-eu/rdf": "file:../rdf"
       },
       "devDependencies": {
         "@polypoly-eu/dummy-server": "file:../../../../dev-utils/dummy-server",
         "@polypoly-eu/rdf-spec": "file:../rdf-spec",
+        "@polypoly-eu/test-utils": "file:../../utils",
         "@rdfjs/dataset": "^1.0.1",
         "@types/chai": "^4.2.14",
         "@types/chai-as-promised": "^7.1.3",
@@ -8477,10 +8386,6 @@
     },
     "../../platform/feature-api/api/pod-api/node_modules/@polypoly-eu/dummy-server": {
       "resolved": "../../dev-utils/dummy-server",
-      "link": true
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/@polypoly-eu/fetch-spec": {
-      "resolved": "../../platform/feature-api/api/fetch-spec",
       "link": true
     },
     "../../platform/feature-api/api/pod-api/node_modules/@polypoly-eu/rdf": {
@@ -9137,7 +9042,6 @@
       "name": "@polypoly-eu/podjs",
       "dev": true,
       "dependencies": {
-        "@polypoly-eu/fetch-spec": "file:../feature-api/api/fetch-spec",
         "@polypoly-eu/pod-api": "file:../feature-api/api/pod-api",
         "@polypoly-eu/rdf": "file:../feature-api/api/rdf",
         "@zip.js/zip.js": "2.3.7",
@@ -9155,10 +9059,6 @@
       "peerDependencies": {
         "body-parser": "^1.19.0"
       }
-    },
-    "../../platform/podjs/node_modules/@polypoly-eu/fetch-spec": {
-      "resolved": "../../platform/feature-api/api/fetch-spec",
-      "link": true
     },
     "../../platform/podjs/node_modules/@polypoly-eu/pod-api": {
       "resolved": "../../platform/feature-api/api/pod-api",
@@ -9968,7 +9868,6 @@
     "@polypoly-eu/podjs": {
       "version": "file:../../platform/podjs",
       "requires": {
-        "@polypoly-eu/fetch-spec": "file:../feature-api/api/fetch-spec",
         "@polypoly-eu/pod-api": "file:../feature-api/api/pod-api",
         "@polypoly-eu/rdf": "file:../feature-api/api/rdf",
         "@polypoly-eu/rdf-spec": "file:../feature-api/api/rdf-spec",
@@ -9982,76 +9881,13 @@
         "rdf-js": "^4.0.2"
       },
       "dependencies": {
-        "@polypoly-eu/fetch-spec": {
-          "version": "file:../../platform/feature-api/api/fetch-spec",
-          "requires": {
-            "ts-node": "^9.1.1"
-          },
-          "dependencies": {
-            "arg": {
-              "version": "4.1.3",
-              "dev": true
-            },
-            "buffer-from": {
-              "version": "1.1.2",
-              "dev": true
-            },
-            "create-require": {
-              "version": "1.1.1",
-              "dev": true
-            },
-            "make-error": {
-              "version": "1.3.6",
-              "dev": true
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "dev": true
-            },
-            "source-map-support": {
-              "version": "0.5.19",
-              "dev": true,
-              "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-              }
-            },
-            "ts-node": {
-              "version": "9.1.1",
-              "dev": true,
-              "requires": {
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "source-map-support": "^0.5.17",
-                "yn": "3.1.1"
-              },
-              "dependencies": {
-                "diff": {
-                  "version": "4.0.2",
-                  "dev": true
-                }
-              }
-            },
-            "typescript": {
-              "version": "4.5.4",
-              "dev": true,
-              "peer": true
-            },
-            "yn": {
-              "version": "3.1.1",
-              "dev": true
-            }
-          }
-        },
         "@polypoly-eu/pod-api": {
           "version": "file:../../platform/feature-api/api/pod-api",
           "requires": {
             "@polypoly-eu/dummy-server": "file:../../../../dev-utils/dummy-server",
-            "@polypoly-eu/fetch-spec": "file:../fetch-spec",
             "@polypoly-eu/rdf": "file:../rdf",
             "@polypoly-eu/rdf-spec": "file:../rdf-spec",
+            "@polypoly-eu/test-utils": "file:../../utils",
             "@rdfjs/dataset": "^1.0.1",
             "@types/chai": "^4.2.14",
             "@types/chai-as-promised": "^7.1.3",
@@ -11129,69 +10965,6 @@
                 },
                 "yeast": {
                   "version": "0.1.2",
-                  "dev": true
-                }
-              }
-            },
-            "@polypoly-eu/fetch-spec": {
-              "version": "file:../../platform/feature-api/api/fetch-spec",
-              "requires": {
-                "ts-node": "^9.1.1"
-              },
-              "dependencies": {
-                "arg": {
-                  "version": "4.1.3",
-                  "dev": true
-                },
-                "buffer-from": {
-                  "version": "1.1.2",
-                  "dev": true
-                },
-                "create-require": {
-                  "version": "1.1.1",
-                  "dev": true
-                },
-                "make-error": {
-                  "version": "1.3.6",
-                  "dev": true
-                },
-                "source-map": {
-                  "version": "0.6.1",
-                  "dev": true
-                },
-                "source-map-support": {
-                  "version": "0.5.19",
-                  "dev": true,
-                  "requires": {
-                    "buffer-from": "^1.0.0",
-                    "source-map": "^0.6.0"
-                  }
-                },
-                "ts-node": {
-                  "version": "9.1.1",
-                  "dev": true,
-                  "requires": {
-                    "arg": "^4.1.0",
-                    "create-require": "^1.1.0",
-                    "diff": "^4.0.1",
-                    "make-error": "^1.1.1",
-                    "source-map-support": "^0.5.17",
-                    "yn": "3.1.1"
-                  },
-                  "dependencies": {
-                    "diff": {
-                      "version": "4.0.2",
-                      "dev": true
-                    }
-                  }
-                },
-                "typescript": {
-                  "version": "4.5.4",
-                  "dev": true,
-                  "peer": true
-                },
-                "yn": {
-                  "version": "3.1.1",
                   "dev": true
                 }
               }
@@ -12467,7 +12240,6 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
-        "@web/test-runner-chrome": "^0.10.5",
         "d3": "^7.0.4",
         "d3-sankey": "^0.12.3",
         "identity-obj-proxy": "^3.0.0",
@@ -14499,7 +14271,9 @@
           "dev": true
         },
         "async": {
-          "version": "2.6.3",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "dev": true,
           "requires": {
             "lodash": "^4.17.14"

--- a/features/polyPreview/package-lock.json
+++ b/features/polyPreview/package-lock.json
@@ -2112,7 +2112,6 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
-        "@web/test-runner-chrome": "^0.10.5",
         "identity-obj-proxy": "^3.0.0"
       }
     },
@@ -4735,9 +4734,10 @@
       }
     },
     "../../feature-utils/poly-look/node_modules/async": {
-      "version": "2.6.3",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -8341,100 +8341,9 @@
     "../../platform/feature-api/api/fetch-spec": {
       "name": "@polypoly-eu/fetch-spec",
       "version": "0.0.1",
-      "dev": true,
+      "extraneous": true,
       "devDependencies": {
         "ts-node": "^9.1.1"
-      }
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/arg": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/buffer-from": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/create-require": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/source-map": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/source-map-support": {
-      "version": "0.5.19",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/ts-node": {
-      "version": "9.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.7"
-      }
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/typescript": {
-      "version": "4.5.4",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "../../platform/feature-api/api/fetch-spec/node_modules/yn": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "../../platform/feature-api/api/pod-api": {
@@ -8442,12 +8351,12 @@
       "version": "0.7.2",
       "dev": true,
       "dependencies": {
-        "@polypoly-eu/fetch-spec": "file:../fetch-spec",
         "@polypoly-eu/rdf": "file:../rdf"
       },
       "devDependencies": {
         "@polypoly-eu/dummy-server": "file:../../../../dev-utils/dummy-server",
         "@polypoly-eu/rdf-spec": "file:../rdf-spec",
+        "@polypoly-eu/test-utils": "file:../../utils",
         "@rdfjs/dataset": "^1.0.1",
         "@types/chai": "^4.2.14",
         "@types/chai-as-promised": "^7.1.3",
@@ -8469,10 +8378,6 @@
     },
     "../../platform/feature-api/api/pod-api/node_modules/@polypoly-eu/dummy-server": {
       "resolved": "../../dev-utils/dummy-server",
-      "link": true
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/@polypoly-eu/fetch-spec": {
-      "resolved": "../../platform/feature-api/api/fetch-spec",
       "link": true
     },
     "../../platform/feature-api/api/pod-api/node_modules/@polypoly-eu/rdf": {
@@ -9129,7 +9034,6 @@
       "name": "@polypoly-eu/podjs",
       "dev": true,
       "dependencies": {
-        "@polypoly-eu/fetch-spec": "file:../feature-api/api/fetch-spec",
         "@polypoly-eu/pod-api": "file:../feature-api/api/pod-api",
         "@polypoly-eu/rdf": "file:../feature-api/api/rdf",
         "@zip.js/zip.js": "2.3.7",
@@ -9147,10 +9051,6 @@
       "peerDependencies": {
         "body-parser": "^1.19.0"
       }
-    },
-    "../../platform/podjs/node_modules/@polypoly-eu/fetch-spec": {
-      "resolved": "../../platform/feature-api/api/fetch-spec",
-      "link": true
     },
     "../../platform/podjs/node_modules/@polypoly-eu/pod-api": {
       "resolved": "../../platform/feature-api/api/pod-api",
@@ -9525,7 +9425,6 @@
     "@polypoly-eu/podjs": {
       "version": "file:../../platform/podjs",
       "requires": {
-        "@polypoly-eu/fetch-spec": "file:../feature-api/api/fetch-spec",
         "@polypoly-eu/pod-api": "file:../feature-api/api/pod-api",
         "@polypoly-eu/rdf": "file:../feature-api/api/rdf",
         "@polypoly-eu/rdf-spec": "file:../feature-api/api/rdf-spec",
@@ -9539,76 +9438,13 @@
         "rdf-js": "^4.0.2"
       },
       "dependencies": {
-        "@polypoly-eu/fetch-spec": {
-          "version": "file:../../platform/feature-api/api/fetch-spec",
-          "requires": {
-            "ts-node": "^9.1.1"
-          },
-          "dependencies": {
-            "arg": {
-              "version": "4.1.3",
-              "dev": true
-            },
-            "buffer-from": {
-              "version": "1.1.2",
-              "dev": true
-            },
-            "create-require": {
-              "version": "1.1.1",
-              "dev": true
-            },
-            "make-error": {
-              "version": "1.3.6",
-              "dev": true
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "dev": true
-            },
-            "source-map-support": {
-              "version": "0.5.19",
-              "dev": true,
-              "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-              }
-            },
-            "ts-node": {
-              "version": "9.1.1",
-              "dev": true,
-              "requires": {
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "source-map-support": "^0.5.17",
-                "yn": "3.1.1"
-              },
-              "dependencies": {
-                "diff": {
-                  "version": "4.0.2",
-                  "dev": true
-                }
-              }
-            },
-            "typescript": {
-              "version": "4.5.4",
-              "dev": true,
-              "peer": true
-            },
-            "yn": {
-              "version": "3.1.1",
-              "dev": true
-            }
-          }
-        },
         "@polypoly-eu/pod-api": {
           "version": "file:../../platform/feature-api/api/pod-api",
           "requires": {
             "@polypoly-eu/dummy-server": "file:../../../../dev-utils/dummy-server",
-            "@polypoly-eu/fetch-spec": "file:../fetch-spec",
             "@polypoly-eu/rdf": "file:../rdf",
             "@polypoly-eu/rdf-spec": "file:../rdf-spec",
+            "@polypoly-eu/test-utils": "file:../../utils",
             "@rdfjs/dataset": "^1.0.1",
             "@types/chai": "^4.2.14",
             "@types/chai-as-promised": "^7.1.3",
@@ -10686,69 +10522,6 @@
                 },
                 "yeast": {
                   "version": "0.1.2",
-                  "dev": true
-                }
-              }
-            },
-            "@polypoly-eu/fetch-spec": {
-              "version": "file:../../platform/feature-api/api/fetch-spec",
-              "requires": {
-                "ts-node": "^9.1.1"
-              },
-              "dependencies": {
-                "arg": {
-                  "version": "4.1.3",
-                  "dev": true
-                },
-                "buffer-from": {
-                  "version": "1.1.2",
-                  "dev": true
-                },
-                "create-require": {
-                  "version": "1.1.1",
-                  "dev": true
-                },
-                "make-error": {
-                  "version": "1.3.6",
-                  "dev": true
-                },
-                "source-map": {
-                  "version": "0.6.1",
-                  "dev": true
-                },
-                "source-map-support": {
-                  "version": "0.5.19",
-                  "dev": true,
-                  "requires": {
-                    "buffer-from": "^1.0.0",
-                    "source-map": "^0.6.0"
-                  }
-                },
-                "ts-node": {
-                  "version": "9.1.1",
-                  "dev": true,
-                  "requires": {
-                    "arg": "^4.1.0",
-                    "create-require": "^1.1.0",
-                    "diff": "^4.0.1",
-                    "make-error": "^1.1.1",
-                    "source-map-support": "^0.5.17",
-                    "yn": "3.1.1"
-                  },
-                  "dependencies": {
-                    "diff": {
-                      "version": "4.0.2",
-                      "dev": true
-                    }
-                  }
-                },
-                "typescript": {
-                  "version": "4.5.4",
-                  "dev": true,
-                  "peer": true
-                },
-                "yn": {
-                  "version": "3.1.1",
                   "dev": true
                 }
               }
@@ -12024,7 +11797,6 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
-        "@web/test-runner-chrome": "^0.10.5",
         "d3": "^7.0.4",
         "d3-sankey": "^0.12.3",
         "identity-obj-proxy": "^3.0.0",
@@ -14056,7 +13828,9 @@
           "dev": true
         },
         "async": {
-          "version": "2.6.3",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "dev": true,
           "requires": {
             "lodash": "^4.17.14"


### PR DESCRIPTION
Opened [issue](https://github.com/modernweb-dev/web/issues/1934) in the dependency that includes it, but since it's two modules removed and one of them (`portfinder`) seems stale, I don't see a chance of this being fixed any time soon. `npm audit fix` works just fine.