### PR TITLE
ref (poly-look) - simplify poly-look.js

### DIFF
--- a/feature-utils/poly-look/src/poly-look.js
+++ b/feature-utils/poly-look/src/poly-look.js
@@ -1,54 +1,6 @@
 import { cssBundler } from "./css";
 cssBundler();
-import {
-  BubbleCluster,
-  VerticalBarChart,
-  MirroredBarChart,
-  SankeyDiagram,
-  TreeMap,
-} from "./visualisations/charts";
-import { PolyChart } from "./visualisations/wrappers/react/polyChart.jsx";
-import {
-  Tab,
-  Tabs,
-  Chip,
-  FilterChips,
-  BlockLegend,
-  LineLegend,
-  ErrorPopup,
-  Card,
-  ClickableCard,
-  RoutingCard,
-  List,
-  SideSwiper,
-  PolyImportProvider,
-  PolyAnalysisProvider,
-  PolyImportContext,
-  PolyAnalysisContext,
-} from "./react-components";
-import { INITIAL_HISTORY_STATE } from "./constants";
-export {
-  BubbleCluster,
-  VerticalBarChart,
-  MirroredBarChart,
-  SankeyDiagram,
-  TreeMap,
-  PolyChart,
-  Chip,
-  FilterChips,
-  Tab,
-  Tabs,
-  BlockLegend,
-  LineLegend,
-  ErrorPopup,
-  Card,
-  ClickableCard,
-  RoutingCard,
-  List,
-  PolyImportProvider,
-  PolyAnalysisProvider,
-  PolyImportContext,
-  PolyAnalysisContext,
-  INITIAL_HISTORY_STATE,
-  SideSwiper,
-};
+
+export { PolyChart } from "./visualisations/wrappers/react/polyChart.jsx";
+export * from "./react-components";
+export * from "./constants";


### PR DESCRIPTION
Lately, I've had a few too many merge conflicts in this file and in `react-components/index.js` . While I think the latter should stay as it is just so you have a place where you can see all the components, the former can be changed since it seems to only serve as an entry point for the bundler.