### PR TITLE
Fix workflow and build issues

### DIFF
--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -52,7 +52,7 @@ jobs:
                       swift:
                       - 'platform/ios/**'
             - name: Install JS packages
-              if: steps.cache.outputs.cache-hit != 'true' && (steps.changes.outputs.coreAndFeatures == 'true' || steps.changes.outputs.js == 'true')
+              if: steps.cache.outputs.cache-hit != 'true' && (steps.changes.outputs.apiAndFeatures == 'true' || steps.changes.outputs.js == 'true')
               run: ./build.js install
             - name: Lint core and features
               if: steps.changes.outputs.js == 'true'

--- a/build/index.js
+++ b/build/index.js
@@ -68,9 +68,14 @@ async function main() {
 
     if (
         !existsSync("node_modules") &&
-        ["lint", "lintfix", "clean", "install", "installAndBuild"].includes(
-            command
-        )
+        [
+            "lint",
+            "lintfix",
+            "clean",
+            "build",
+            "install",
+            "installAndBuild",
+        ].includes(command)
     ) {
         await runCommand("root-install", "👷👷‍♀️", async () => {
             await npmInstall("/");


### PR DESCRIPTION
As exemplified by the latest failure in [this latest PR](https://github.com/polypoly-eu/polyPod/runs/6197622974?check_suite_focus=true)
It's likely that there was one error when solving a conflict when updating the workflow. As a matter of fact there was a cache miss, but the path that checked if `install` was needed was not triggered, due to that mismatch between the updated name and the updated patch check.

> Surprisingly (maybe not), `build` only needs root installs. I guess that since what's involved in build: babel, TS, rollup, is mostly hoisted, it would fail only if there were some specific rollup plugin somewhere. Clarifying dependencies is good.