### PR TITLE
Replace android URL encoding with ascii

### DIFF
--- a/features/google/src/views/import/import.jsx
+++ b/features/google/src/views/import/import.jsx
@@ -31,7 +31,11 @@ const ImportView = () => {
         if (files?.[0]?.id) handleRemoveFile(files[0].id);
         runWithLoadingScreen(async function () {
             try {
-                await polyOut.importArchive(selectedFile.url);
+                const cleanedSelectedFileUrl = selectedFile.url
+                    .replaceAll("%3A", ":")
+                    .replaceAll("%2F", "/");
+                console.log(cleanedSelectedFileUrl);
+                await polyOut.importArchive(cleanedSelectedFileUrl);
                 refreshFiles();
                 setSelectedFile(null);
             } catch (error) {


### PR DESCRIPTION
This did not solve it as now I'm getting:
` java.lang.SecurityException: Permission Denial: reading com.android.providers.downloads.DownloadStorageProvider uri content://com.android.providers.downloads.documents/document/raw:/storage/emulated/0/Download/google-fake-malcomgerlach.zip from pid=14039, uid=10145 requires that you obtain access using ACTION_OPEN_DOCUMENT or related APIs`

This was the path before the replace:
`content://com.android.providers.downloads.documents/document/raw%3A%2Fstorage%2Femulated%2F0%2FDownload%2Fgoogle-fake-malcomgerlach.zip`