### PR TITLE
[🐛] {PROD4POD-1549} Try and avoid first-time build errors by adding a new setup command

### DIFF
--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -51,12 +51,12 @@ jobs:
                       - 'platform/podjs/**'
                       swift:
                       - 'platform/ios/**'
-            - name: Install JS packages
-              if: steps.cache.outputs.cache-hit != 'true' && (steps.changes.outputs.apiAndFeatures == 'true' || steps.changes.outputs.js == 'true')
-              run: ./build.js install
             - name: Lint core and features
               if: steps.changes.outputs.js == 'true'
               run: ./build.js lint
+            - name: Install JS packages
+              if: steps.cache.outputs.cache-hit != 'true' && (steps.changes.outputs.apiAndFeatures == 'true' || steps.changes.outputs.js == 'true')
+              run: ./build.js offlineInstall
             - name: Lint Swift
               if: steps.changes.outputs.swift == 'true'
               working-directory: platform/ios

--- a/build/README.md
+++ b/build/README.md
@@ -15,5 +15,3 @@ the logic in this module, such as Yarn and pnpm workspaces, and while we could
 get those to work with a few workarounds, in the end we decided to stick with
 plain NPM. It's probably not the best package manager, but the most widely
 understood and supported one in the JavaScript ecosystem.
-
-Still, hopefully we will be able to eliminate this module one day.

--- a/build/README.md
+++ b/build/README.md
@@ -5,15 +5,18 @@ that compiles to JavaScript) in the right order.
 
 ## Use
 
-If you are building this *for the first time ever*, run
-
-    ./build.js setup
-
-Consecutive builds will just need
+This command
 
      ./build.js
 
-Run `./build.js --help` for available commands.
+will
+
+1. Make a "root" install, that is, install all packages that are common to different
+   submodules as well as other dev tools like linting.
+2. Install packages in every one of the submodules, running a `npm ci`.
+3. Build those packages that need building, running `npm run build`
+
+Run `./build.js --help` for other available commands.
 
 ## Background
 

--- a/build/README.md
+++ b/build/README.md
@@ -3,6 +3,18 @@
 This package contains logic for building all the code written in JavaScript (or
 that compiles to JavaScript) in the right order.
 
+## Use
+
+If you are building this *for the first time ever*, run
+
+    ./build.js setup
+
+Consecutive builds will just need
+
+     ./build.js
+
+Run `./build.js --help` for available commands.
+
 ## Background
 
 The polyPod core code, as well as all the bundled features, are separated into

--- a/build/cli.js
+++ b/build/cli.js
@@ -10,6 +10,7 @@ const validCommands = [
     "lintfix",
     "list",
     "list-deps",
+    "offlineInstall",
     "setup",
     "syncdeps",
     "test",

--- a/build/cli.js
+++ b/build/cli.js
@@ -10,6 +10,7 @@ const validCommands = [
     "lintfix",
     "list",
     "list-deps",
+    "setup",
     "syncdeps",
     "test",
 ];

--- a/build/cli.js
+++ b/build/cli.js
@@ -11,7 +11,6 @@ const validCommands = [
     "list",
     "list-deps",
     "offlineInstall",
-    "setup",
     "syncdeps",
     "test",
 ];

--- a/build/index.js
+++ b/build/index.js
@@ -67,15 +67,11 @@ async function main() {
     const eslintOptions = ["--ext", ".ts,.js,.tsx,.jsx", "."];
 
     if (
-        !existsSync("node_modules") &&
-        [
-            "lint",
-            "lintfix",
-            "clean",
-            "build",
-            "install",
-            "installAndBuild",
-        ].includes(command)
+        (!existsSync("node_modules") &&
+            ["lint", "lintfix", "clean", "build", "offlineInstall"].includes(
+                command
+            )) ||
+        ["install", "installAndBuild"].includes(command)
     ) {
         await runCommand("root-install", "👷👷‍♀️", async () => {
             await npmInstall("/");

--- a/build/npm.js
+++ b/build/npm.js
@@ -42,15 +42,15 @@ const npx = async (...args) => {
     await executeProcess("npx", ...args);
 };
 
-async function npmInstall(name, offLine = true) {
+async function npmInstall(name, offline = true) {
     let args = ["--no-audit"];
-    if (offLine) {
-        args.push( "--prefer-offline" );
+    if (offline) {
+        args.push("--prefer-offline");
     }
-    args.push( "ci");
+    args.push("ci");
     if (fs.existsSync("package-lock.json")) {
         logDetail(`${name}: Installing dependencies ...`);
-        await npm( ...args );
+        await npm(...args);
     }
 }
 

--- a/build/npm.js
+++ b/build/npm.js
@@ -42,10 +42,15 @@ const npx = async (...args) => {
     await executeProcess("npx", ...args);
 };
 
-async function npmInstall(name) {
+async function npmInstall(name, offLine = true) {
+    let args = ["--no-audit"];
+    if (offLine) {
+        args.push( "--prefer-offline" );
+    }
+    args.push( "ci");
     if (fs.existsSync("package-lock.json")) {
         logDetail(`${name}: Installing dependencies ...`);
-        await npm("--no-audit", "--prefer-offline", "ci");
+        await npm( ...args );
     }
 }
 

--- a/build/pkg.js
+++ b/build/pkg.js
@@ -62,6 +62,10 @@ class Pkg {
             await fsPromises.rm(path, { recursive: true, force: true });
     }
 
+    async setup() {
+        await npmInstall(this.name, false);
+    }
+
     async install() {
         await npmInstall(this.name);
     }

--- a/build/pkg.js
+++ b/build/pkg.js
@@ -62,11 +62,11 @@ class Pkg {
             await fsPromises.rm(path, { recursive: true, force: true });
     }
 
-    async setup() {
+    async install() {
         await npmInstall(this.name, false);
     }
 
-    async install() {
+    async offlineInstall() {
         await npmInstall(this.name);
     }
 

--- a/build/pkg.js
+++ b/build/pkg.js
@@ -63,11 +63,11 @@ class Pkg {
     }
 
     async install() {
-        await npmInstall(this.name, false);
+        await npmInstall(this.name);
     }
 
     async offlineInstall() {
-        await npmInstall(this.name);
+        await npmInstall(this.name, true);
     }
 
     async build() {


### PR DESCRIPTION
There are many changes in this PR, while trying to stick to its spirit, which is making builds work from the first time.
1. `install` now, by default, does not `prefer-offline`. It will run `npm ci --no-audit` on every package. It will also run a root install every time.
2. `installAndBuild` will also run a root install
3. A new commandm `offlineInstall` has been added. This is run from CI instead of `install`, since it does not have any problem as apparently caches in the CI runner are pre-populated. This is used now instead of `install` in CI, so that it's got the same behavior as before.
4. Lint is now run before install, since `lint` by default will run a root install if it does not find `node_modules`.

Some changes have been made to the README, although this would definitely need more extensive documentation.

This takes almost twice as much as the old npm ci, so we might as well keep it separate
![Captura de pantalla de 2022-05-02 12-49-34](https://user-images.githubusercontent.com/500/166222957-02577b61-a338-4465-97fa-8783b2a9a7eb.png)
