### PR TITLE
Fix pod.js generation in lexicon feature

### DIFF
--- a/platform/podjs/rollup-plugin-gen-podjs/genPodjs.js
+++ b/platform/podjs/rollup-plugin-gen-podjs/genPodjs.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 
 function executeReplacement(podJs, manifestJsonPath) {
     try {
@@ -15,14 +16,12 @@ function executeReplacement(podJs, manifestJsonPath) {
 }
 
 function copyPodJs(dest) {
-    if (!fs.existsSync(dest)) {
-        fs.mkdirSync(dest);
-
-        fs.copyFileSync(
-            "node_modules/@polypoly-eu/podjs/dist/pod.js",
-            `${dest}/pod.js`
-        );
+    const destDir = path.dirname(dest);
+    if (!fs.existsSync(destDir)) {
+        fs.mkdirSync(destDir);
     }
+
+    fs.copyFileSync("node_modules/@polypoly-eu/podjs/dist/pod.js", `${dest}`);
 }
 
 /**
@@ -37,7 +36,7 @@ function loadManifest(options = {}) {
     const podJsPath = `${options.build_dir}/pod.js`;
     console.log("Loading", options.manifestPath, "into", podJsPath);
 
-    copyPodJs(options.build_dir);
+    copyPodJs(podJsPath);
 
     executeReplacement(podJsPath, options.manifestPath);
 }


### PR DESCRIPTION
It was previously skipping the pod.js copy, because the 'public'
directory already existed - it happened to work with our other features
because pod.js was going right into the build directory ('dist') there,
and the genPodJs plugin happened to be the first one to be called.

I believe the logic is now what it was supposed to be originally -
merely ensuring that the directory pod.js is supposed to be copied into
actually exists.