### PR TITLE
Fix zip file reading via pod.js

### DIFF
--- a/feature-utils/poly-import/src/storage.js
+++ b/feature-utils/poly-import/src/storage.js
@@ -69,7 +69,7 @@ export class ZipFile {
     }
 
     get id() {
-        return this._file.getId();
+        return this._file.id;
     }
 
     async _readEntriesList() {

--- a/feature-utils/poly-import/src/storage.js
+++ b/feature-utils/poly-import/src/storage.js
@@ -69,7 +69,7 @@ export class ZipFile {
     }
 
     get id() {
-        return this._file.id;
+        return this._file.getId();
     }
 
     async _readEntriesList() {

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -262,15 +262,32 @@ class IDBPolyOut implements PolyOut {
     }
 
     async stat(id: string): Promise<Stats> {
-        if (id != "") return (await this.getFile(id)).stat();
-        return {
-            getId: () => "",
-            getSize: () => 0,
-            getTime: () => "",
-            getName: () => "",
-            isFile: () => false,
-            isDirectory: () => true,
-        };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const stats: any =
+            id != ""
+                ? await (await this.getFile(id)).stat()
+                : {
+                      getId: () => "",
+                      getSize: () => 0,
+                      getTime: () => "",
+                      getName: () => "",
+                      isFile: () => false,
+                      isDirectory: () => true,
+                  };
+
+        // While these properties aren't part of the interface, they are
+        // incidentally present in other PolyPod implementations and features
+        // rely on them, so we return them in addition to the accessors defined
+        // in the interface. We should get rid of either the accessors or the
+        // value properties globally though.
+        stats.id = stats.getId();
+        stats.size = stats.getSize();
+        stats.time = stats.getTime();
+        stats.name = stats.getName();
+        stats.file = stats.isFile();
+        stats.directory = stats.isDirectory();
+
+        return stats;
     }
 
     async readDir(id: string): Promise<Entry[]> {

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -185,16 +185,16 @@ interface FileInfo {
  *       implementations, and their usages in all features.
  */
 class CompatStats implements Stats {
-    readonly file: boolean;
-
     constructor(
         readonly id: string,
         readonly size: number,
         readonly time: string,
         readonly name: string,
         readonly directory: boolean
-    ) {
-        this.file = !directory;
+    ) {}
+
+    get file(): boolean {
+        return !this.directory;
     }
 
     getId(): string {
@@ -262,13 +262,12 @@ class IDBPolyOut implements PolyOut {
                     return entry.getData(new zip.Uint8ArrayWriter());
                 },
                 stat() {
-                    const { uncompressedSize, directory, lastModDate } = entry;
                     return new CompatStats(
                         id,
-                        uncompressedSize,
-                        lastModDate.toISOString(),
+                        entry.uncompressedSize,
+                        entry.lastModDate.toISOString(),
                         filename,
-                        directory
+                        entry.directory
                     );
                 },
             };
@@ -280,13 +279,11 @@ class IDBPolyOut implements PolyOut {
                 return new Uint8Array(await file.blob.arrayBuffer());
             },
             stat() {
-                const { size } = file.blob;
-                const { time, name } = file;
                 return new CompatStats(
                     id,
-                    size,
-                    time.toISOString(),
-                    name,
+                    file.blob.size,
+                    file.time.toISOString(),
+                    file.name,
                     false
                 );
             },


### PR DESCRIPTION
Trying to open the google feature with pod.js, I got a runtime error,
since apparently the object returned from pod.js' implementation of, I
presume, polyOut.stat, does not have an incidental "id" property
anymore.