### PR TITLE
[PROD4POD-1211] iOS: polyIn.has throws an error instead of returning false

### DIFF
--- a/platform/ios/PolyPodApp/PodApi/PostOffice.swift
+++ b/platform/ios/PolyPodApp/PodApi/PostOffice.swift
@@ -201,11 +201,9 @@ extension PostOffice {
         
         PodApi.shared.polyIn.hasQuads(quads: extendedDataSet) { doesHave in
             if doesHave {
-                completionHandler(MessagePackValue(), true)
+                completionHandler(MessagePackValue(true), nil)
             } else {
-                // TODO: This needs a closer look - should we really fail if the
-                //       data we check for is not there?
-                completionHandler(false, createErrorResponse(#function, "Not there"))
+                completionHandler(MessagePackValue(false), nil)
             }
         }
     }

--- a/platform/ios/PolyPodApp/PodApi/PostOffice.swift
+++ b/platform/ios/PolyPodApp/PodApi/PostOffice.swift
@@ -200,11 +200,7 @@ extension PostOffice {
         }
         
         PodApi.shared.polyIn.hasQuads(quads: extendedDataSet) { doesHave in
-            if doesHave {
-                completionHandler(MessagePackValue(true), nil)
-            } else {
-                completionHandler(MessagePackValue(false), nil)
-            }
+            completionHandler(MessagePackValue(doesHave), nil)
         }
     }
     


### PR DESCRIPTION
An error was returned when a quad was not found.

Now, no error is returned in either case. A boolean indicating the whether the search was successful is returned for the response as a MessagePackValue.

I don't know how to test this yet. I am figuring it out.