### PR TITLE
Introduce re-authentication option in settings - PROD4POD1091

### DIFF
--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -76,12 +76,12 @@ class Authentication {
             }
 
             val title =
-                if (reAuth) activity.getString(R.string.auth_prompt_title)
-                else activity.getString(R.string.re_auth_prompt_title)
+                if (reAuth) activity.getString(R.string.re_auth_prompt_title)
+                else activity.getString(R.string.auth_prompt_title)
 
             val subtitle =
-                if (reAuth) activity.getString(R.string.auth_prompt_subtitle)
-                else activity.getString(R.string.re_auth_prompt_subtitle)
+                if (reAuth) activity.getString(R.string.re_auth_prompt_subtitle)
+                else activity.getString(R.string.auth_prompt_subtitle)
 
             val promptInfo = BiometricPrompt.PromptInfo.Builder()
                 .setTitle(title)
@@ -114,8 +114,8 @@ class Authentication {
             super.onAuthenticationSucceeded(result)
 
             val title =
-                if (reAuth) context.getString(R.string.auth_prompt_success)
-                else context.getString(R.string.re_auth_prompt_success)
+                if (reAuth) context.getString(R.string.re_auth_prompt_success)
+                else context.getString(R.string.auth_prompt_success)
 
             Toast.makeText(
                 context,

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -30,6 +30,17 @@ class Authentication {
             }
         }
 
+        fun disable(
+            activity: FragmentActivity,
+            disableComplete: () -> Unit
+        ) {
+            authenticate(activity, false) { success ->
+                if (success)
+                    disableComplete()
+            }
+        }
+
+
         fun authenticate(
             activity: FragmentActivity,
             force: Boolean = false,

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -31,8 +31,8 @@ class Authentication {
                         activity,
                         newStatus
                     )
-                    setupComplete(success)
                 }
+                setupComplete(success)
             }
         }
 

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -22,21 +22,27 @@ class Authentication {
 
         fun setUp(
             activity: FragmentActivity,
-            setupComplete: () -> Unit
+            setupComplete: (Boolean) -> Unit
         ) {
             authenticate(activity, true) { success ->
-                if (success)
-                    setupComplete()
+                if (success) {
+                    println("To Enable authenticate")
+                    setupComplete(true)
+                }
+                setupComplete(false)
             }
         }
 
         fun disable(
             activity: FragmentActivity,
-            disableComplete: () -> Unit
+            disableComplete: (Boolean) -> Unit
         ) {
             authenticate(activity, false) { success ->
-                if (success)
-                    disableComplete()
+                if (success) {
+                    println("Disabled authenticate")
+                    disableComplete(true)
+                }
+                disableComplete(false)
             }
         }
 

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -24,10 +24,9 @@ class Authentication {
             activity: FragmentActivity,
             setupComplete: () -> Unit
         ) {
-            authenticate(activity, true, false) { success ->
-                if (success) {
+            authenticate(activity, force = true, reAuth = false) { success ->
+                if (success)
                     setupComplete()
-                }
             }
         }
 
@@ -35,7 +34,7 @@ class Authentication {
             activity: FragmentActivity,
             setupComplete: (Boolean) -> Boolean
         ) {
-            authenticate(activity, true, true) { success ->
+            authenticate(activity, force = true, reAuth = true) { success ->
                 if (success) {
                     Preferences.setBiometricEnabled(
                         activity,
@@ -50,7 +49,7 @@ class Authentication {
             activity: FragmentActivity,
             disableComplete: (Boolean) -> Boolean
         ) {
-            authenticate(activity, false, true) { success ->
+            authenticate(activity, force = false, reAuth = true) { success ->
                 if (success) {
                     Preferences.setBiometricEnabled(
                         activity,
@@ -67,8 +66,7 @@ class Authentication {
             reAuth: Boolean = false,
             authComplete: ((Boolean) -> Unit)
         ) {
-            if (
-                !biometricsAvailable(activity) ||
+            if (!biometricsAvailable(activity) ||
                 (!force && !Preferences.getBiometricEnabled(activity))
             ) {
                 authComplete(true)

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -23,7 +23,7 @@ class Authentication {
         fun setUp(
             activity: FragmentActivity,
             newStatus: Boolean,
-            setupComplete: (Boolean) -> Boolean
+            setupComplete: () -> Unit
         ) {
             authenticate(activity, newStatus) { success ->
                 if (success) {
@@ -32,7 +32,7 @@ class Authentication {
                         newStatus
                     )
                 }
-                setupComplete(success)
+                setupComplete()
             }
         }
 

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -13,7 +13,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         Authentication.authenticate(this) { success ->
             if (success) {
                 FeatureStorage().installBundledFeatures(this)

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
@@ -73,9 +73,8 @@ class OnboardingActivity : AppCompatActivity() {
                 )
                 button.visibility = View.VISIBLE
                 button.setOnClickListener {
-                    Authentication.setUp(this, newStatus = true) { _ ->
+                    Authentication.setUp(this, newStatus = true) {
                         close()
-                        true
                     }
                 }
                 val doNotAskButton = slide.findViewById<View>(

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
@@ -74,6 +74,7 @@ class OnboardingActivity : AppCompatActivity() {
                 button.visibility = View.VISIBLE
                 button.setOnClickListener {
                     Authentication.setUp(this, newStatus = true) { _ ->
+                        close()
                         true
                     }
                 }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
@@ -73,9 +73,8 @@ class OnboardingActivity : AppCompatActivity() {
                 )
                 button.visibility = View.VISIBLE
                 button.setOnClickListener {
-                    Authentication.setUp(this) {
-                        Preferences.setBiometricEnabled(this, true)
-                        close()
+                    Authentication.setUp(this, newStatus = true) { _ ->
+                        true
                     }
                 }
                 val doNotAskButton = slide.findViewById<View>(

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
@@ -6,6 +6,7 @@ import org.json.JSONObject
 
 class Preferences {
     companion object {
+        private const val authenticationKey = "authenticationKey"
         private const val firstRunKey = "firstRun"
         private const val lastNotificationIdKey = "lastNotificationId"
         private const val lastNotificationStateKey = "lastNotificationState"
@@ -36,6 +37,12 @@ class Preferences {
             val edit = getPrefs(context).edit()
             edit.putInt(lastNotificationIdKey, id)
             edit.putString(lastNotificationStateKey, state)
+            edit.commit()
+        }
+
+        fun setAuthentication(context: String, shouldCheck: Boolean) {
+            val edit = getPrefs(context).edit()
+            edit.putBoolean(authenticationKey, shouldCheck)
             edit.commit()
         }
 

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
@@ -45,7 +45,7 @@ class Preferences {
             edit.commit()
         }
 
-        fun getBiometricCheck(context: Context): Boolean =
+        fun isBiometricCheck(context: Context): Boolean =
             getPrefs(context).getBoolean(biometricCheckKey, true)
 
         fun setBiometricEnabled(context: Context, shouldCheck: Boolean) {
@@ -54,7 +54,7 @@ class Preferences {
             edit.commit()
         }
 
-        fun getBiometricEnabled(context: Context): Boolean =
+        fun isBiometricEnabled(context: Context): Boolean =
             getPrefs(context).getBoolean(biometricEnabledKey, false)
 
         fun setFileSystem(context: Context, fs: Map<String, String>) {

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
@@ -6,7 +6,6 @@ import org.json.JSONObject
 
 class Preferences {
     companion object {
-        private const val authenticationKey = "authenticationKey"
         private const val firstRunKey = "firstRun"
         private const val lastNotificationIdKey = "lastNotificationId"
         private const val lastNotificationStateKey = "lastNotificationState"
@@ -37,12 +36,6 @@ class Preferences {
             val edit = getPrefs(context).edit()
             edit.putInt(lastNotificationIdKey, id)
             edit.putString(lastNotificationStateKey, state)
-            edit.commit()
-        }
-
-        fun setAuthentication(context: Context, shouldCheck: Boolean) {
-            val edit = getPrefs(context).edit()
-            edit.putBoolean(authenticationKey, shouldCheck)
             edit.commit()
         }
 

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
@@ -40,7 +40,7 @@ class Preferences {
             edit.commit()
         }
 
-        fun setAuthentication(context: String, shouldCheck: Boolean) {
+        fun setAuthentication(context: Context, shouldCheck: Boolean) {
             val edit = getPrefs(context).edit()
             edit.putBoolean(authenticationKey, shouldCheck)
             edit.commit()
@@ -73,15 +73,13 @@ class Preferences {
         fun getFileSystem(context: Context): Map<String, String> {
             val outputMap = HashMap<String, String>()
             val jsonString = getPrefs(context).getString(fsKey, "{}")
-            if (jsonString == null) {
-                throw Error("File system error")
-            }
+                ?: throw Error("File system error")
             val jsonObject = JSONObject(jsonString)
             val keysItr: Iterator<String> = jsonObject.keys()
             while (keysItr.hasNext()) {
                 val k = keysItr.next()
                 val v = jsonObject.get(k) as String
-                outputMap.put(k, v)
+                outputMap[k] = v
             }
             return outputMap
         }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/polyOut/PolyOut.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/polyOut/PolyOut.kt
@@ -7,14 +7,12 @@ import android.provider.OpenableColumns
 import coop.polypoly.polypod.Preferences
 import coop.polypoly.polypod.features.FeatureStorage
 import coop.polypoly.polypod.polyNav.ZipTools
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.supervisorScope
 import java.io.File
 import java.nio.ByteBuffer
 import java.util.UUID
-import kotlin.coroutines.EmptyCoroutineContext
 
 open class PolyOut(
     val context: Context
@@ -22,7 +20,6 @@ open class PolyOut(
     private var readDirCache =
         mutableMapOf<String, Array<Map<String, String>>>()
     private var statCache = mutableMapOf<String, MutableMap<String, String>>()
-    private val coroutineScope = CoroutineScope(EmptyCoroutineContext)
 
     companion object {
         val fsDomain = "polypod-assets.local"

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/settings/MainFragment.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/settings/MainFragment.kt
@@ -53,12 +53,12 @@ class MainFragment : PreferenceFragmentCompat() {
             }
     }
 
-    private fun onAuthRequest(newStatus: Boolean, onReturn: (Boolean) -> Unit) {
+    private fun onAuthRequest(newStatus: Boolean, onReturn: () -> Unit) {
         Authentication.setUp(
             requireActivity(),
             newStatus
-        ) { success ->
-            onReturn(success)
+        ) {
+            onReturn()
             true
         }
     }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/settings/MainFragment.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/settings/MainFragment.kt
@@ -4,16 +4,52 @@ import android.os.Bundle
 import androidx.navigation.findNavController
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import coop.polypoly.polypod.Authentication
+import coop.polypoly.polypod.Preferences
 import coop.polypoly.polypod.R
 import coop.polypoly.polypod.RuntimeInfo
 
 class MainFragment : PreferenceFragmentCompat() {
+
     override fun onCreatePreferences(
         savedInstanceState: Bundle?,
         rootKey: String?
     ) {
         setPreferencesFromResource(R.xml.settings, rootKey)
         findPreference<Preference>("version")?.summary = RuntimeInfo.VERSION
+
+        findPreference<Preference>("authentication")?.onPreferenceChangeListener =
+            Preference.OnPreferenceChangeListener { preference, newValue ->
+
+                var status = newValue as Boolean;
+                println( "Pref " + preference.key + " changed to " + status.toString())
+
+                if (status) {
+                    Authentication.setUp(requireActivity()) { success ->
+                        if (!success) {
+                            println("setup auth failed")
+                            false
+                        } else {
+                            Preferences.setAuthentication(requireContext(), status)
+                            println("Enabled auth")
+                        }
+                    }
+                } else {
+                    println(requireActivity())
+                    Authentication.disable(requireActivity()) { success ->
+
+                        if (!success) {
+                            println("disable auth failed")
+                            false
+                        } else {
+                            Preferences.setAuthentication(requireContext(), status)
+                            println("Disabled auth")
+                        }
+                    }
+                }
+
+                true
+            }
 
         findPreference<Preference>("imprint")?.onPreferenceClickListener =
             Preference.OnPreferenceClickListener {

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/settings/MainFragment.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/settings/MainFragment.kt
@@ -25,7 +25,7 @@ class MainFragment : PreferenceFragmentCompat() {
                     val pref =
                         findPreference<SwitchPreference>("biometricEnabledKey")
                     pref?.isChecked =
-                        Preferences.getBiometricEnabled(requireContext())
+                        Preferences.isBiometricEnabled(requireContext())
                 }
                 false
             }
@@ -54,16 +54,12 @@ class MainFragment : PreferenceFragmentCompat() {
     }
 
     private fun onAuthRequest(newStatus: Boolean, onReturn: (Boolean) -> Unit) {
-        if (newStatus) {
-            Authentication.reSetUp(requireActivity()) { success ->
-                onReturn(success)
-                true
-            }
-        } else {
-            Authentication.disable(requireActivity()) { success ->
-                onReturn(success)
-                true
-            }
+        Authentication.setUp(
+            requireActivity(),
+            newStatus
+        ) { success ->
+            onReturn(success)
+            true
         }
     }
 }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/settings/MainFragment.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/settings/MainFragment.kt
@@ -21,7 +21,7 @@ class MainFragment : PreferenceFragmentCompat() {
         findPreference<Preference>("biometricEnabledKey")
             ?.onPreferenceChangeListener =
             Preference.OnPreferenceChangeListener { _, newValue ->
-                onAuthRequest(newValue as Boolean) { _ ->
+                onAuthRequest(newValue as Boolean) {
                     val pref =
                         findPreference<SwitchPreference>("biometricEnabledKey")
                     pref?.isChecked =

--- a/platform/android/app/src/main/res/values-de/strings.xml
+++ b/platform/android/app/src/main/res/values-de/strings.xml
@@ -20,6 +20,9 @@
     <string name="onboarding_slide4_body_text">Wir möchten gerne sicherstellen, dass Ihre Daten im polyPod vor fremden Zugriff sicher sind. Dafür bitten wir Sie jetzt, die Gerätesperre auch für den polyPod einzuschalten.</string>
     <string name="settings_title">Einstellungen</string>
     <string name="settings_about_section">Info</string>
+    <string name="settings_sec_section">SecurityXXX</string>
+    <string name="settings_auth">AuthenticationXXX</string>
+
     <string name="settings_version">Version</string>
     <string name="settings_legal_section">Rechtliches</string>
     <string name="settings_imprint_title">Impressum</string>

--- a/platform/android/app/src/main/res/values-de/strings.xml
+++ b/platform/android/app/src/main/res/values-de/strings.xml
@@ -35,9 +35,17 @@
     <string name="button_url_open_confirm">Ja</string>
     <string name="button_url_open_reject">Nein</string>
     <string name="button_update_notification_close">OK</string>
+
     <string name="auth_prompt_title">Einloggen in Ihren polyPod</string>
     <string name="auth_prompt_subtitle">Den Sperrbildschirm vom Gerät verwenden</string>
     <string name="auth_prompt_success">Authentifizierung erfolgreich</string>
+    <string name="re_auth_prompt_title">xxxx your polyPod</string>
+    <string name="re_auth_prompt_subtitle">no parlo deutsch</string>
+    <string name="re_auth_prompt_success">Authentifizierung erfolgreich</string>
+    <string name="re_auth_prompt_confirm">OK</string>
+    <string name="re_auth_prompt_cancel">Cancel</string>
+    <string name="re_auth_prompt_failure">Cancelled re-Authentifizierung</string>
+
     <string name="message_feature_error">Leider gab es einen Fehler in \'%1$s\':\n\n%2$s\n\nIch beende es.</string>
     <string name="button_feature_error_close">OK</string>
 </resources>

--- a/platform/android/app/src/main/res/values-de/strings.xml
+++ b/platform/android/app/src/main/res/values-de/strings.xml
@@ -20,8 +20,8 @@
     <string name="onboarding_slide4_body_text">Wir möchten gerne sicherstellen, dass Ihre Daten im polyPod vor fremden Zugriff sicher sind. Dafür bitten wir Sie jetzt, die Gerätesperre auch für den polyPod einzuschalten.</string>
     <string name="settings_title">Einstellungen</string>
     <string name="settings_about_section">Info</string>
-    <string name="settings_sec_section">SecurityXXX</string>
-    <string name="settings_auth">AuthenticationXXX</string>
+    <string name="settings_sec_section">Sicherheit</string>
+    <string name="settings_auth">Authentifizierung</string>
 
     <string name="settings_version">Version</string>
     <string name="settings_legal_section">Rechtliches</string>
@@ -40,8 +40,8 @@
     <string name="auth_prompt_subtitle">Den Sperrbildschirm vom Gerät verwenden</string>
     <string name="auth_prompt_success">Authentifizierung erfolgreich</string>
 
-    <string name="re_auth_prompt_title">xxxx your polyPod</string>
-    <string name="re_auth_prompt_subtitle">no parlo deutsch</string>
+    <string name="re_auth_prompt_title">Bitte authentifizieren Sie sich erneut</string>
+    <string name="re_auth_prompt_subtitle">Aus Sicherheitsgründen bitten wir Sie, sich noch einmal zu authentifizieren bevor wir diese Einstellung ändern.</string>
     <string name="re_auth_prompt_success">Authentifizierung erfolgreich</string>
 
     <string name="message_feature_error">Leider gab es einen Fehler in \'%1$s\':\n\n%2$s\n\nIch beende es.</string>

--- a/platform/android/app/src/main/res/values-de/strings.xml
+++ b/platform/android/app/src/main/res/values-de/strings.xml
@@ -37,11 +37,11 @@
     <string name="button_update_notification_close">OK</string>
 
     <string name="auth_prompt_title">Einloggen in Ihren polyPod</string>
-    <string name="auth_prompt_subtitle">Den Sperrbildschirm vom Gerät verwenden</string>
+    <string name="auth_prompt_subtitle">Bitte authentifizieren Sie sich mit dem Sperrbildschirm Ihres Gerätes</string>
     <string name="auth_prompt_success">Authentifizierung erfolgreich</string>
 
-    <string name="re_auth_prompt_title">Bitte authentifizieren Sie sich erneut</string>
-    <string name="re_auth_prompt_subtitle">Aus Sicherheitsgründen bitten wir Sie, sich noch einmal zu authentifizieren bevor wir diese Einstellung ändern.</string>
+    <string name="re_auth_prompt_title">Authentifizieren um fortzufahren</string>
+    <string name="re_auth_prompt_subtitle">Bitte authentifizieren Sie sich mit dem Sperrbildschirm Ihres Gerätes</string>
     <string name="re_auth_prompt_success">Authentifizierung erfolgreich</string>
 
     <string name="message_feature_error">Leider gab es einen Fehler in \'%1$s\':\n\n%2$s\n\nIch beende es.</string>

--- a/platform/android/app/src/main/res/values-de/strings.xml
+++ b/platform/android/app/src/main/res/values-de/strings.xml
@@ -39,12 +39,10 @@
     <string name="auth_prompt_title">Einloggen in Ihren polyPod</string>
     <string name="auth_prompt_subtitle">Den Sperrbildschirm vom Gerät verwenden</string>
     <string name="auth_prompt_success">Authentifizierung erfolgreich</string>
+
     <string name="re_auth_prompt_title">xxxx your polyPod</string>
     <string name="re_auth_prompt_subtitle">no parlo deutsch</string>
     <string name="re_auth_prompt_success">Authentifizierung erfolgreich</string>
-    <string name="re_auth_prompt_confirm">OK</string>
-    <string name="re_auth_prompt_cancel">Cancel</string>
-    <string name="re_auth_prompt_failure">Cancelled re-Authentifizierung</string>
 
     <string name="message_feature_error">Leider gab es einen Fehler in \'%1$s\':\n\n%2$s\n\nIch beende es.</string>
     <string name="button_feature_error_close">OK</string>

--- a/platform/android/app/src/main/res/values/strings.xml
+++ b/platform/android/app/src/main/res/values/strings.xml
@@ -39,10 +39,10 @@
     <string name="auth_prompt_subtitle">Use device lock screen</string>
     <string name="auth_prompt_success">Authentication successful</string>
     <string name="re_auth_prompt_title">Re-authenticate your polyPod</string>
-    <string name="re_auth_prompt_subtitle">for security reasons, we ask you to re-authenticate before changing this setting</string>
+    <string name="re_auth_prompt_subtitle">For security reasons, we ask you to re-authenticate before changing this setting</string>
     <string name="re_auth_prompt_confirm">OK</string>
     <string name="re_auth_prompt_cancel">Cancel</string>
-    <string name="re_auth_prompt_success">Authorized re-authentication</string>
+    <string name="re_auth_prompt_success">Authorized authentication successfully</string>
     <string name="re_auth_prompt_failure">Cancelled re-authentication</string>
 
     <string name="message_feature_error">Unfortunately, \'%1$s\' had an error:\n\n%2$s\n\nI will close it for you.</string>

--- a/platform/android/app/src/main/res/values/strings.xml
+++ b/platform/android/app/src/main/res/values/strings.xml
@@ -38,12 +38,10 @@
     <string name="auth_prompt_title">Login into your polyPod</string>
     <string name="auth_prompt_subtitle">Use device lock screen</string>
     <string name="auth_prompt_success">Authentication successful</string>
-    <string name="re_auth_prompt_title">Re-authenticate your polyPod</string>
+
+    <string name="re_auth_prompt_title">Please confirm your Login.</string>
     <string name="re_auth_prompt_subtitle">For security reasons, we ask you to re-authenticate before changing this setting</string>
-    <string name="re_auth_prompt_confirm">OK</string>
-    <string name="re_auth_prompt_cancel">Cancel</string>
-    <string name="re_auth_prompt_success">Authorized authentication successfully</string>
-    <string name="re_auth_prompt_failure">Cancelled re-authentication</string>
+    <string name="re_auth_prompt_success">Re-authorized authentication successfully</string>
 
     <string name="message_feature_error">Unfortunately, \'%1$s\' had an error:\n\n%2$s\n\nI will close it for you.</string>
     <string name="button_feature_error_close">OK</string>

--- a/platform/android/app/src/main/res/values/strings.xml
+++ b/platform/android/app/src/main/res/values/strings.xml
@@ -34,9 +34,17 @@
     <string name="button_url_open_confirm">Yes</string>
     <string name="button_url_open_reject">No</string>
     <string name="button_update_notification_close">OK</string>
+
     <string name="auth_prompt_title">Login into your polyPod</string>
     <string name="auth_prompt_subtitle">Use device lock screen</string>
     <string name="auth_prompt_success">Authentication successful</string>
+    <string name="re_auth_prompt_title">Re-authenticate your polyPod</string>
+    <string name="re_auth_prompt_subtitle">for security reasons, we ask you to re-authenticate before changing this setting</string>
+    <string name="re_auth_prompt_confirm">OK</string>
+    <string name="re_auth_prompt_cancel">Cancel</string>
+    <string name="re_auth_prompt_success">Authorized re-authentication</string>
+    <string name="re_auth_prompt_failure">Cancelled re-authentication</string>
+
     <string name="message_feature_error">Unfortunately, \'%1$s\' had an error:\n\n%2$s\n\nI will close it for you.</string>
     <string name="button_feature_error_close">OK</string>
 </resources>

--- a/platform/android/app/src/main/res/values/strings.xml
+++ b/platform/android/app/src/main/res/values/strings.xml
@@ -35,13 +35,13 @@
     <string name="button_url_open_reject">No</string>
     <string name="button_update_notification_close">OK</string>
 
-    <string name="auth_prompt_title">Login into your polyPod</string>
-    <string name="auth_prompt_subtitle">Use device lock screen</string>
+    <string name="auth_prompt_title">Log in to your polyPod</string>
+    <string name="auth_prompt_subtitle">Please authenticate using your device\'s screen lock</string>
     <string name="auth_prompt_success">Authentication successful</string>
 
-    <string name="re_auth_prompt_title">Please confirm your Login.</string>
-    <string name="re_auth_prompt_subtitle">For security reasons, we ask you to re-authenticate before changing this setting</string>
-    <string name="re_auth_prompt_success">Re-authorized authentication successfully</string>
+    <string name="re_auth_prompt_title">Authenticate to continue</string>
+    <string name="re_auth_prompt_subtitle">Please authenticate using your device\'s screen lock</string>
+    <string name="re_auth_prompt_success">Authentication successful</string>
 
     <string name="message_feature_error">Unfortunately, \'%1$s\' had an error:\n\n%2$s\n\nI will close it for you.</string>
     <string name="button_feature_error_close">OK</string>

--- a/platform/android/app/src/main/res/values/strings.xml
+++ b/platform/android/app/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="onboarding_slide4_body_text">We would like to ensure any data you put into polyPod is as secure as possible. For this we would like to ask you to enable some way of authentication for future access.</string>
     <string name="settings_title">Settings</string>
     <string name="settings_about_section">Info</string>
+    <string name="settings_sec_section">Security</string>
+    <string name="settings_auth">Authentication</string>
     <string name="settings_version">Version</string>
     <string name="settings_legal_section">Legal</string>
     <string name="settings_imprint_title">Imprint</string>

--- a/platform/android/app/src/main/res/xml/settings.xml
+++ b/platform/android/app/src/main/res/xml/settings.xml
@@ -11,9 +11,8 @@
 
     <PreferenceCategory android:title="@string/settings_sec_section">
         <SwitchPreference
-            android:key="authentication"
-            android:title="Authentication"
-            android:defaultValue="false"/>
+            android:key="biometricEnabledKey"
+            android:title="Authentication"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_legal_section">

--- a/platform/android/app/src/main/res/xml/settings.xml
+++ b/platform/android/app/src/main/res/xml/settings.xml
@@ -9,6 +9,13 @@
             android:title="@string/settings_version" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/settings_sec_section">
+        <SwitchPreference
+            android:key="authentication"
+            android:title="Authentication"
+            android:defaultValue="false"/>
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/settings_legal_section">
         <Preference
             app:key="imprint"

--- a/platform/ios/PolyPodApp/Extensions/BindingExtensions.swift
+++ b/platform/ios/PolyPodApp/Extensions/BindingExtensions.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+extension Binding {
+    func onChange(_ handler: @escaping (Value) -> Void) -> Binding<Value> {
+        Binding(
+            get: { self.wrappedValue },
+            set: { newValue in
+                self.wrappedValue = newValue
+                handler(newValue)
+            }
+        )
+    }
+}

--- a/platform/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
+++ b/platform/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		1AF468DE24361D9D00E51B6D /* FileManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF468DD24361D9D00E51B6D /* FileManagerExtensions.swift */; };
 		3B3CEDFA274FC37C000C3E6E /* FilePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E989B350269CA6B7000EE977 /* FilePicker.swift */; };
 		3B5487E227CD0FF700480CB5 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5487E127CD0FF700480CB5 /* Endpoint.swift */; };
+		5105EA05281ACEEC0040AE0D /* BindingExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5105EA04281ACEEC0040AE0D /* BindingExtensions.swift */; };
+		5105EA07281AFDBB0040AE0D /* BindingExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5105EA04281ACEEC0040AE0D /* BindingExtensions.swift */; };
 		5B8653022643FC310014208C /* PolyNav.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8653012643FC310014208C /* PolyNav.swift */; };
 		901C0588278EE58700BC8364 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C0587278EE58700BC8364 /* CoreDataStack.swift */; };
 		901C058A278F2AF800BC8364 /* CoreData+PolyIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C0589278F2AF800BC8364 /* CoreData+PolyIn.swift */; };

--- a/platform/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
+++ b/platform/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		1AF468DB24349E6B00E51B6D /* PodApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodApi.swift; sourceTree = "<group>"; };
 		1AF468DD24361D9D00E51B6D /* FileManagerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerExtensions.swift; sourceTree = "<group>"; };
 		3B5487E127CD0FF700480CB5 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
+		5105EA04281ACEEC0040AE0D /* BindingExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingExtensions.swift; sourceTree = "<group>"; };
 		5B0F7B5F26A924DF00F4EFF4 /* PolyPod.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PolyPod.entitlements; sourceTree = "<group>"; };
 		5B8653012643FC310014208C /* PolyNav.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolyNav.swift; sourceTree = "<group>"; };
 		901C0587278EE58700BC8364 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
@@ -568,6 +569,7 @@
 				1AF46892241FBA7200E51B6D /* JSONSerializationExtensions.swift */,
 				1AF468DD24361D9D00E51B6D /* FileManagerExtensions.swift */,
 				E9F370D4262EABFF006254C1 /* LocalizedStringKeyExtensions.swift */,
+				5105EA04281ACEEC0040AE0D /* BindingExtensions.swift */,
 				E9F370E6262EEF13006254C1 /* UIColorExtensions.swift */,
 				E97D325526307CE100A5A180 /* ColorExtensions.swift */,
 				E9545EC727359A34001E8C7F /* UserDefaultsExtensions.swift */,
@@ -854,6 +856,7 @@
 				E9545EC4273543EB001E8C7F /* UpdateNotificationTest.swift in Sources */,
 				1ABADBFE24EE710B00369791 /* Variable+CoreDataClass.swift in Sources */,
 				1ABADBF924EE710B00369791 /* BlankNode+CoreDataClass.swift in Sources */,
+				5105EA07281AFDBB0040AE0D /* BindingExtensions.swift in Sources */,
 				E989B353269DDC9E000EE977 /* PolyNavTests.swift in Sources */,
 				1ABADBFF24EE710B00369791 /* Variable+CoreDataProperties.swift in Sources */,
 				904D4A712790633000A75AED /* DispatchToMainQueue.swift in Sources */,
@@ -972,6 +975,7 @@
 				E9545EC827359A34001E8C7F /* UserDefaultsExtensions.swift in Sources */,
 				E9CF1B642625EA3200216B70 /* FeatureView.swift in Sources */,
 				1AF468B0242A34CF00E51B6D /* PolyIn.swift in Sources */,
+				5105EA05281ACEEC0040AE0D /* BindingExtensions.swift in Sources */,
 				1A66F76B2490DFA000ED4308 /* FetchResponse.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/platform/ios/PolyPodApp/PolyPod/Authentication.swift
+++ b/platform/ios/PolyPodApp/PolyPod/Authentication.swift
@@ -70,7 +70,7 @@ class Authentication {
         )
     }
     
-    private func isSetUp() -> Bool {
+    func isSetUp() -> Bool {
         return UserDefaults.standard.bool(forKey: Authentication.setUpKey)
     }
     

--- a/platform/ios/PolyPodApp/PolyPod/Authentication.swift
+++ b/platform/ios/PolyPodApp/PolyPod/Authentication.swift
@@ -35,7 +35,7 @@ class Authentication {
         UserDefaults.standard.set(true, forKey: Authentication.disableCheckKey)
     }
     
-    func setUp(_ reAuth: Bool, _ completeAction: @escaping (Bool) -> Void) {
+    func setUp(reAuth: Bool, _ completeAction: @escaping (Bool) -> Void) {
         
         let reason = reAuth ?
         "re_auth_prompt_set_up": "auth_prompt_set_up"

--- a/platform/ios/PolyPodApp/PolyPod/Authentication.swift
+++ b/platform/ios/PolyPodApp/PolyPod/Authentication.swift
@@ -56,10 +56,7 @@ class Authentication {
             return
         }
         
-        let reason = isSetUp() ?
-        "re_auth_prompt_unlock": "auth_prompt_unlock"
-
-        authenticateLocally(withReason: reason) { success in
+        authenticateLocally(withReason: "auth_prompt_unlock") { success in
             self.authenticated = success
             completeAction(success)
         }

--- a/platform/ios/PolyPodApp/PolyPod/Authentication.swift
+++ b/platform/ios/PolyPodApp/PolyPod/Authentication.swift
@@ -51,7 +51,7 @@ class Authentication {
             
     
     func authenticate(_ completeAction: @escaping (Bool) -> Void) {
-        if isCheckDisabled() || !isSetUp() || authenticated {
+        if !isSetUp() || authenticated {
             completeAction(true)
             return
         }

--- a/platform/ios/PolyPodApp/PolyPod/Authentication.swift
+++ b/platform/ios/PolyPodApp/PolyPod/Authentication.swift
@@ -43,6 +43,15 @@ class Authentication {
         }
     }
     
+    func disable(_ completeAction: @escaping (Bool) -> Void) {
+        authenticateLocally(reason: "auth_prompt_disable") { success in
+            self.authenticated = false
+            UserDefaults.standard.set(false, forKey: Authentication.setUpKey)
+            completeAction(success)
+        }
+    }
+
+    
     func authenticate(_ completeAction: @escaping (Bool) -> Void) {
         if isCheckDisabled() || !isSetUp() || authenticated {
             completeAction(true)

--- a/platform/ios/PolyPodApp/PolyPod/Authentication.swift
+++ b/platform/ios/PolyPodApp/PolyPod/Authentication.swift
@@ -1,11 +1,11 @@
 import LocalAuthentication
 
 private func isSimulator() -> Bool {
-    #if targetEnvironment(simulator)
+#if targetEnvironment(simulator)
     return true
-    #else
+#else
     return false
-    #endif
+#endif
 }
 
 class Authentication {
@@ -35,48 +35,31 @@ class Authentication {
         UserDefaults.standard.set(true, forKey: Authentication.disableCheckKey)
     }
     
-    func setUp(reAuth: Bool, _ completeAction: @escaping (Bool) -> Void) {
-        
-        let reason = reAuth ?
+    
+    func setUp(newStatus: Bool, _ completeAction: @escaping (Bool) -> Void) {
+        let reason = isSetUp() ?
         "re_auth_prompt_set_up": "auth_prompt_set_up"
-        
-        authenticateLocally(reason) { success in
-            self.authenticated = success
 
-            if (!success) {
-                completeAction(false)
-                return
+        authenticateLocally(withReason: reason) { success in
+            if (success) {
+                self.authenticated = newStatus
+                UserDefaults.standard.set(newStatus, forKey: Authentication.setUpKey)
             }
-            
-            UserDefaults.standard.set(true, forKey: Authentication.setUpKey)
             completeAction(success)
         }
     }
-    
-    func disable(_ completeAction: @escaping (Bool) -> Void) {
-        authenticateLocally("auth_prompt_disable") { success in
-            self.authenticated = false
-            if (!success) {
-                completeAction(false)
-                return
-            }
             
-            UserDefaults.standard.set(false, forKey: Authentication.setUpKey)
-            completeAction(success)
-        }
-    }
-
     
-    func authenticate(_ reAuth: Bool, _ completeAction: @escaping (Bool) -> Void) {
+    func authenticate(_ completeAction: @escaping (Bool) -> Void) {
         if isCheckDisabled() || !isSetUp() || authenticated {
             completeAction(true)
             return
         }
         
-        let reason = reAuth ?
+        let reason = isSetUp() ?
         "re_auth_prompt_unlock": "auth_prompt_unlock"
 
-        authenticateLocally(reason) { success in
+        authenticateLocally(withReason: reason) { success in
             self.authenticated = success
             completeAction(success)
         }
@@ -93,7 +76,7 @@ class Authentication {
     }
     
     private func authenticateLocally(
-        _ reason: String,
+        withReason reason: String,
         _ completeAction: @escaping (Bool) -> Void
     ) {
         let context = LAContext()

--- a/platform/ios/PolyPodApp/PolyPod/ContentView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/ContentView.swift
@@ -123,7 +123,7 @@ struct ContentView: View {
         // authentication fails. Since we don't have a dedicated screen for the
         // locked state yet, we simply keep asking the user until they stop
         // cancelling or leave the app.
-        Authentication.shared.authenticate { success in
+        Authentication.shared.authenticate(false) { success in
             if success {
                 completeAction()
                 return

--- a/platform/ios/PolyPodApp/PolyPod/ContentView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/ContentView.swift
@@ -123,7 +123,7 @@ struct ContentView: View {
         // authentication fails. Since we don't have a dedicated screen for the
         // locked state yet, we simply keep asking the user until they stop
         // cancelling or leave the app.
-        Authentication.shared.authenticate(false) { success in
+        Authentication.shared.authenticate { success in
             if success {
                 completeAction()
                 return

--- a/platform/ios/PolyPodApp/PolyPod/OnboardingView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/OnboardingView.swift
@@ -67,7 +67,7 @@ struct OnboardingView: View {
     }
     
     private func setUpAuth() {
-        Authentication.shared.setUp(false) { success in
+        Authentication.shared.setUp(reAuth: false) { success in
             if success {
                 closeAction()
             }

--- a/platform/ios/PolyPodApp/PolyPod/OnboardingView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/OnboardingView.swift
@@ -67,7 +67,7 @@ struct OnboardingView: View {
     }
     
     private func setUpAuth() {
-        Authentication.shared.setUp(reAuth: false) { success in
+        Authentication.shared.setUp(newStatus: true) { success in
             if success {
                 closeAction()
             }

--- a/platform/ios/PolyPodApp/PolyPod/OnboardingView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/OnboardingView.swift
@@ -67,7 +67,7 @@ struct OnboardingView: View {
     }
     
     private func setUpAuth() {
-        Authentication.shared.setUp { success in
+        Authentication.shared.setUp(false) { success in
             if success {
                 closeAction()
             }

--- a/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
@@ -93,8 +93,7 @@ private struct MainSection: View {
             
             Section(header: SettingsHeader("settings_sec_section")) {
                 SettingsToggleButton(
-                    label: "settings_auth",
-                    isOn: false
+                    label: "settings_auth"
                 )
             }
             .listRowInsets(
@@ -172,16 +171,22 @@ private struct SettingsButton: View {
 
 private struct SettingsToggleButton: View {
     let label: LocalizedStringKey
-    @State var isOn: Bool
-    
+    @State private var isToggle : Bool = false
+       
     var body: some View {
-        Toggle(label, isOn: $isOn)
-            .foregroundColor(Color.PolyPod.darkForeground)
-            .font(.custom("Jost-Regular", size: 18))
-            .padding(.leading, 32)
-            .padding(.trailing, 32)
+       VStack {
+          Toggle(isOn: $isToggle){
+             Text(label)
+                .foregroundColor(Color.PolyPod.darkForeground)
+                .font(.custom("Jost-Regular", size: 18))
+                .kerning(-0.18)
+          }
+          .padding(.trailing, 32)
+        }.padding(.leading, 32)
     }
 }
+
+
 private struct PrivacyPolicyView: View {
     var body: some View {
         HTMLView(content: loadPrivacyPolicyText())

--- a/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
@@ -91,6 +91,16 @@ private struct MainSection: View {
                 EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
             )
             
+            Section(header: SettingsHeader("settings_sec_section")) {
+                SettingsToggleButton(
+                    label: "settings_auth",
+                    isOn: false
+                )
+            }
+            .listRowInsets(
+                EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+            )
+            
             Section(header: SettingsHeader("settings_legal_section")) {
                 SettingsButton(
                     label: "settings_imprint_title",
@@ -160,6 +170,18 @@ private struct SettingsButton: View {
     }
 }
 
+private struct SettingsToggleButton: View {
+    let label: LocalizedStringKey
+    @State var isOn: Bool
+    
+    var body: some View {
+        Toggle(label, isOn: $isOn)
+            .foregroundColor(Color.PolyPod.darkForeground)
+            .font(.custom("Jost-Regular", size: 18))
+            .padding(.leading, 32)
+            .padding(.trailing, 32)
+    }
+}
 private struct PrivacyPolicyView: View {
     var body: some View {
         HTMLView(content: loadPrivacyPolicyText())

--- a/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
@@ -96,25 +96,27 @@ private struct MainSection: View {
             Section(header: SettingsHeader("settings_sec_section")) {
                 SettingsToggleButton(
                     label: "settings_auth",
-                    isToggle: isToggle,
+                    isToggle: $isToggle,
                     onChange: { status in
-                        print("status is \(status)")
 
                         if status {
                             Authentication.shared.setUp { success in
-                                print("success is \(success)")
-
                                 if !success {
                                     isToggle = false
                                     print("setup auth failed")
+                                    return
                                 }
-                                print("set up auth")
-                                isToggle = true; // ?
                             }
+                            print("Enabled auth")
                         } else {
-                            Authentication.shared.disable { _ in}
+                            Authentication.shared.disable { success in
+                                if !success {
+                                    isToggle = true
+                                    print("disable auth failed")
+                                    return
+                                }
+                            }
                             print("Disabled auth")
-                            isToggle = false;  // ?
                         }
                         
                     }
@@ -197,48 +199,28 @@ typealias OnChange = ((Bool) -> Void)?
 
 private struct SettingsToggleButton: View {
     let label: LocalizedStringKey
-    @State var isToggle : Bool;
-    
-    //let onChange: (Bool, Binding<Bool>) -> Void
-    
+    let isToggle : Binding<Bool>;
+        
     var onChange: OnChange
 
     var body: some View {
        VStack {
-           Toggle(isOn: $isToggle.onChange(toggleChange)) {
+           Toggle(isOn: isToggle.onChange(toggleChange)) {
                     Text(label)
                            .foregroundColor(Color.PolyPod.darkForeground)
-                           .font(.custom("Jost-Regular", size: 14))
+                           .font(.custom("Jost-Regular", size: 18))
                            .kerning(-0.18)
-
-                       if isToggle {
-                           Text("Granted")                       .foregroundColor(Color.PolyPod.darkForeground)
-                               .font(.custom("Jost-Regular", size: 14))
-                               .kerning(-0.18)
-                       }
-                       else {
-                           Text("Not Granted")                       .foregroundColor(Color.PolyPod.darkForeground)
-                               .font(.custom("Jost-Regular", size: 14))
-                               .kerning(-0.18)
-                       }
                    }
                    .padding(.trailing, 32)
         }.padding(.leading, 32)
     }
     
     func toggleChange(_ value: Bool) {
-        print("Toggle value: \(value)")
         if let action = self.onChange {
           action(value)
         }
     }
-    
-//    func onChanged(perform action: OnChange) -> Self {
-//      var copy = self
-//      copy.action = action
-//      return copy
-//    }
-        
+            
 }
 
 

--- a/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
@@ -172,18 +172,45 @@ private struct SettingsButton: View {
 private struct SettingsToggleButton: View {
     let label: LocalizedStringKey
     @State private var isToggle : Bool = false
-       
+
+
     var body: some View {
        VStack {
-          Toggle(isOn: $isToggle){
-             Text(label)
-                .foregroundColor(Color.PolyPod.darkForeground)
-                .font(.custom("Jost-Regular", size: 18))
-                .kerning(-0.18)
-          }
-          .padding(.trailing, 32)
+           if #available(iOS 15.0, *) {
+                   Toggle(isOn: $isToggle){
+                       Text(label)
+                           .foregroundColor(Color.PolyPod.darkForeground)
+                           .font(.custom("Jost-Regular", size: 14))
+                       if isToggle {
+                           Text("Granted")                       .foregroundColor(Color.PolyPod.darkForeground)
+                               .font(.custom("Jost-Regular", size: 14))
+                           // .kerning(-0.18)
+                       }
+                       else {
+                           Text("Not Granted")                       .foregroundColor(Color.PolyPod.darkForeground)
+                               .font(.custom("Jost-Regular", size: 14))
+                           // .kerning(-0.18)
+                       }
+                   }
+                   .padding(.trailing, 32)
+                   .onChange(of: isToggle) { value in
+                       print("in onChange value: \(value)")
+                   }
+                   .confirmationDialog(
+                    "Do you want to grant device authentication with PIN/biometrics?",
+                    isPresented: $isToggle,
+                    titleVisibility: .visible
+                   ) {
+                       Button("Yes", action: { })
+                       Button("No", role: .destructive, action:{ })
+
+                   }
+               } else {
+                   // Fallback on earlier versions
+               }
         }.padding(.leading, 32)
     }
+    
 }
 
 

--- a/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
@@ -72,8 +72,8 @@ private struct MainSection: View {
     @Binding var activeSection: Sections
     @State private var showVersion = false
     @State private var shareLogs = false
-    @State private var isToggled = Authentication.shared.isSetUp()
-
+    @State private var isAuthenticationConfigured = Authentication.shared.isSetUp()
+    
     var body: some View {
         List() {
             Section(header: SettingsHeader("settings_about_section")) {
@@ -92,26 +92,17 @@ private struct MainSection: View {
                 EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
             )
             
-
+            
             Section(header: SettingsHeader("settings_sec_section")) {
                 SettingsToggleButton(
                     label: "settings_auth",
-                    isToggled: $isToggled,
-                    onChange: { status in
-                        if status {
-                            Authentication.shared.setUp(reAuth: true) { success in
-                                if !success {
-                                    isToggled = false
-                                }
-                            }
-                        } else {
-                            Authentication.shared.disable { success in
-                                if !success {
-                                    isToggled = true
-                                }
+                    isToggled: $isAuthenticationConfigured,
+                    onChange: { isOn in
+                        Authentication.shared.setUp(newStatus: isOn) { success in
+                            if !success {
+                                isAuthenticationConfigured = !isOn
                             }
                         }
-                        
                     }
                 )
             }
@@ -188,32 +179,31 @@ private struct SettingsButton: View {
     }
 }
 
-typealias OnChange = ((Bool) -> Void)?
 
 private struct SettingsToggleButton: View {
     let label: LocalizedStringKey
     let isToggled : Binding<Bool>;
-        
-    var onChange: OnChange
-
+    
+    var onChange: ((Bool) -> Void)?
+    
     var body: some View {
-       VStack {
-           Toggle(isOn: isToggled.onChange(toggleChange)) {
-                    Text(label)
-                           .foregroundColor(Color.PolyPod.darkForeground)
-                           .font(.custom("Jost-Regular", size: 18))
-                           .kerning(-0.18)
-                   }
-                   .padding(.trailing, 32)
+        VStack {
+            Toggle(isOn: isToggled.onChange(toggleChange)) {
+                Text(label)
+                    .foregroundColor(Color.PolyPod.darkForeground)
+                    .font(.custom("Jost-Regular", size: 18))
+                    .kerning(-0.18)
+            }
+            .padding(.trailing, 32)
         }.padding(.leading, 32)
     }
     
     func toggleChange(_ value: Bool) {
         if let action = self.onChange {
-          action(value)
+            action(value)
         }
     }
-            
+    
 }
 
 

--- a/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
@@ -100,23 +100,17 @@ private struct MainSection: View {
                     onChange: { status in
 
                         if status {
-                            Authentication.shared.setUp { success in
+                            Authentication.shared.setUp(true) { success in
                                 if !success {
                                     isToggle = false
-                                    print("setup auth failed")
-                                    return
                                 }
                             }
-                            print("Enabled auth")
                         } else {
                             Authentication.shared.disable { success in
                                 if !success {
                                     isToggle = true
-                                    print("disable auth failed")
-                                    return
                                 }
                             }
-                            print("Disabled auth")
                         }
                         
                     }

--- a/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
@@ -72,7 +72,7 @@ private struct MainSection: View {
     @Binding var activeSection: Sections
     @State private var showVersion = false
     @State private var shareLogs = false
-    @State private var isToggle = Authentication.shared.isSetUp()
+    @State private var isToggled = Authentication.shared.isSetUp()
 
     var body: some View {
         List() {
@@ -96,18 +96,18 @@ private struct MainSection: View {
             Section(header: SettingsHeader("settings_sec_section")) {
                 SettingsToggleButton(
                     label: "settings_auth",
-                    isToggle: $isToggle,
+                    isToggled: $isToggled,
                     onChange: { status in
                         if status {
-                            Authentication.shared.setUp(true) { success in
+                            Authentication.shared.setUp(reAuth: true) { success in
                                 if !success {
-                                    isToggle = false
+                                    isToggled = false
                                 }
                             }
                         } else {
                             Authentication.shared.disable { success in
                                 if !success {
-                                    isToggle = true
+                                    isToggled = true
                                 }
                             }
                         }
@@ -192,13 +192,13 @@ typealias OnChange = ((Bool) -> Void)?
 
 private struct SettingsToggleButton: View {
     let label: LocalizedStringKey
-    let isToggle : Binding<Bool>;
+    let isToggled : Binding<Bool>;
         
     var onChange: OnChange
 
     var body: some View {
        VStack {
-           Toggle(isOn: isToggle.onChange(toggleChange)) {
+           Toggle(isOn: isToggled.onChange(toggleChange)) {
                     Text(label)
                            .foregroundColor(Color.PolyPod.darkForeground)
                            .font(.custom("Jost-Regular", size: 18))

--- a/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
@@ -98,7 +98,6 @@ private struct MainSection: View {
                     label: "settings_auth",
                     isToggle: $isToggle,
                     onChange: { status in
-
                         if status {
                             Authentication.shared.setUp(true) { success in
                                 if !success {

--- a/platform/ios/PolyPodApp/PolyPod/de.lproj/Localizable.strings
+++ b/platform/ios/PolyPodApp/PolyPod/de.lproj/Localizable.strings
@@ -45,7 +45,6 @@
 "re_auth_prompt_set_up" = "Bitte authentifizieren Sie sich erneut";
 
 "auth_prompt_unlock" = "Einloggen in polyPod";
-"re_auth_prompt_unlock" = "Bitte bestätigen Sie ihren Login";
 
 "settings_imprint_text" = "
 <p>Angaben gemäß § 5 TMG</p>

--- a/platform/ios/PolyPodApp/PolyPod/de.lproj/Localizable.strings
+++ b/platform/ios/PolyPodApp/PolyPod/de.lproj/Localizable.strings
@@ -44,8 +44,6 @@
 "auth_prompt_set_up" = "Sperre einrichten";
 "re_auth_prompt_set_up" = "Bitte authentifizieren Sie sich erneut";
 
-"auth_prompt_disable" = "Erneute Authentifizierung abschalten";
-
 "auth_prompt_unlock" = "Einloggen in polyPod";
 "re_auth_prompt_unlock" = "Bitte bestätigen Sie ihren Login";
 

--- a/platform/ios/PolyPodApp/PolyPod/de.lproj/Localizable.strings
+++ b/platform/ios/PolyPodApp/PolyPod/de.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "button_reject" = "Nein";
 "button_update_notification_close" = "OK";
 "auth_prompt_set_up" = "Sperre einrichten";
+"auth_prompt_disable" = "xx einrichten";
+
 "auth_prompt_unlock" = "Einloggen in polyPod";
 
 "settings_imprint_text" = "

--- a/platform/ios/PolyPodApp/PolyPod/de.lproj/Localizable.strings
+++ b/platform/ios/PolyPodApp/PolyPod/de.lproj/Localizable.strings
@@ -20,10 +20,14 @@
 "onboarding_slide4_body_text" = "Wir möchten gerne sicherstellen, dass Ihre Daten im polyPod vor fremden Zugriff sicher sind. Dafür bitten wir Sie jetzt, die Gerätesperre auch für den polyPod einzuschalten.";
 "settings_title" = "Einstellungen";
 "settings_about_section" = "Info";
+"settings_auth" = "Authentifizierung";
+
 "settings_version" = "Version";
 "settings_legal_section" = "Rechtliches";
 "settings_imprint_title" = "Impressum";
 "settings_privacy_policy_title" = "Datenschutzerklärung";
+"settings_sec_section" = "Sicherheit";
+
 "settings_terms_of_use_title" = "Nutzungsbedingungen";
 "settings_licenses_title" = "Lizenzen";
 "settings_export_logs" = "Protokolle exportieren";
@@ -38,12 +42,12 @@
 "button_update_notification_close" = "OK";
 
 "auth_prompt_set_up" = "Sperre einrichten";
-"re_auth_prompt_set_up" = "Re-Sperre einrichten XX";
+"re_auth_prompt_set_up" = "Bitte authentifizieren Sie sich erneut";
 
-"auth_prompt_disable" = " ";
+"auth_prompt_disable" = "Erneute Authentifizierung abschalten";
 
 "auth_prompt_unlock" = "Einloggen in polyPod";
-"re_auth_prompt_unlock" = " ";
+"re_auth_prompt_unlock" = "Bitte bestätigen Sie ihren Login";
 
 "settings_imprint_text" = "
 <p>Angaben gemäß § 5 TMG</p>

--- a/platform/ios/PolyPodApp/PolyPod/de.lproj/Localizable.strings
+++ b/platform/ios/PolyPodApp/PolyPod/de.lproj/Localizable.strings
@@ -36,10 +36,14 @@
 "button_confirm" = "Ja";
 "button_reject" = "Nein";
 "button_update_notification_close" = "OK";
+
 "auth_prompt_set_up" = "Sperre einrichten";
-"auth_prompt_disable" = "xx einrichten";
+"re_auth_prompt_set_up" = "Re-Sperre einrichten XX";
+
+"auth_prompt_disable" = " ";
 
 "auth_prompt_unlock" = "Einloggen in polyPod";
+"re_auth_prompt_unlock" = " ";
 
 "settings_imprint_text" = "
 <p>Angaben gemäß § 5 TMG</p>

--- a/platform/ios/PolyPodApp/PolyPod/en.lproj/Localizable.strings
+++ b/platform/ios/PolyPodApp/PolyPod/en.lproj/Localizable.strings
@@ -20,10 +20,12 @@
 "onboarding_slide4_body_text" = "We would like to ensure any data you put into polyPod is as secure as possible. For this we would like to ask you to enable some way of authentication for future access.";
 "settings_title" = "Settings";
 "settings_about_section" = "Info";
+"settings_auth" = "Authentication";
 "settings_version" = "Version";
 "settings_legal_section" = "Legal";
 "settings_imprint_title" = "Imprint";
 "settings_privacy_policy_title" = "Privacy Policy";
+"settings_sec_section" = "Security";
 "settings_terms_of_use_title" = "Terms of Use";
 "settings_licenses_title" = "Licenses";
 "settings_export_logs" = "Export logs";

--- a/platform/ios/PolyPodApp/PolyPod/en.lproj/Localizable.strings
+++ b/platform/ios/PolyPodApp/PolyPod/en.lproj/Localizable.strings
@@ -42,8 +42,6 @@
 "auth_prompt_set_up" = "Set up authentication";
 "re_auth_prompt_set_up" = "Re-authorize authentication";
 
-"auth_prompt_disable" = "Disable authentification";
-
 "auth_prompt_unlock" = "Login to your polyPod";
 "re_auth_prompt_unlock" = "Please confirm your Login";
 

--- a/platform/ios/PolyPodApp/PolyPod/en.lproj/Localizable.strings
+++ b/platform/ios/PolyPodApp/PolyPod/en.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "button_reject" = "No";
 "button_update_notification_close" = "OK";
 "auth_prompt_set_up" = "Set up authentification";
+"auth_prompt_disable" = "Disable authentification";
 "auth_prompt_unlock" = "Login to your polyPod";
 
 "settings_imprint_text" = "

--- a/platform/ios/PolyPodApp/PolyPod/en.lproj/Localizable.strings
+++ b/platform/ios/PolyPodApp/PolyPod/en.lproj/Localizable.strings
@@ -43,7 +43,6 @@
 "re_auth_prompt_set_up" = "Re-authorize authentication";
 
 "auth_prompt_unlock" = "Login to your polyPod";
-"re_auth_prompt_unlock" = "Please confirm your Login";
 
 "settings_imprint_text" = "
 <p>Details according to § 5 TMG</p>

--- a/platform/ios/PolyPodApp/PolyPod/en.lproj/Localizable.strings
+++ b/platform/ios/PolyPodApp/PolyPod/en.lproj/Localizable.strings
@@ -38,9 +38,14 @@
 "button_confirm" = "Yes";
 "button_reject" = "No";
 "button_update_notification_close" = "OK";
-"auth_prompt_set_up" = "Set up authentification";
+
+"auth_prompt_set_up" = "Set up authentication";
+"re_auth_prompt_set_up" = "Re-authorize authentication";
+
 "auth_prompt_disable" = "Disable authentification";
+
 "auth_prompt_unlock" = "Login to your polyPod";
+"re_auth_prompt_unlock" = "Please confirm your Login";
 
 "settings_imprint_text" = "
 <p>Details according to § 5 TMG</p>


### PR DESCRIPTION
🏗️ 
With this PR change, we allow users to turn PIN/biometrics authentication on/off via settings, and not only in Login/Onboarding phase.

It regards changes on both iOs and Android platforms, where the user is required to re-authenticate with their PIN/biometrics when they're turning the option on or off via a toggle button.

It mainly includes:
- Addition of toggle button in UI
- Addition of 'disable()' to handle the setting's off status
- Call Biometrics to re-authenticate 
- Set new value of "biometrics"/"authorization" key in Preferences
- Handle callbacks so we update value in UI when we've the result
- minor refactorings on the go


### How it looks like

#### In iOS:
<img width="285" alt="Screenshot 2022-05-04 at 23 30 03" src="https://user-images.githubusercontent.com/2449310/166829785-7f084dd2-00e7-4b31-b97d-c965b384693c.png">
<img width="293" alt="Screenshot 2022-05-04 at 23 29 51" src="https://user-images.githubusercontent.com/2449310/166829778-a80c5297-9ed2-4833-9465-a91f0d3ccabd.png">

#### In Android:
when setting is off:
![IMG_6762](https://user-images.githubusercontent.com/2449310/166829867-325e6cf6-8ec0-47e8-b58c-82e484721161.png)
when we toggle the button to on, it triggers a re-authentication:
![IMG_6763](https://user-images.githubusercontent.com/2449310/166829871-b60ee64b-638b-4093-b3d1-d41f05a54167.png)
the result when back to settings:
![IMG_6764](https://user-images.githubusercontent.com/2449310/166829874-2b655ddd-862e-4817-847e-a1d08fc85577.png)


Note:
I haven't seen any tests for other settings or onboarding/authentication, correct me if I'm wrong or let me know if you think we should add some here.