### PR TITLE
PROD4POD-1553: AppStoreConnect submit build for beta review

### DIFF
--- a/platform/AppStoreConnect/Sources/AppStoreConnect/AppStoreConnect.swift
+++ b/platform/AppStoreConnect/Sources/AppStoreConnect/AppStoreConnect.swift
@@ -10,6 +10,8 @@ public enum AppStoreConnectError: Error {
     case appNotFound
     case provisioningProfileNotFound
     case provisioningProfileContentIsMissing
+    case betaAppReviewStateIsMissing
+    case betaAppReviewRejected
 }
 
 // A facade for AppStoreConnect_Swift_SDK.APIProvider that manages multiple requests

--- a/platform/AppStoreConnect/Sources/AppStoreConnect/CreateBetaBuildLocalization.swift
+++ b/platform/AppStoreConnect/Sources/AppStoreConnect/CreateBetaBuildLocalization.swift
@@ -1,0 +1,14 @@
+import Foundation
+import AppStoreConnect_Swift_SDK
+
+extension AppStoreConnect {
+    func create(
+        betaBuildLocalizationForBuildWithId id: String,
+        locale: String,
+        whatsNew: String? = nil) async throws {
+            let endpoint = APIEndpoint.create(betaBuildLocalizationForBuildWithId: id,
+                                              locale: locale,
+                                              whatsNew: whatsNew)
+            _ = try await apiProvider.request(endpoint)
+    }
+}

--- a/platform/AppStoreConnect/Sources/AppStoreConnect/ReleaseToExternalTesters.swift
+++ b/platform/AppStoreConnect/Sources/AppStoreConnect/ReleaseToExternalTesters.swift
@@ -14,10 +14,18 @@ extension AppStoreConnect {
                                               groups: [String]) async throws {
         let app = try await getApp(forBundleIdentifier: appBundleIdentifier)
         let build = try await buildIsProcessed(forAppID: app.id,
-                                                        withVersion: version,
-                                                        buildNumber: buildNumber)
+                                               withVersion: version,
+                                               buildNumber: buildNumber)
+        try await addAccess(forBetaGroups: groups, toBuild: build.id)
+        try await create(betaBuildLocalizationForBuildWithId: build.id,
+                         locale: "en",
+                         whatsNew: "Build \(version)") // TODO: Create a proper change log
+        try await submitAppForBetaReview(buildWithId: build.id)
+    }
+    
+    func addAccess(forBetaGroups groups: [String], toBuild buildId: String) async throws {
         let addTesters = APIEndpoint.add(accessForBetaGroupsWithIds: groups,
-                                         toBuildWithId: build.id)
+                                         toBuildWithId: buildId)
         try await apiProvider.request(addTesters)
     }
 }

--- a/platform/AppStoreConnect/Sources/AppStoreConnect/SubmitAppForBetaReview.swift
+++ b/platform/AppStoreConnect/Sources/AppStoreConnect/SubmitAppForBetaReview.swift
@@ -1,0 +1,20 @@
+import Foundation
+import AppStoreConnect_Swift_SDK
+
+extension AppStoreConnect {
+    func submitAppForBetaReview(buildWithId id: String) async throws {
+        NSLog("Submiting build \(id) to beta review.")
+        let endpoint = APIEndpoint.submitAppForBetaReview(buildWithId: id)
+        let response = try await apiProvider.request(endpoint)
+        guard let state = response.data.attributes?.betaReviewState else {
+            NSLog("Failed to extract response for beta app review submission.")
+            throw AppStoreConnectError.betaAppReviewStateIsMissing
+        }
+        
+        if state == .rejected {
+            NSLog("Beta app review submission was rejected.")
+            throw AppStoreConnectError.betaAppReviewRejected
+        }
+        NSLog("Beta app review submission was succesful.")
+    }
+}


### PR DESCRIPTION
Before the build is sent to testers, it has to be sent to beta app review.

What was added:
- Add `What 's new` text for the build.
- Submit build for beta review.