### PR TITLE
Fix the Filterchips

### DIFF
--- a/feature-utils/poly-look/src/react-components/filterChips.jsx
+++ b/feature-utils/poly-look/src/react-components/filterChips.jsx
@@ -61,6 +61,14 @@ const FilterChips = ({
         )
   );
 
+  const [initialDefaultChips, setInitialDefaultChips] =
+    useState(defaultActiveChips);
+
+  if (defaultActiveChips !== initialDefaultChips) {
+    setActiveChips(defaultActiveChips);
+    setInitialDefaultChips(defaultActiveChips);
+  }
+
   const isChipActive = (id) => activeChips.indexOf(id) !== -1;
 
   const replaceOthers = (chipsIds) =>

--- a/feature-utils/poly-look/test/react-components/filterChips.test.js
+++ b/feature-utils/poly-look/test/react-components/filterChips.test.js
@@ -1,7 +1,8 @@
 import React from "react";
-import { render, fireEvent, screen } from "@testing-library/react";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import FilterChips from "../../src/react-components/filterChips.jsx";
+import { updatePropertySignature } from "typescript";
 
 const chipsContent = [...Array(3).keys()].map((i) => `chip${i}`);
 const chipsContentObject = [...Array(3).keys()].map((i) => {
@@ -22,6 +23,16 @@ const component = (
     exclusive
   />
 );
+
+const componentsWithDifferentDefault = chipsContent.map((chipId) => (
+  <FilterChips
+    chipsContent={chipsContent}
+    onChipClick={mockedHandleClick}
+    defaultActiveChips={[chipId]}
+    theme
+    exclusive
+  />
+));
 
 it("Chips content is an object array", () => {
   render(<FilterChips chipsContent={chipsContentObject} />);
@@ -82,6 +93,19 @@ describe("Chips content is an array", () => {
     }
     if (theme === darkTheme) {
       expect(component).toHaveClass("poly-theme-dark");
+    }
+  });
+});
+
+describe("check that props can update the active chips state from outside", () => {
+  it("changes selected chip after new default is introduced", async () => {
+    const { rerender } = render(component);
+    for (let i = 0; i < componentsWithDifferentDefault.length; i++) {
+      let chipElement = screen.getByText(chipsContent[i]);
+      expect(chipElement).not.toHaveClass("chip selected");
+      await waitFor(() => rerender(componentsWithDifferentDefault[i]));
+      chipElement = screen.getByText(chipsContent[i]);
+      expect(chipElement).toHaveClass("chip selected");
     }
   });
 });

--- a/feature-utils/poly-look/test/react-components/filterChips.test.js
+++ b/feature-utils/poly-look/test/react-components/filterChips.test.js
@@ -2,7 +2,6 @@ import React from "react";
 import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import FilterChips from "../../src/react-components/filterChips.jsx";
-import { updatePropertySignature } from "typescript";
 
 const chipsContent = [...Array(3).keys()].map((i) => `chip${i}`);
 const chipsContentObject = [...Array(3).keys()].map((i) => {

--- a/feature-utils/poly-look/test/react-components/filterChips.test.js
+++ b/feature-utils/poly-look/test/react-components/filterChips.test.js
@@ -104,7 +104,6 @@ describe("check that props can update the active chips state from outside", () =
       let chipElement = screen.getByText(chipsContent[i]);
       expect(chipElement).not.toHaveClass("chip selected");
       await waitFor(() => rerender(componentsWithDifferentDefault[i]));
-      chipElement = screen.getByText(chipsContent[i]);
       expect(chipElement).toHaveClass("chip selected");
     }
   });


### PR DESCRIPTION
Yeah thats a weird one. Apparently the Filterchips were broken when you press a bubble.
It doesn't really have a way to update chips from outside. This should be just a dumb component without state, BUT the "all" and "others" chip used in polyExplorer make this quite complicated logic which i wouldn't want to repeat.

Soooo I added another state to compare the current state to the original one, so when the defaultChip changes from outside it'll change on the inside. Yeah just a hack for now..