### PR TITLE
Increase timeout in iOS tests

### DIFF
--- a/platform/ios/PolyPodApp/PolyPodUITests/UpdateNotificationTest.swift
+++ b/platform/ios/PolyPodApp/PolyPodUITests/UpdateNotificationTest.swift
@@ -60,7 +60,7 @@ class UpdateNotificationTest: XCTestCase {
             ]
         }
         app.launch()
-        let background = app.wait(for: .runningForeground, timeout: 30)
+        let background = app.wait(for: .runningForeground, timeout: 60)
         XCTAssertTrue(background)
     }
 


### PR DESCRIPTION
This was timing out repeatedly lately, for instance [here](https://github.com/polypoly-eu/polyPod/runs/6391074448?check_suite_focus=true). The error was reported like:

```
Executed 5 tests, with 1 failure (0 unexpected) in 53.690 (53.694) seconds
```

So I guess we need to increase the timeou to 60 seconds. That would reduce the likelihood of this failing. The first attempt (in #315) did result in some improvement until now, maybe due to degraded performance of the OSX runner or some unrelated thing.