### PR TITLE
Bump up ECMA version of ESLint's parser

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
     ],
     plugins: ["cypress"],
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2021,
         sourceType: "module",
     },
     env: {

--- a/build/.eslintrc.json
+++ b/build/.eslintrc.json
@@ -1,7 +1,4 @@
 {
-    "parserOptions": {
-        "ecmaVersion": 10
-    },
     "env": {
         "es6": true,
         "node": true

--- a/feature-utils/poly-look/.eslintrc.js
+++ b/feature-utils/poly-look/.eslintrc.js
@@ -1,7 +1,6 @@
 module.exports = {
   extends: ["eslint:recommended"],
   parserOptions: {
-    ecmaVersion: 2020,
     sourceType: "module",
   },
   globals: {

--- a/feature-utils/silly-i18n/.eslintrc.cjs
+++ b/feature-utils/silly-i18n/.eslintrc.cjs
@@ -8,8 +8,7 @@ module.exports = {
         {
             files: ["*.js"],
             parserOptions: {
-                sourceType: "module",
-                ecmaVersion: 2020
+                sourceType: "module"
             }
         }
     ]

--- a/features/polyPreview/.eslintrc.js
+++ b/features/polyPreview/.eslintrc.js
@@ -8,7 +8,6 @@ module.exports = {
             files: ["*.js"],
             parserOptions: {
                 sourceType: "module",
-                ecmaVersion: 2020
             }
         }
     ]


### PR DESCRIPTION
This came up in #860 where I'd like to use the `||=` operator but unless we advance `parserOption.ecmaVersion` to `2021` in the ESlint configuration, ESLint will fail to parse any script using the new operator.

It seems to be sufficient to just set this setting in the top-level ESlint configuration and if we stop overriding it in the configurations down the source tree.