### PR TITLE
Avoid flatbuffers code being linted

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -35,6 +35,7 @@ module.exports = {
         ".eslintrc.*",
         "**/build/*",
         "PolyPodApp/",
+        "flatbuffers_shared/",
     ],
     rules: {
         semi: 2,


### PR DESCRIPTION
Flatbuffers included a number of TypeScript files, that were yielding false positives in linting, at least if you had made a core build locally; no issue in the global CI