### PR TITLE
[🙈] Eliminate linting errors by configuring in the proper place.

### DIFF
--- a/platform/core/.eslintrc
+++ b/platform/core/.eslintrc
@@ -1,3 +1,3 @@
 {
-    "ignorePatterns": ["/flatbuffers_shared/flatbuffers"]
+    "ignorePatterns": ["/flatbuffers_shared/"]
 }


### PR DESCRIPTION
Avoid version issues by using the whole directory. This is in place of #881 reverted by #883 