### PR TITLE
rename of unrecognizedCard to reportCard

### DIFF
--- a/features/facebookImport/src/locales/de/explore.json
+++ b/features/facebookImport/src/locales/de/explore.json
@@ -4,9 +4,9 @@
     "report.success": "Ihr Report wurde an uns gesendet. Vielen Dank!",
     "report.error": "Ihr Report wurde nicht gesendet. Bitte erneut versuchen!",
     "loading": "Ihre Daten werden analysiert",
-    "unrecognizedCard.headline": "Wir brauchen Ihre Hilfe!",
-    "unrecognizedCard.text": "Wenn Sie uns eine anonymisierte Zusammenfassung der Strukturen Ihres Facebook-Exportes senden, können wir den Facebook-Daten Importer für Sie und alle anderen verbessern, so dass Sie mehr Analysen und Berichte angezeigt bekommen.",
-    "unrecognizedCard.button": "Mehr erfahren",
+    "reportCard.headline": "Wir brauchen Ihre Hilfe!",
+    "reportCard.text": "Wenn Sie uns eine anonymisierte Zusammenfassung der Strukturen Ihres Facebook-Exportes senden, können wir den Facebook-Daten Importer für Sie und alle anderen verbessern, so dass Sie mehr Analysen und Berichte angezeigt bekommen.",
+    "reportCard.button": "Mehr erfahren",
     "details.button": "Details ansehen",
     "analysis.label.techDemo": "Tech Demo",
     "scroll": "Scrollen Sie weiter, um mehr zu sehen"

--- a/features/facebookImport/src/locales/en/explore.json
+++ b/features/facebookImport/src/locales/en/explore.json
@@ -4,9 +4,9 @@
     "report.success": "Your report was sent to us. Thank you!",
     "report.error": "Your report could not be sent. Please try again!",
     "loading": "Your data is being analysed",
-    "unrecognizedCard.headline": "We need your help!",
-    "unrecognizedCard.text": "If you send us an anonymised report about the structure of your Facebook data, it would help us improve the Facebook Data Importer so that it can show you even more insights.",
-    "unrecognizedCard.button": "Learn more",
+    "reportCard.headline": "We need your help!",
+    "reportCard.text": "If you send us an anonymised report about the structure of your Facebook data, it would help us improve the Facebook Data Importer so that it can show you even more insights.",
+    "reportCard.button": "Learn more",
     "details.button": "View details",
     "analysis.label.techDemo": "Tech demo",
     "scroll": "Scroll to view more"

--- a/features/facebookImport/src/views/explore/explore.jsx
+++ b/features/facebookImport/src/views/explore/explore.jsx
@@ -20,15 +20,15 @@ const PopUpMessage = ({ children, reportResultAnswer }) => {
     return <div className={"pop-up" + reportResultAnswer}>{children}</div>;
 };
 
-const UnrecognizedCard = () => {
+const ReportCard = () => {
     return (
         <div className="analysis-card unrecognized-analysis-card">
             <div className="unrecognized-analysis-title">
-                <h1>{i18n.t("explore:unrecognizedCard.headline")}</h1>
+                <h1>{i18n.t("explore:reportCard.headline")}</h1>
             </div>
-            <p>{i18n.t("explore:unrecognizedCard.text")}</p>
+            <p>{i18n.t("explore:reportCard.text")}</p>
             <RouteButton route="/report" className="report-button">
-                {i18n.t("explore:unrecognizedCard.button")}
+                {i18n.t("explore:reportCard.button")}
             </RouteButton>
         </div>
     );
@@ -84,7 +84,7 @@ const ExploreView = () => {
             );
         return (
             <List>
-                <UnrecognizedCard />
+                <ReportCard />
                 {ministories.map((MinistoryClass, index) => {
                     const ministory = new MinistoryClass({
                         account,

--- a/features/google/src/views/explore/explore.jsx
+++ b/features/google/src/views/explore/explore.jsx
@@ -13,7 +13,7 @@ import "./explore.css";
 import { ministories } from "../ministories/ministories.js";
 import { useHistory } from "react-router-dom";
 
-const UnrecognizedCard = () => {
+const ReportCard = () => {
     const history = useHistory();
 
     return (
@@ -40,7 +40,7 @@ const ExploreView = () => {
         return (
             <Screen className="explore" layout="poly-standard-layout">
                 <List>
-                    <UnrecognizedCard />
+                    <ReportCard />
                     {ministories.map((MinistoryClass, index) => {
                         const ministory = new MinistoryClass({
                             account,


### PR DESCRIPTION

As the unrecognized data ministory has been scrapped in https://github.com/polypoly-eu/polyPod/pull/824 and the card in the explore view is really only leading the user to the reports page, it makes sense for the card to be renamed to ReportCard.