### PR TITLE
Get rid of i18n.js proxy modules

### DIFF
--- a/features/facebookImport/src/components/activitiesMiniStory/activitiesMiniStory.jsx
+++ b/features/facebookImport/src/components/activitiesMiniStory/activitiesMiniStory.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 
 import InfoButton from "../buttons/infoButton/infoButton.jsx";
 

--- a/features/facebookImport/src/components/advertisingValueMiniStory/advertisingValueMiniStory.jsx
+++ b/features/facebookImport/src/components/advertisingValueMiniStory/advertisingValueMiniStory.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 import ListOfDetails from "../listOfDetails/listOfDetails.jsx";
 import "./advertisingValueMiniStory.css";
 

--- a/features/facebookImport/src/components/buttons/scrollButton/scrollButton.jsx
+++ b/features/facebookImport/src/components/buttons/scrollButton/scrollButton.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-// import i18n from "../../../i18n.js";
+// import i18n from "!silly-i18n";
 
 import "./scrollButton.css";
 

--- a/features/facebookImport/src/components/dataStructureMiniStory/dataStructureMiniStory.jsx
+++ b/features/facebookImport/src/components/dataStructureMiniStory/dataStructureMiniStory.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import InfoButton from "../buttons/infoButton/infoButton.jsx";
 import { PolyChart, FilterChips } from "@polypoly-eu/poly-look";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 import "./dataStructureMiniStory.css";
 

--- a/features/facebookImport/src/components/importExplanationExpandable/importExplanationExpandable.jsx
+++ b/features/facebookImport/src/components/importExplanationExpandable/importExplanationExpandable.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import RouteButton from "../buttons/routeButton.jsx";
 import InfoBox from "../infoBox/infoBox.jsx";
 import ScrollButton from "../buttons/scrollButton/scrollButton.jsx";

--- a/features/facebookImport/src/components/loading/loading.jsx
+++ b/features/facebookImport/src/components/loading/loading.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 import "./loading.css";
 

--- a/features/facebookImport/src/components/messagesMiniStory/messagesMiniStory.jsx
+++ b/features/facebookImport/src/components/messagesMiniStory/messagesMiniStory.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 
 import BarChart from "../dataViz/barChart.jsx";
 import InfoButton from "../buttons/infoButton/infoButton.jsx";

--- a/features/facebookImport/src/components/onOffFacebookMiniStory/onOffFacebookMiniStory.jsx
+++ b/features/facebookImport/src/components/onOffFacebookMiniStory/onOffFacebookMiniStory.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { PolyChart } from "@polypoly-eu/poly-look";
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 
 import "./onOffFacebookMiniStory.css";
 import BarChart from "../dataViz/barChart.jsx";

--- a/features/facebookImport/src/components/picturesMiniStory/picturesMiniStory.jsx
+++ b/features/facebookImport/src/components/picturesMiniStory/picturesMiniStory.jsx
@@ -3,7 +3,7 @@ import * as d3 from "d3";
 
 import picturesMinistorySvg from "../../static/images/pictures-ministory/pictures-ministory.svg";
 import InfoButton from "../buttons/infoButton/infoButton.jsx";
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 
 import "./picturesMiniStory.css";
 

--- a/features/facebookImport/src/components/postReactionTypesMiniStory/postReactionTypesMiniStory.jsx
+++ b/features/facebookImport/src/components/postReactionTypesMiniStory/postReactionTypesMiniStory.jsx
@@ -3,7 +3,7 @@ import { PolyChart } from "@polypoly-eu/poly-look";
 
 import InfoButton from "../buttons/infoButton/infoButton.jsx";
 
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 
 import likeIcon from "../../static/images/reactions-ministory/like.svg";
 import loveIcon from "../../static/images/reactions-ministory/love.svg";

--- a/features/facebookImport/src/context/importer-context.jsx
+++ b/features/facebookImport/src/context/importer-context.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 
-import i18n from "../i18n.js";
+import i18n from "!silly-i18n";
 import { useHistory, useLocation } from "react-router-dom";
 
 import popUps from "../popUps";

--- a/features/facebookImport/src/facebookImporter.jsx
+++ b/features/facebookImport/src/facebookImporter.jsx
@@ -21,7 +21,7 @@ import {
 } from "@polypoly-eu/poly-look";
 import { dataImporters } from "./model/importer.js";
 import FacebookAccount from "./model/entities/facebook-account.js";
-import i18n from "./i18n.js";
+import i18n from "!silly-i18n";
 
 import Overview from "./views/overview/overview.jsx";
 import ImportView from "./views/import/import.jsx";

--- a/features/facebookImport/src/i18n.js
+++ b/features/facebookImport/src/i18n.js
@@ -1,2 +1,0 @@
-// TODO: Remove this module, and import "!silly-i18n" directly.
-export { default } from "!silly-i18n";

--- a/features/facebookImport/src/model/entities/facebook-account.js
+++ b/features/facebookImport/src/model/entities/facebook-account.js
@@ -1,5 +1,5 @@
 import { DataAccount } from "@polypoly-eu/poly-import";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import MessageThreadsGroup from "./message-threads-group.js";
 import RelatedAccountsGroup from "./related-accounts-group.js";
 

--- a/features/facebookImport/src/popUps/baseInfoPopUp/baseInfoPopUp.jsx
+++ b/features/facebookImport/src/popUps/baseInfoPopUp/baseInfoPopUp.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { ImporterContext } from "../../context/importer-context.jsx";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 import "./baseInfoPopUp.css";
 

--- a/features/facebookImport/src/popUps/infoPopUps/activities.jsx
+++ b/features/facebookImport/src/popUps/infoPopUps/activities.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import Infographic from "../../components/infographic/infographic.jsx";
 

--- a/features/facebookImport/src/popUps/infoPopUps/dataStructure.jsx
+++ b/features/facebookImport/src/popUps/infoPopUps/dataStructure.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import Infographic from "../../components/infographic/infographic.jsx";
 

--- a/features/facebookImport/src/popUps/infoPopUps/messages.jsx
+++ b/features/facebookImport/src/popUps/infoPopUps/messages.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import Infographic from "../../components/infographic/infographic.jsx";
 

--- a/features/facebookImport/src/popUps/infoPopUps/offFacebook.jsx
+++ b/features/facebookImport/src/popUps/infoPopUps/offFacebook.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import Infographic from "../../components/infographic/infographic.jsx";
 

--- a/features/facebookImport/src/popUps/infoPopUps/onOffFacebook.jsx
+++ b/features/facebookImport/src/popUps/infoPopUps/onOffFacebook.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import Infographic from "../../components/infographic/infographic.jsx";
 

--- a/features/facebookImport/src/popUps/infoPopUps/pictures.jsx
+++ b/features/facebookImport/src/popUps/infoPopUps/pictures.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 
 const PicturesInfoPopUp = () => {

--- a/features/facebookImport/src/popUps/infoPopUps/postReaction.jsx
+++ b/features/facebookImport/src/popUps/infoPopUps/postReaction.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import Infographic from "../../components/infographic/infographic.jsx";
 

--- a/features/facebookImport/src/utils/formatTime.js
+++ b/features/facebookImport/src/utils/formatTime.js
@@ -1,4 +1,4 @@
-import i18n from "../i18n";
+import i18n from "!silly-i18n";
 
 const defaultFormat = i18n.t("common:time.format");
 

--- a/features/facebookImport/src/views/explore/explore.jsx
+++ b/features/facebookImport/src/views/explore/explore.jsx
@@ -11,7 +11,7 @@ import {
     ClickableCard,
 } from "@polypoly-eu/poly-look";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 import "./explore.css";
 import { ministories } from "../ministories/ministories.js";

--- a/features/facebookImport/src/views/import/import.jsx
+++ b/features/facebookImport/src/views/import/import.jsx
@@ -4,7 +4,7 @@ import { FileSelectionError, FileImportError } from "@polypoly-eu/poly-import";
 import { PolyImportContext } from "@polypoly-eu/poly-look";
 import ProgressBarComponent from "../../components/progressBar/progressBar.jsx";
 import ImportExplanationExpandable from "../../components/importExplanationExpandable/importExplanationExpandable.jsx";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import PolypolyDialog from "../../components/dialogs/polypolyDialog/polypolyDialog.jsx";
 import { FBIMPORT_NAMESPACE } from "../../constants.js";
 

--- a/features/facebookImport/src/views/ministories/aboutPictures.jsx
+++ b/features/facebookImport/src/views/ministories/aboutPictures.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 import analysisKeys from "../../model/analyses/utils/analysisKeys";
 
 import PicturesMiniStory from "../../components/picturesMiniStory/picturesMiniStory.jsx";

--- a/features/facebookImport/src/views/ministories/activities.jsx
+++ b/features/facebookImport/src/views/ministories/activities.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import {
     ActivitiesMiniStorySummary,
     ActivitiesMiniStoryDetails,

--- a/features/facebookImport/src/views/ministories/advertisingValue.jsx
+++ b/features/facebookImport/src/views/ministories/advertisingValue.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Story from "./story.jsx";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import analysisKeys from "../../model/analyses/utils/analysisKeys";
 import {
     AdvertisingValueMiniStorySummary,

--- a/features/facebookImport/src/views/ministories/connectedAdvertisers.jsx
+++ b/features/facebookImport/src/views/ministories/connectedAdvertisers.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ListOfDetails from "../../components/listOfDetails/listOfDetails.jsx";
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 import analysisKeys from "../../model/analyses/utils/analysisKeys";
 import { SingleDataStory } from "./singleDataStory.jsx";
 

--- a/features/facebookImport/src/views/ministories/dataStructureBubbles.jsx
+++ b/features/facebookImport/src/views/ministories/dataStructureBubbles.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import DataStructureMiniStory from "../../components/dataStructureMiniStory/dataStructureMiniStory.jsx";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import analysisKeys from "../../model/analyses/utils/analysisKeys";
 import { SingleDataStory } from "./singleDataStory.jsx";
 

--- a/features/facebookImport/src/views/ministories/messages.jsx
+++ b/features/facebookImport/src/views/ministories/messages.jsx
@@ -4,7 +4,7 @@ import {
     MessagesMiniStoryDetails,
     MessagesMiniStorySummary,
 } from "../../components/messagesMiniStory/messagesMiniStory.jsx";
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 import analysisKeys from "../../model/analyses/utils/analysisKeys";
 
 class MessagesMinistory extends Story {

--- a/features/facebookImport/src/views/ministories/onOffFacebookEvents.jsx
+++ b/features/facebookImport/src/views/ministories/onOffFacebookEvents.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 import {
     OnOffFacebookMiniStorySummary,

--- a/features/facebookImport/src/views/ministories/postReactionsTypes.jsx
+++ b/features/facebookImport/src/views/ministories/postReactionsTypes.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PostReactionTypesMiniStory from "../../components/postReactionTypesMiniStory/postReactionTypesMiniStory.jsx";
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 import analysisKeys from "../../model/analyses/utils/analysisKeys";
 import { SingleDataStory } from "./singleDataStory.jsx";
 

--- a/features/facebookImport/src/views/overview/overview.jsx
+++ b/features/facebookImport/src/views/overview/overview.jsx
@@ -8,7 +8,7 @@ import {
 } from "@polypoly-eu/poly-look";
 import RouteButton from "../../components/buttons/routeButton.jsx";
 import PolypolyDialog from "../../components/dialogs/polypolyDialog/polypolyDialog.jsx";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import { useHistory } from "react-router";
 import { formatTime } from "../../utils/formatTime.js";
 import { analyzeFile } from "@polypoly-eu/poly-analysis";

--- a/features/facebookImport/src/views/report/report.jsx
+++ b/features/facebookImport/src/views/report/report.jsx
@@ -2,7 +2,7 @@ import React, { useContext, useState } from "react";
 import RouteButton from "../../components/buttons/routeButton.jsx";
 import { ImporterContext } from "../../context/importer-context.jsx";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 import "./report.css";
 

--- a/features/google/src/components/activitiesOverTimeStory/activitiesOverTimeStory.jsx
+++ b/features/google/src/components/activitiesOverTimeStory/activitiesOverTimeStory.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 
 import "./activitiesOverTimeStory.css";
 import "./datePicker.css";

--- a/features/google/src/google.jsx
+++ b/features/google/src/google.jsx
@@ -25,7 +25,7 @@ import {
 } from "@polypoly-eu/poly-look";
 import GoogleAccount from "./model/google-account.js";
 import { dataImporters } from "./model/importer.js";
-import i18n from "../../facebookImport/src/i18n.js";
+import i18n from "!silly-i18n";
 import ExploreView from "./views/explore/explore.jsx";
 import DetailsView from "./views/explore/details.jsx";
 import ReportWrapper from "./views/report/reportWrapper.jsx";

--- a/features/google/src/i18n.js
+++ b/features/google/src/i18n.js
@@ -1,2 +1,0 @@
-// TODO: Remove this module, and import "!silly-i18n" directly.
-export { default } from "!silly-i18n";

--- a/features/google/src/views/explore/explore.jsx
+++ b/features/google/src/views/explore/explore.jsx
@@ -9,7 +9,7 @@ import {
     PolyButton,
 } from "@polypoly-eu/poly-look";
 
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 
 import "./explore.css";
 import { ministories } from "../ministories/ministories.js";

--- a/features/google/src/views/ministories/activitiesOverTime.jsx
+++ b/features/google/src/views/ministories/activitiesOverTime.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import { SingleDataStory } from "./singleDataStory.jsx";
 import analysisKeys from "../../model/analyses/analysisKeys.js";
 import {

--- a/features/google/src/views/overview/overview.jsx
+++ b/features/google/src/views/overview/overview.jsx
@@ -9,7 +9,7 @@ import {
     INITIAL_HISTORY_STATE,
 } from "@polypoly-eu/poly-look";
 import { useHistory } from "react-router-dom";
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 import { analyzeFile } from "@polypoly-eu/poly-analysis";
 import { specificAnalyses } from "../../model/analyses/analyses";
 import {

--- a/features/polyExplorer/src/components/buttons/scrollButton/scrollButton.jsx
+++ b/features/polyExplorer/src/components/buttons/scrollButton/scrollButton.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 
 import "./scrollButton.css";
 

--- a/features/polyExplorer/src/components/clusterStories/dataTypes.jsx
+++ b/features/polyExplorer/src/components/clusterStories/dataTypes.jsx
@@ -7,7 +7,7 @@ import {
     createDataTypesTabs,
     createDataTypesSharedCombined,
 } from "../../screens/stories/story-utils.js";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 const DataTypes = ({ entities, i18nHeader }) => {
     const bubbleColor = "#FB8A89";

--- a/features/polyExplorer/src/components/clusterStories/messengerMauChart.jsx
+++ b/features/polyExplorer/src/components/clusterStories/messengerMauChart.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { FilterChips, LineLegend, PolyChart } from "@polypoly-eu/poly-look";
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 
 import "./messengerMauChart.css";
 

--- a/features/polyExplorer/src/components/clusterStories/messengerTreeMap.jsx
+++ b/features/polyExplorer/src/components/clusterStories/messengerTreeMap.jsx
@@ -3,7 +3,7 @@ import { createFacebookandOtherTreeMapData } from "../../screens/stories/story-u
 import { BlockLegend, PolyChart } from "@polypoly-eu/poly-look";
 
 import "./messengerTreeMap.css";
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 
 const MessengerTreeMap = ({ messengers, i18nHeader }) => {
     const facebookGroupName = "Facebook (US)";

--- a/features/polyExplorer/src/components/clusterStories/overviewBarChart.jsx
+++ b/features/polyExplorer/src/components/clusterStories/overviewBarChart.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Tabs, Tab, PolyChart } from "@polypoly-eu/poly-look";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 import "./overviewBarChart.css";
 import { latestActiveUsersValue } from "../../screens/stories/story-utils.js";

--- a/features/polyExplorer/src/components/clusterStories/purposes.jsx
+++ b/features/polyExplorer/src/components/clusterStories/purposes.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import PurposesBarChart from "../dataViz/purposesBarChart.jsx";
 import SourceInfoButton from "../sourceInfoButton/sourceInfoButton.jsx";
 

--- a/features/polyExplorer/src/components/clusterStories/receivingCompanies.jsx
+++ b/features/polyExplorer/src/components/clusterStories/receivingCompanies.jsx
@@ -2,7 +2,7 @@ import React, { useState, useContext, useMemo } from "react";
 import { Tabs, Tab, PolyChart } from "@polypoly-eu/poly-look";
 import SourceInfoButton from "../sourceInfoButton/sourceInfoButton.jsx";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import { ExplorerContext } from "../../context/explorer-context.jsx";
 
 import "./receivingCompanies.css";

--- a/features/polyExplorer/src/components/clusterStories/storiesInfoScreen.jsx
+++ b/features/polyExplorer/src/components/clusterStories/storiesInfoScreen.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { ExplorerContext } from "../../context/explorer-context.jsx";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 import "./storiesInfoScreen.css";
 

--- a/features/polyExplorer/src/components/constructionPopup/constructionPopup.jsx
+++ b/features/polyExplorer/src/components/constructionPopup/constructionPopup.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 import "./constructionPopup.css";
 

--- a/features/polyExplorer/src/components/dataRegionsLegend/dataRegionsLegend.jsx
+++ b/features/polyExplorer/src/components/dataRegionsLegend/dataRegionsLegend.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import "./dataRegionsLegend.css";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import { I18nSection } from "@polypoly-eu/silly-i18n";
 
 const i18nC = new I18nSection(i18n, "common");

--- a/features/polyExplorer/src/components/dataSharingGauge/dataSharingGauge.jsx
+++ b/features/polyExplorer/src/components/dataSharingGauge/dataSharingGauge.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 import "./dataSharingGauge.css";
 

--- a/features/polyExplorer/src/components/dataSharingLegend/dataSharingLegend.jsx
+++ b/features/polyExplorer/src/components/dataSharingLegend/dataSharingLegend.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import LinkButton from "../linkButton/linkButton.jsx";
 
 const DataSharingLegend = ({ route, stateChange }) => (

--- a/features/polyExplorer/src/components/dataViz/companyBubbles.jsx
+++ b/features/polyExplorer/src/components/dataViz/companyBubbles.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-case-declarations */
 import React, { useEffect, useRef, useState } from "react";
 import * as d3 from "d3";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import utils from "./utils.js";
 import { ANIMATION_TIME, DIAGRAMS, OPACITY_RANGE } from "../../constants";
 import "./dataViz.css";

--- a/features/polyExplorer/src/components/dataViz/purposeChart.jsx
+++ b/features/polyExplorer/src/components/dataViz/purposeChart.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import Scrollable from "../../components/scrollable/scrollable.jsx";
 
 import "./purposeChart.css";

--- a/features/polyExplorer/src/components/dataViz/purposesBarChart.jsx
+++ b/features/polyExplorer/src/components/dataViz/purposesBarChart.jsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState } from "react";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import * as d3 from "d3";
 
 const PurposesBarChart = ({ data, animation, onClick }) => {

--- a/features/polyExplorer/src/components/featuredEntity/featuredEntity.jsx
+++ b/features/polyExplorer/src/components/featuredEntity/featuredEntity.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { ExplorerContext } from "../../context/explorer-context.jsx";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import DataSharingGauge from "../dataSharingGauge/dataSharingGauge.jsx";
 import LinkButton from "../buttons/linkButton/linkButton.jsx";
 import "./featuredEntity.css";

--- a/features/polyExplorer/src/components/filteredEntityList/filteredEntityList.jsx
+++ b/features/polyExplorer/src/components/filteredEntityList/filteredEntityList.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 import EntityList from "../entityList/entityList.jsx";
 import LinkButton from "../buttons/linkButton/linkButton.jsx";

--- a/features/polyExplorer/src/components/storiesPreview/storiesPreview.jsx
+++ b/features/polyExplorer/src/components/storiesPreview/storiesPreview.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useHistory } from "react-router-dom";
 import { ClickableCard, List, RoutingWrapper } from "@polypoly-eu/poly-look";
-import i18n from "../../i18n";
+import i18n from "!silly-i18n";
 import { I18nSection } from "@polypoly-eu/silly-i18n";
 
 import "./storiesPreview.css";

--- a/features/polyExplorer/src/context/explorer-context.jsx
+++ b/features/polyExplorer/src/context/explorer-context.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { pod } from "../fakePod.js";
 import { useHistory, useLocation } from "react-router-dom";
-import i18n from "../i18n.js";
+import i18n from "!silly-i18n";
 
 //model
 import { Company } from "../model/company.js";

--- a/features/polyExplorer/src/i18n.js
+++ b/features/polyExplorer/src/i18n.js
@@ -1,2 +1,0 @@
-// TODO: Remove this module, and import "!silly-i18n" directly.
-export { default } from "!silly-i18n";

--- a/features/polyExplorer/src/popUps/centerBox/centerBox.jsx
+++ b/features/polyExplorer/src/popUps/centerBox/centerBox.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 import "./centerBox.css";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/barChartInfo/companiesBarChartInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/barChartInfo/companiesBarChartInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import StoriesInfoScreen from "../../../components/clusterStories/storiesInfoScreen.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/barChartInfo/overviewBarChartInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/barChartInfo/overviewBarChartInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import StoriesInfoScreen from "../../../components/clusterStories/storiesInfoScreen.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/barChartInfo/purposesBarChartInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/barChartInfo/purposesBarChartInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import StoriesInfoScreen from "../../../components/clusterStories/storiesInfoScreen.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/baseInfoPopUp/baseInfoPopUp.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/baseInfoPopUp/baseInfoPopUp.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { ExplorerContext } from "../../../context/explorer-context.jsx";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 
 import "./baseInfoPopUp.css";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/categoryInfo/categoryInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/categoryInfo/categoryInfo.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import highlights from "../../../data/highlights.js";
 import globals from "../../../data/global.json";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";

--- a/features/polyExplorer/src/popUps/infoPopUps/companiesInfo/companiesInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/companiesInfo/companiesInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/companyRevenueBarChartInfo/companyRevenueBarChartInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/companyRevenueBarChartInfo/companyRevenueBarChartInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import StoriesInfoScreen from "../../../components/clusterStories/storiesInfoScreen.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/companyRevenueChart/companyRevenueBarChartInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/companyRevenueChart/companyRevenueBarChartInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import StoriesInfoScreen from "../../components/clusterStories/storiesInfoScreen.jsx";
 import Infographic from "../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/correlationInfo/correlationInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/correlationInfo/correlationInfo.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import highlights from "../../../data/highlights.js";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";

--- a/features/polyExplorer/src/popUps/infoPopUps/dataRegionInfo/dataRegionInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/dataRegionInfo/dataRegionInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import SectionTitle from "../../../components/clusterStories/sectionTitle.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/dataRegionsDiagramInfo/dataRegionsDiagramInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/dataRegionsDiagramInfo/dataRegionsDiagramInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import StoriesInfoScreen from "../../../components/clusterStories/storiesInfoScreen.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 import { DataRegionInfoContent } from "../dataRegionInfo/dataRegionInfo.jsx";

--- a/features/polyExplorer/src/popUps/infoPopUps/dataTypesInfo/dataTypesInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/dataTypesInfo/dataTypesInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/dataTypesMatrixInfo/companyDataTypesInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/dataTypesMatrixInfo/companyDataTypesInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import StoriesInfoScreen from "../../../components/clusterStories/storiesInfoScreen.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/dataTypesMatrixInfo/sharesDataTypesInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/dataTypesMatrixInfo/sharesDataTypesInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import StoriesInfoScreen from "../../../components/clusterStories/storiesInfoScreen.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/dataTypesMatrixInfo/typesDataTypesInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/dataTypesMatrixInfo/typesDataTypesInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import StoriesInfoScreen from "../../../components/clusterStories/storiesInfoScreen.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/detailsLineChartInfo/detailsLineChartInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/detailsLineChartInfo/detailsLineChartInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import StoriesInfoScreen from "../../../components/clusterStories/storiesInfoScreen.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/detailsTreemapInfo/detailsTreemapInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/detailsTreemapInfo/detailsTreemapInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import StoriesInfoScreen from "../../../components/clusterStories/storiesInfoScreen.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/featuredEntityInfo/featuredEntityInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/featuredEntityInfo/featuredEntityInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/industriesPackedCircleInfo/industriesPackedCircleInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/industriesPackedCircleInfo/industriesPackedCircleInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import StoriesInfoScreen from "../../../components/clusterStories/storiesInfoScreen.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/infoPopUps/info/info.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/info/info.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 
 import "./info.css";

--- a/features/polyExplorer/src/popUps/infoPopUps/jurisdictionInfo/jurisdictionInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/jurisdictionInfo/jurisdictionInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import "./jurisdictionInfo.css";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";

--- a/features/polyExplorer/src/popUps/infoPopUps/purposeInfo/purposeInfo.jsx
+++ b/features/polyExplorer/src/popUps/infoPopUps/purposeInfo/purposeInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import BaseInfoPopUp from "../baseInfoPopUp/baseInfoPopUp.jsx";
 import Infographic from "../../../components/infographic/infographic.jsx";
 

--- a/features/polyExplorer/src/popUps/onboardingPopup/onboardingPopup.jsx
+++ b/features/polyExplorer/src/popUps/onboardingPopup/onboardingPopup.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import "./onboardingPopup.css";
 
 const OnboardingPopup = ({ onClose, onMoreInfo }) => {

--- a/features/polyExplorer/src/screens/dataExploration/dataExploration.jsx
+++ b/features/polyExplorer/src/screens/dataExploration/dataExploration.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useEffect, useContext } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import Screen from "../../components/screen/screen.jsx";
 import DataTypeBubbleAll from "../../components/dataViz/dataTypeBubbleAll.jsx";
 import DataTypeBubbleCategory from "../../components/dataViz/dataTypeBubbleCategory.jsx";

--- a/features/polyExplorer/src/screens/entityDetails/companyRevenueChart/companyRevenueChart.jsx
+++ b/features/polyExplorer/src/screens/entityDetails/companyRevenueChart/companyRevenueChart.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import i18n from "../../../i18n.js";
+import i18n from "!silly-i18n";
 import "./companyRevenueChart.css";
 
 const CompanyRevenueChart = ({ annualRevenues }) => {

--- a/features/polyExplorer/src/screens/entityDetails/entityDetails.jsx
+++ b/features/polyExplorer/src/screens/entityDetails/entityDetails.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import Screen from "../../components/screen/screen.jsx";
 import CompanyRevenueChart from "./companyRevenueChart/companyRevenueChart.jsx";
 import DataRegionsLegend from "../../components/dataRegionsLegend/dataRegionsLegend.jsx";

--- a/features/polyExplorer/src/screens/entityFilter/entityFilter.jsx
+++ b/features/polyExplorer/src/screens/entityFilter/entityFilter.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import { EntityFilter } from "../../model/entityFilter.js";
 import Scrollable from "../../components/scrollable/scrollable.jsx";
 import Screen from "../../components/screen/screen.jsx";

--- a/features/polyExplorer/src/screens/entitySearch/entitySearch.jsx
+++ b/features/polyExplorer/src/screens/entitySearch/entitySearch.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useContext } from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import Screen from "../../components/screen/screen.jsx";
 import LinkButton from "../../components/buttons/linkButton/linkButton.jsx";
 

--- a/features/polyExplorer/src/screens/main/main.jsx
+++ b/features/polyExplorer/src/screens/main/main.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import Screen from "../../components/screen/screen.jsx";
 import FilteredEntityList from "../../components/filteredEntityList/filteredEntityList.jsx";
 import StoriesPreview from "../../components/storiesPreview/storiesPreview.jsx";

--- a/features/polyExplorer/src/screens/stories/digitalGiantsStory.jsx
+++ b/features/polyExplorer/src/screens/stories/digitalGiantsStory.jsx
@@ -3,7 +3,7 @@ import React, { useContext } from "react";
 import ClusterStory from "../../components/clusterStory/clusterStory.jsx";
 import GradientCircleList from "../../components/gradientCircleList/gradientCircleList.jsx";
 import { ExplorerContext } from "../../context/explorer-context.jsx";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import SectionTitle from "../../components/clusterStories/sectionTitle.jsx";
 import DataTypes from "../../components/clusterStories/dataTypes.jsx";
 import Purposes from "../../components/clusterStories/purposes.jsx";

--- a/features/polyExplorer/src/screens/stories/messengerStory.jsx
+++ b/features/polyExplorer/src/screens/stories/messengerStory.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 
 import ClusterStory from "../../components/clusterStory/clusterStory.jsx";
 import { ExplorerContext } from "../../context/explorer-context.jsx";
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 import SectionTitle from "../../components/clusterStories/sectionTitle.jsx";
 import DataTypes from "../../components/clusterStories/dataTypes.jsx";
 import Purposes from "../../components/clusterStories/purposes.jsx";

--- a/features/polyExplorer/src/screens/stories/story-utils.js
+++ b/features/polyExplorer/src/screens/stories/story-utils.js
@@ -1,4 +1,4 @@
-import i18n from "../../i18n.js";
+import i18n from "!silly-i18n";
 
 export function countOccurences(array) {
     const occurences = {};

--- a/features/polyPreview/src/i18n.js
+++ b/features/polyPreview/src/i18n.js
@@ -1,2 +1,0 @@
-// TODO: Remove this module, and import "!silly-i18n" directly.
-export { default } from "!silly-i18n";

--- a/features/polyPreview/src/index.js
+++ b/features/polyPreview/src/index.js
@@ -1,5 +1,5 @@
 import SwiperCore from "swiper/core";
-import i18n from "./i18n.js";
+import i18n from "!silly-i18n";
 
 import "swiper/css";
 import "./styles.css";


### PR DESCRIPTION
The changes in here were generated with following command line:

    git grep i18n | grep import | cut -d: -f1 | sort -u | python3 -c $'import sys, re\nfor f in sys.stdin.read().splitlines():\n  s=open(f).read();open(f, "w").write(re.sub(r"(import .*? from )\\".*?/i18n(?:.js)?\\"", "\\\\1\\"!silly-i18n\\"", s))'