### PR TITLE
Fix missing export warnings when building podjs

### DIFF
--- a/platform/podjs/rollup.config.js
+++ b/platform/podjs/rollup.config.js
@@ -19,6 +19,7 @@ export default [
         plugins: [
             json(),
             resolve(),
+            commonjs(),
             sucrase({
                 exclude: ["node_modules/**"],
                 transforms: ["typescript"],


### PR DESCRIPTION
In #810, I introduced the `rdf-string` package. Since then when building *pod.js*, Rollup emits various `[...] is not exported by node_modules/rdf-string/index.js` warnings. Apparently, `rdf-string` is the only package bundled that is distributed as CommonJS, and we never configured the `commonjs` plugin for the `index.js` build target.