### PR TITLE
Make "en" explicit fallback language

### DIFF
--- a/feature-utils/silly-i18n/rollup-plugin.cjs
+++ b/feature-utils/silly-i18n/rollup-plugin.cjs
@@ -47,10 +47,12 @@ exports.default = function (options) {
                     ? ["", JSON.stringify(language)]
                     : [", determineLanguage", "determineLanguage()"];
                 const translationsArg = JSON.stringify(translations);
+                const fallbackLanguage = options?.fallbackLanguage || "en";
+                const fallbackLanguageArg = JSON.stringify(fallbackLanguage);
 
                 return (
                     `import { I18n${importExtra} } from "@polypoly-eu/silly-i18n"\n` +
-                    `export default new I18n(${languageArg}, ${translationsArg});`
+                    `export default new I18n(${languageArg}, ${translationsArg}, ${fallbackLanguageArg});`
                 );
             }
         },


### PR DESCRIPTION
By default the  `I18n` class selects the first language in the provided translations as fallback language (i.e. the language used instead if there are no translations for the requested language). Before #860, the translations for `en` always came first in the manually maintained boilerplate. But now where the code initializing the `I18n` class is generated, the languages occur in alphabetic order which makes `de` the implicit fallback language.