### PR TITLE
Safeguard bundle resources for iOS/Android

### DIFF
--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -178,19 +178,24 @@ dependencies {
 }
 
 task copyRemotePod(type: Copy) {
-    assert file("../../feature-api/communication/dist/bootstrap.js").exists()
-    from "../../feature-api/communication/dist/bootstrap.js"
+    def path = "../../feature-api/communication/dist/bootstrap.js"
+    assert file(path).exists()
+    from path
     rename "bootstrap.js", "pod.js"
     into "build/generated-assets/container/"
 }
 
 task copyBundledFeatures(type: Copy) {
-    from "../../../features/bundle/dist"
+    def path = "../../../features/bundle/dist"
+    assert file(path).exists()
+    from path
     into "build/generated-assets/features"
 }
 
 task copyThirdPartyLicenses(type: Copy) {
-    from "../../../3rd-party-licenses"
+    def path = "../../../3rd-party-licenses"
+    assert file(path).exists()
+    from path
     into "build/generated-assets/3rd-party-licenses"
 }
 
@@ -208,7 +213,9 @@ task installAppOnDevice {
 }
 
 task copyEndpoints(type: Copy) {
-    from "../../../../polyPod-config"
+    def path = "../../../../polyPod-config"
+    assert file(path).exists()
+    from path
     into "build/generated-assets/config-assets"
 }
 

--- a/platform/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
+++ b/platform/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
@@ -775,7 +775,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "ENDPOINTS_SOURCE=\"$PROJECT_DIR/../../../../polyPod-config\"\nENDPOINTS_TARGET=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/config\"\nrm -rf \"$ENDPOINTS_TARGET\"\ncp -r \"$ENDPOINTS_SOURCE\" \"$ENDPOINTS_TARGET\"\n";
+			shellScript = "set -e\nENDPOINTS_SOURCE=\"$PROJECT_DIR/../../../polyPod-config\"\nENDPOINTS_TARGET=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/config\"\nrm -rf \"$ENDPOINTS_TARGET\"\ncp -r \"$ENDPOINTS_SOURCE\" \"$ENDPOINTS_TARGET\"\n";
 		};
 		E923739E2628228F00D2CFF3 /* Copy polyPod Features */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -811,7 +811,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "LICENSES_SOURCE=\"$PROJECT_DIR/../../../3rd-party-licenses\"\nLICENSES_TARGET=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/3rd-party-licenses\"\nLEGAL_SOURCE=\"$PROJECT_DIR/../../../assets/legal\"\nLEGAL_TARGET=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/legal\"\nrm -rf \"$LICENSES_TARGET\" \"$LEGAL_TARGET\"\ncp -r \"$LICENSES_SOURCE\" \"$LICENSES_TARGET\"\ncp -r \"$LEGAL_SOURCE\" \"$LEGAL_TARGET\"\n";
+			shellScript = "set -e\nLICENSES_SOURCE=\"$PROJECT_DIR/../../3rd-party-licenses\"\nLICENSES_TARGET=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/3rd-party-licenses\"\nLEGAL_SOURCE=\"$PROJECT_DIR/../../assets/legal\"\nLEGAL_TARGET=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/legal\"\nrm -rf \"$LICENSES_TARGET\" \"$LEGAL_TARGET\"\ncp -r \"$LICENSES_SOURCE\" \"$LICENSES_TARGET\"\ncp -r \"$LEGAL_SOURCE\" \"$LEGAL_TARGET\"\n";
 		};
 		E9CF1B7D2627365600216B70 /* Update Bundle Version */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/platform/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
+++ b/platform/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
@@ -775,7 +775,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nENDPOINTS_SOURCE=\"$PROJECT_DIR/../../../polyPod-config\"\nENDPOINTS_TARGET=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/config\"\nrm -rf \"$ENDPOINTS_TARGET\"\ncp -r \"$ENDPOINTS_SOURCE\" \"$ENDPOINTS_TARGET\"\n";
+			shellScript = "set -e\nENDPOINTS_SOURCE=\"$PROJECT_DIR/../../../../polyPod-config\"\nENDPOINTS_TARGET=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/config\"\nrm -rf \"$ENDPOINTS_TARGET\"\ncp -r \"$ENDPOINTS_SOURCE\" \"$ENDPOINTS_TARGET\"\n";
 		};
 		E923739E2628228F00D2CFF3 /* Copy polyPod Features */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -811,7 +811,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nLICENSES_SOURCE=\"$PROJECT_DIR/../../3rd-party-licenses\"\nLICENSES_TARGET=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/3rd-party-licenses\"\nLEGAL_SOURCE=\"$PROJECT_DIR/../../assets/legal\"\nLEGAL_TARGET=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/legal\"\nrm -rf \"$LICENSES_TARGET\" \"$LEGAL_TARGET\"\ncp -r \"$LICENSES_SOURCE\" \"$LICENSES_TARGET\"\ncp -r \"$LEGAL_SOURCE\" \"$LEGAL_TARGET\"\n";
+			shellScript = "set -e\nLICENSES_SOURCE=\"$PROJECT_DIR/../../../3rd-party-licenses\"\nLICENSES_TARGET=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/3rd-party-licenses\"\nLEGAL_SOURCE=\"$PROJECT_DIR/../../../assets/legal\"\nLEGAL_TARGET=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/legal\"\nrm -rf \"$LICENSES_TARGET\" \"$LEGAL_TARGET\"\ncp -r \"$LICENSES_SOURCE\" \"$LICENSES_TARGET\"\ncp -r \"$LEGAL_SOURCE\" \"$LEGAL_TARGET\"\n";
 		};
 		E9CF1B7D2627365600216B70 /* Update Bundle Version */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
We already did encounter scenarios when updating some file paths, or some scripts did fail to generate the bundle resources, the Android and iOS builds where successful, only for us to find the issues after the app was published to testing.

Instead of having a silent fail and producing a successful build, now the build will fail if resources are missing, acting as a sort of integration test.