### PR TITLE
Convert feature-utils/silly-i18n/rollup-plugin.cjs to ESM

### DIFF
--- a/feature-utils/silly-i18n/rollup-plugin.js
+++ b/feature-utils/silly-i18n/rollup-plugin.js
@@ -1,14 +1,14 @@
-const fs = require("fs");
-const path = require("path");
-const util = require("util");
-const glob = require("glob");
+import fs from "fs";
+import path from "path";
+import util from "util";
+import glob from "glob";
 
 const DIRNAME = "locales";
 const FILEEXT = ".json";
 const PLUGIN = "silly-i18n";
 const SUFFIX = `?${PLUGIN}`;
 
-exports.default = function (options) {
+export default function (options) {
     return {
         name: PLUGIN,
 
@@ -57,4 +57,4 @@ exports.default = function (options) {
             }
         },
     };
-};
+}

--- a/features/facebookImport/rollup.config.mjs
+++ b/features/facebookImport/rollup.config.mjs
@@ -7,7 +7,7 @@ import replace from "@rollup/plugin-replace";
 import serve from "rollup-plugin-serve";
 import svg from "rollup-plugin-svg";
 import genPodjs from "@polypoly-eu/podjs/rollup-plugin-gen-podjs/genPodjs.js";
-import sillyI18n from "@polypoly-eu/silly-i18n/rollup-plugin.cjs";
+import sillyI18n from "@polypoly-eu/silly-i18n/rollup-plugin.js";
 
 const fallbackURL = "http://localhost:8000";
 const fallbackAuthorization = "username:password";

--- a/features/google/rollup.config.mjs
+++ b/features/google/rollup.config.mjs
@@ -7,7 +7,7 @@ import serve from "rollup-plugin-serve";
 import svg from "rollup-plugin-svg";
 import replace from "@rollup/plugin-replace";
 import genPodjs from "@polypoly-eu/podjs/rollup-plugin-gen-podjs/genPodjs.js";
-import sillyI18n from "@polypoly-eu/silly-i18n/rollup-plugin.cjs";
+import sillyI18n from "@polypoly-eu/silly-i18n/rollup-plugin.js";
 
 const externalPackages = {
     "@polypoly-eu/poly-look": "polyLook",

--- a/features/lexicon/rollup.config.mjs
+++ b/features/lexicon/rollup.config.mjs
@@ -7,7 +7,7 @@ import json from "@rollup/plugin-json";
 import sucrase from "@rollup/plugin-sucrase";
 import copy from "@polypoly-eu/rollup-plugin-copy-watch";
 import genPodjs from "@polypoly-eu/podjs/rollup-plugin-gen-podjs/genPodjs.js";
-import sillyI18n from "@polypoly-eu/silly-i18n/rollup-plugin.cjs";
+import sillyI18n from "@polypoly-eu/silly-i18n/rollup-plugin.js";
 
 const production = !process.env.ROLLUP_WATCH;
 

--- a/features/polyExplorer/rollup.config.mjs
+++ b/features/polyExplorer/rollup.config.mjs
@@ -7,7 +7,7 @@ import svg from "rollup-plugin-svg";
 import replace from "@rollup/plugin-replace";
 import commonjs from "@rollup/plugin-commonjs";
 import genPodjs from "@polypoly-eu/podjs/rollup-plugin-gen-podjs/genPodjs.js";
-import sillyI18n from "@polypoly-eu/silly-i18n/rollup-plugin.cjs";
+import sillyI18n from "@polypoly-eu/silly-i18n/rollup-plugin.js";
 
 export default {
     input: "src/index.jsx",

--- a/features/polyPreview/rollup.config.mjs
+++ b/features/polyPreview/rollup.config.mjs
@@ -3,7 +3,7 @@ import css from "rollup-plugin-css-only";
 import resolve from "@rollup/plugin-node-resolve";
 import sucrase from "@rollup/plugin-sucrase";
 import genPodjs from "@polypoly-eu/podjs/rollup-plugin-gen-podjs/genPodjs.js";
-import sillyI18n from "@polypoly-eu/silly-i18n/rollup-plugin.cjs";
+import sillyI18n from "@polypoly-eu/silly-i18n/rollup-plugin.js";
 
 export default {
     input: "src/index.js",

--- a/platform/podjs/rollup-plugin-gen-podjs/genPodjs.js
+++ b/platform/podjs/rollup-plugin-gen-podjs/genPodjs.js
@@ -1,5 +1,5 @@
-const fs = require("fs");
-const path = require("path");
+import fs from "fs";
+import path from "path";
 
 function executeReplacement(podJs, manifestJsonPath) {
     try {
@@ -41,4 +41,4 @@ function loadManifest(options = {}) {
     executeReplacement(podJsPath, options.manifestPath);
 }
 
-module.exports = loadManifest;
+export default loadManifest;

--- a/platform/podjs/rollup-plugin-gen-podjs/genPodjs.js
+++ b/platform/podjs/rollup-plugin-gen-podjs/genPodjs.js
@@ -41,4 +41,4 @@ function loadManifest(options = {}) {
     executeReplacement(podJsPath, options.manifestPath);
 }
 
-exports.default = loadManifest;
+module.exports = loadManifest;

--- a/platform/podjs/rollup-plugin-gen-podjs/package.json
+++ b/platform/podjs/rollup-plugin-gen-podjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
When I introduced `@polypoly-eu/silly-i18n/rollup-plugin.cjs` in #860 I made it a CommonJS module to keep the changes in that PR as minimal as possible. In order to use a Rollup plugin in ESM format that is referenced as a package you have to prevent Rollup from transpiling the configuration script (by using the `.mjs` file extension). That's because the configuration script  is transpiled to CommonJS and therefore cannot import external ESM modules.