### PR TITLE
Delete «main» key in package.json where it takes the default value.

### DIFF
--- a/dev-utils/rollup-plugin-copy-watch/package.json
+++ b/dev-utils/rollup-plugin-copy-watch/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@polypoly-eu/rollup-plugin-copy-watch",
-  "main": "index.js",
   "private": true,
   "dependencies": {
     "rollup-plugin-copy": "^3.4.0"

--- a/platform/utils/endpoints-generator/package.json
+++ b/platform/utils/endpoints-generator/package.json
@@ -1,6 +1,5 @@
 {
   "name": "endpoints-generator",
-  "main": "index.js",
   "scripts": {
     "build": "node index.js"
   },


### PR DESCRIPTION
Which is `index.js`

> The rest are probably OK, although in some cases it points to the source (`src` directory) and in others to the `dist` bundled directory. In the case of `pod.js` it's probably wrong, as well as probably not needed anyway (since it's mainly copied, not included as a module); in the rest, it's probably OK, although the fact that it uses generated code needs to be accounted for.