### PR TITLE
Do not crash the app if core is already bootstrappped

### DIFF
--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -5,9 +5,11 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import coop.polypoly.core.Core
+import coop.polypoly.core.CoreAlreadyBootstrappedException
 import coop.polypoly.polypod.core.UpdateNotification
 import coop.polypoly.polypod.features.FeatureStorage
 import coop.polypoly.polypod.logging.LoggerFactory
+import java.lang.Exception
 
 class MainActivity : AppCompatActivity() {
     companion object {
@@ -23,8 +25,13 @@ class MainActivity : AppCompatActivity() {
         val language = Language.determine(this@MainActivity)
         try {
             Core.bootstrapCore(language)
-            logger.info("Core is bootstraped!")
+            logger.info("Core is bootstrapped!")
         } catch (ex: Exception) {
+            if (ex is CoreAlreadyBootstrappedException) {
+                logger.info(ex.message)
+                return
+            }
+
             logger.error(
                 "Failed to boostrap core",
                 ex.message

--- a/platform/core/PolyPodCoreAndroid/core/src/main/java/coop/polypoly/core/Core.kt
+++ b/platform/core/PolyPodCoreAndroid/core/src/main/java/coop/polypoly/core/Core.kt
@@ -13,6 +13,9 @@ class Core {
                 ByteBuffer.wrap(bytes)
             )
             response.failure?.let {
+                if (it.code == FailureCode.CoreAlreadyBootstrapped) {
+                    throw CoreAlreadyBootstrappedException()
+                }
                 throw InternalCoreException.make("Core bootstrap", it)
             }
         }

--- a/platform/core/PolyPodCoreAndroid/core/src/main/java/coop/polypoly/core/CoreExceptions.kt
+++ b/platform/core/PolyPodCoreAndroid/core/src/main/java/coop/polypoly/core/CoreExceptions.kt
@@ -14,6 +14,9 @@ class InternalCoreException(message: String) : Exception(message) {
     }
 }
 
+class CoreAlreadyBootstrappedException() :
+    Exception("Core is already bootstrapped.")
+
 class InvalidResultException(message: String) : Exception(message) {
     companion object {
         fun make(context: String, result: String): InvalidResultException {

--- a/platform/core/PolyPodCoreAndroid/core/src/main/java/coop/polypoly/core/CoreExceptions.kt
+++ b/platform/core/PolyPodCoreAndroid/core/src/main/java/coop/polypoly/core/CoreExceptions.kt
@@ -15,7 +15,7 @@ class InternalCoreException(message: String) : Exception(message) {
 }
 
 class CoreAlreadyBootstrappedException() :
-    Exception("Core is already bootstrapped.")
+    Exception("Core is already bootstrapped")
 
 class InvalidResultException(message: String) : Exception(message) {
     companion object {

--- a/platform/core/flatbuffers_shared/flatbuffer_models/failure.fbs
+++ b/platform/core/flatbuffers_shared/flatbuffer_models/failure.fbs
@@ -1,6 +1,6 @@
 enum FailureCode: byte {
-    FailedToBootstrapCore = 1,
-    CoreNotBootstraped,
+    CoreNotBootstrapped = 1,
+    CoreAlreadyBootstrapped,
     FailedToParseFeatureManifest,
     NullCStringPointer,
     FailedToCreateCString,
@@ -10,7 +10,7 @@ enum FailureCode: byte {
 
 table Failure {
     // Flatbuffers require to have a default value for enums
-    code:FailureCode = FailedToBootstrapCore;
+    code:FailureCode = CoreNotBootstrapped;
     message:string (required);
 }
 

--- a/platform/core/src/core.rs
+++ b/platform/core/src/core.rs
@@ -16,13 +16,13 @@ struct Core {
 fn get_instance() -> Result<&'static Core, CoreFailure> {
     match CORE.get() {
         Some(core) => Ok(core),
-        None => Err(CoreFailure::core_not_bootstraped()),
+        None => Err(CoreFailure::core_not_bootstrapped()),
     }
 }
 
 pub fn bootstrap(language_code: String) -> Result<(), CoreFailure> {
     if CORE.get().is_some() {
-        return Err(CoreFailure::core_bootstrap_failed());
+        return Err(CoreFailure::core_already_bootstrapped());
     }
 
     let core = Core { language_code };

--- a/platform/core/src/core_failure.rs
+++ b/platform/core/src/core_failure.rs
@@ -7,16 +7,16 @@ pub struct CoreFailure {
 }
 
 impl CoreFailure {
-    pub fn core_bootstrap_failed() -> Self {
+    pub fn core_already_bootstrapped() -> Self {
         CoreFailure {
-            code: FailureCode::FailedToBootstrapCore,
+            code: FailureCode::CoreAlreadyBootstrapped,
             message: "Core was already initialized".to_string(),
         }
     }
 
-    pub fn core_not_bootstraped() -> Self {
+    pub fn core_not_bootstrapped() -> Self {
         CoreFailure {
-            code: FailureCode::CoreNotBootstraped,
+            code: FailureCode::CoreNotBootstrapped,
             message: "Core was not initialized".to_string(),
         }
     }

--- a/platform/core/src/flatbuffers_mapping/core_bootstrap_fbs_mapping.rs
+++ b/platform/core/src/flatbuffers_mapping/core_bootstrap_fbs_mapping.rs
@@ -46,7 +46,7 @@ mod tests {
 
     #[test]
     fn test_build_failure() {
-        let expected_failure = CoreFailure::core_bootstrap_failed();
+        let expected_failure = CoreFailure::core_already_bootstrapped();
         let byte_response = build_core_bootstrap_response(Err(expected_failure.clone()));
 
         let parsed = root_as_core_bootstrap_response(&byte_response);

--- a/platform/ios/PolyPodApp/PolyPod/AppDelegate.swift
+++ b/platform/ios/PolyPodApp/PolyPod/AppDelegate.swift
@@ -16,8 +16,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         case .success:
             Log.info("Core bootstraped!")
         case let .failure(content):
-            assertionFailure(content.localizedDescription)
             Log.error(content.localizedDescription)
+            switch content as? PolyPodCoreError {
+            case .internalCoreFailure(_, let failure)
+                where failure.code == .corealreadybootstrapped:
+                // Ignore already bootstrapped error, this code path might be
+                // called multiple times during testing
+                break
+            default:
+                fatalError(content.localizedDescription)
+            }
         }
         
         let defaults = UserDefaults.standard


### PR DESCRIPTION
Instrumentation tests might restart the app without clearing its memory several times, thus ignore the error thrown by core when it is already bootstrapped, which is in no way a breaking failure.