### PR TITLE
Avoid 🧹 downloaded tools

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -35,6 +35,7 @@ module.exports = {
         ".eslintrc.*",
         "**/build/*",
         "PolyPodApp/",
+        "platform/core/tools",
     ],
     rules: {
         semi: 2,


### PR DESCRIPTION
This just generates noise during local linting.