### PR TITLE
[🔥] Eliminating video generation in this E2E test

### DIFF
--- a/features/example/cypress.json
+++ b/features/example/cypress.json
@@ -1,3 +1,4 @@
 {
-  "pluginsFile": false
+  "pluginsFile": false,
+  "video": false
 }


### PR DESCRIPTION
This is not really used, even less so in CI. I think it was simply not disabled since we were starting to use cypress.