### PR TITLE
Fix ios bug

### DIFF
--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/polyOut/PolyOut.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/polyOut/PolyOut.kt
@@ -116,7 +116,9 @@ open class PolyOut(
     open suspend fun readDir(
         id: String
     ): Array<Map<String, String>> {
+        System.out.println("hello")
         val fs = Preferences.getFileSystem(context)
+        System.out.println("Why would you think it broke here")
         if (id == "") {
             val newFs = fs.filter {
                 File(idToPath(it.key, context)).exists()

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/polyOut/PolyOut.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/polyOut/PolyOut.kt
@@ -116,9 +116,7 @@ open class PolyOut(
     open suspend fun readDir(
         id: String
     ): Array<Map<String, String>> {
-        System.out.println("hello")
         val fs = Preferences.getFileSystem(context)
-        System.out.println("Why would you think it broke here")
         if (id == "") {
             val newFs = fs.filter {
                 File(idToPath(it.key, context)).exists()

--- a/platform/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
+++ b/platform/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
@@ -92,7 +92,7 @@ extension PolyOut {
                     size: try calculateFileSize(filePath.path),
                     time: "\(Int(floor(time.timeIntervalSince1970)))",
                     name: name ?? URL(fileURLWithPath: filePath.path).lastPathComponent,
-                    id: idFromPodUrl(url) ?? ""
+                    id: url
                 ), nil)
             }
             catch {
@@ -178,6 +178,7 @@ extension PolyOut {
             }
             return FileManager.default.fileExists(atPath: path)
         }
+        print(storedFiles)
         let idPrefix = "\(PolyOut.fsPrefix)\(PolyOut.fsFilesRoot)/"
         let entries = storedFiles.map {[
             "id": $0,

--- a/platform/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
+++ b/platform/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
@@ -178,7 +178,6 @@ extension PolyOut {
             }
             return FileManager.default.fileExists(atPath: path)
         }
-        print(storedFiles)
         let idPrefix = "\(PolyOut.fsPrefix)\(PolyOut.fsFilesRoot)/"
         let entries = storedFiles.map {[
             "id": $0,


### PR DESCRIPTION
The problem was that readDir and stat have used a different definition of "id". One with prefix and one without

We have path, url and id and they seem to get mixed up