### PR TITLE
[⚰] {PROD4POD-632} fetch-spec redux

### DIFF
--- a/platform/feature-api/api/pod-api/package-lock.json
+++ b/platform/feature-api/api/pod-api/package-lock.json
@@ -50,14 +50,6 @@
       "version": "0.0.1",
       "extraneous": true
     },
-    "../fetch-spec": {
-      "name": "@polypoly-eu/fetch-spec",
-      "version": "0.0.1",
-      "extraneous": true,
-      "devDependencies": {
-        "ts-node": "^9.1.1"
-      }
-    },
     "../rdf": {
       "name": "@polypoly-eu/rdf",
       "version": "0.2.0",

--- a/platform/podjs/package-lock.json
+++ b/platform/podjs/package-lock.json
@@ -42,14 +42,6 @@
         "supertest": "^6.2.2"
       }
     },
-    "../feature-api/api/fetch-spec": {
-      "name": "@polypoly-eu/fetch-spec",
-      "version": "0.0.1",
-      "extraneous": true,
-      "devDependencies": {
-        "ts-node": "^9.1.1"
-      }
-    },
     "../feature-api/api/pod-api": {
       "name": "@polypoly-eu/pod-api",
       "version": "0.8.0",


### PR DESCRIPTION
Although all code has been removed, and uninstalled from dependencies, there's an error in `npm uninstall` that leaves packages in the package-lock.json, unremovable if it's not by hand. There are still remains of this in all features, however, these lockfiles change more frequently and they will probably be eliminated next time they're updated. That does not happen with these (although one of them is going to be eliminated when #794 lands) so that limits the scope of this PR.