### PR TITLE
Minor improvements in the build of android bindings

### DIFF
--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -74,6 +74,7 @@ jobs:
                   distribution: 'temurin'
                   cache: 'gradle'
             - name: Build core with Android bindings
+              if: steps.changes.outputs.android == 'true'
               working-directory: platform/core
               run: make android_bindings
             - name: Test android

--- a/platform/core/Makefile
+++ b/platform/core/Makefile
@@ -90,7 +90,7 @@ $(rust_flatbuffers_dir)/%.rs: $(flatbuffer_models_dir)/%.fbs
 	./$(flatc) --rust -o $(rust_flatbuffers_dir) --filename-suffix "" --include-prefix flatbuffers_generated $^
 
 $(rust_flatbuffers_generated_lib): $(rust_flatbuffer_models)
-	$(os_echo) $(foreach model, $^, \
+	@$(os_echo) $(foreach model, $^, \
 		"pub mod $(basename $(notdir $(model))); \n") > $(rust_flatbuffers_generated_lib)
 
 $(target): $(flatc) $(flatbuffers) $(rust_flatbuffers_generated_lib)

--- a/platform/core/Makefile
+++ b/platform/core/Makefile
@@ -152,7 +152,7 @@ endef
 $(ndk):
 	mkdir -p $(ndk)
 	curl -L $(ndk_download_url) -o $(ndk_archive)
-	unzip -d $(ndk) $(ndk_archive)
+	unzip -q -d $(ndk) $(ndk_archive)
 	rm $(ndk_archive)
 
 $(android_flatbuffers_lib): $(flatbuffers)

--- a/platform/core/Makefile
+++ b/platform/core/Makefile
@@ -165,9 +165,9 @@ $(kotlin_flatbuffer_models_dir)/%.kt: $(flatbuffer_models_dir)/%.fbs
 $(android_binaries): $(target) $(ndk) $(kotlin_flatbuffer_models) $(android_flatbuffers_lib)
 	cargo install cargo-ndk
 	rustup target add $(android_triples)
-	
-	$(foreach tripple, $(android_triples), \
-		cargo ndk --platform $(android_version) --target $(tripple) build $(cargo_build_flag); \
+
+	$(foreach triple, $(android_triples), \
+		cargo ndk --platform $(android_version) --target $(triple) build $(cargo_build_flag); \
 	)
 
 $(android_core_libraries): $(android_binaries)


### PR DESCRIPTION
This step takes 4 minutes, and it compiles a ton of things. It would be nice to cache, but I'll need to find out what can be fruitfully cached and what not (for instance, caching a zipped download will probably take longer than just downloading it). At any rate, the biggest improvement here is that Android bindings will only be compiled if there's some change in the Android directories; up to now it was always being compiled, no matter what. The rest of the changes are in the commit messages, mainly reducing verbiage and fixing a typo.