### PR TITLE
[⬆] Upgrade CodeQL actions to v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         queries: security-extended
         languages: ${{ matrix.language }}
@@ -62,4 +62,4 @@ jobs:
         ./gradlew compileDebugJavaWithJavac
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
v1 is being deprecated according to https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/