### PR TITLE
Fix wrong path id

### DIFF
--- a/platform/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
+++ b/platform/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
@@ -234,13 +234,17 @@ extension PolyOut {
     
     func removeArchive(fileId: String, completionHandler: (Error?) -> Void) {
         do {
-            let path = fsUriFromId(idFromPodUrl(fileId)!).path
+            guard let id = idFromPodUrl(fileId) else {
+                throw PolyOutError.failedToParsePath(fileId)
+            }
+            let path = fsUriFromId(id).path
             if FileManager.default.fileExists(atPath: path) {
                 try FileManager.default.removeItem(atPath: path)
             }
-            throw PolyOutError.failedToParsePath(fileId)
         }
-        catch {completionHandler(PolyOutError.failedToParsePath(fileId))}
+        catch {
+            completionHandler(error)
+        }
         var fileStore = UserDefaults.standard.value(
             forKey: PolyOut.fsKey
         ) as? [String:[String]] ?? [:]

--- a/platform/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
+++ b/platform/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
@@ -234,12 +234,13 @@ extension PolyOut {
     
     func removeArchive(fileId: String, completionHandler: (Error?) -> Void) {
         do {
-            let path = fsUriFromId(fileId).path
+            let path = fsUriFromId(idFromPodUrl(fileId)!).path
             if FileManager.default.fileExists(atPath: path) {
                 try FileManager.default.removeItem(atPath: path)
             }
+            throw PolyOutError.failedToParsePath(fileId)
         }
-        catch {}
+        catch {completionHandler(PolyOutError.failedToParsePath(fileId))}
         var fileStore = UserDefaults.standard.value(
             forKey: PolyOut.fsKey
         ) as? [String:[String]] ?? [:]


### PR DESCRIPTION
Again a quick fix for removeArchive not working (us not being able to remove files) in ios due to ids. 

It would be lovely if someone could get onto https://jira.polypoly.eu/browse/PROD4POD-1613.