### PR TITLE
Fix Core bytes memory management

### DIFF
--- a/platform/core/PolyPodCoreSwift/Sources/PolyPodCoreSwift/Core.swift
+++ b/platform/core/PolyPodCoreSwift/Sources/PolyPodCoreSwift/Core.swift
@@ -5,7 +5,7 @@ import FlatBuffers
 /// Possible errors that can be thrown by PolyPodCoreSwift
 public enum PolyPodCoreError: Error {
     /// Internal Rust Core failure with error code and message
-    case internalCoreFailure(context: String, failure: Failure)
+    case internalCoreFailure(context: String, failure: FBObject<Failure>)
     /// Rust Core returned an invalid result type for a given operation
     case invalidResult(context: String, result:String)
     /// Rust Core returned an invalid failure content
@@ -43,7 +43,8 @@ public final class Core {
         return processCoreResponse(core_bootstrap(languageCode)) { byteBuffer in
             let response = CoreBootstrapResponse.getRootAsCoreBootstrapResponse(bb: byteBuffer)
             if let failure = response.failure {
-                throw PolyPodCoreError.internalCoreFailure(context: "Failed to bootstrap core", failure: failure)
+                throw PolyPodCoreError.internalCoreFailure(context: "Failed to bootstrap core",
+                                                           failure: FBObject(byteBuffer, failure))
             }
         }
     }
@@ -51,17 +52,17 @@ public final class Core {
     /// Parse the FeatureManifest from the given json
     /// - Parameter json: Raw JSON to parse the FeatureManifest from
     /// - Returns: A FeatureManifest if parsing succeded, nil otherwise
-    public func parseFeatureManifest(json: String) -> Result<FeatureManifest, Error> {
+    public func parseFeatureManifest(json: String) -> Result<FBObject<FeatureManifest>, Error> {
         processCoreResponse(parse_feature_manifest_from_json(json)) { byteBuffer in
             let response = FeatureManifestParsingResponse.getRootAsFeatureManifestParsingResponse(bb: byteBuffer)
             switch response.resultType {
             case .featuremanifest:
-                return response.result(type: FeatureManifest.self)
+                return FBObject(byteBuffer, response.result(type: FeatureManifest.self))
             case .failure:
                 if let failure = response.result(type: Failure.self) {
                     throw PolyPodCoreError.internalCoreFailure(
                         context: "Failed to load Feature Manifest",
-                        failure: failure
+                        failure: FBObject(byteBuffer, failure)
                     )
                 } else {
                     throw PolyPodCoreError.invalidFailure(context: "Failed to load Feature Manifest")
@@ -79,12 +80,10 @@ public final class Core {
     
     private func processCoreResponse<T>(_ responseByteBuffer: CByteBuffer,
                                         flatbufferMapping: (ByteBuffer) throws -> T) -> Result<T, Error> {
-        defer {
-            free_bytes(responseByteBuffer.data)
-        }
         return Result {
             try flatbufferMapping(
-                ByteBuffer(assumingMemoryBound: responseByteBuffer.data, capacity: Int(responseByteBuffer.length))
+                ByteBuffer(assumingMemoryBound: responseByteBuffer.data,
+                           capacity: Int(responseByteBuffer.length))
             )
         }
     }

--- a/platform/core/PolyPodCoreSwift/Sources/PolyPodCoreSwift/Core.swift
+++ b/platform/core/PolyPodCoreSwift/Sources/PolyPodCoreSwift/Core.swift
@@ -5,7 +5,7 @@ import FlatBuffers
 /// Possible errors that can be thrown by PolyPodCoreSwift
 public enum PolyPodCoreError: Error {
     /// Internal Rust Core failure with error code and message
-    case internalCoreFailure(context: String, failure: FBObject<Failure>)
+    case internalCoreFailure(context: String, failure: FlatbObject<Failure>)
     /// Rust Core returned an invalid result type for a given operation
     case invalidResult(context: String, result:String)
     /// Rust Core returned an invalid failure content
@@ -45,7 +45,7 @@ public final class Core {
             let response = CoreBootstrapResponse.getRootAsCoreBootstrapResponse(bb: byteBuffer)
             if let failure = response.failure {
                 throw PolyPodCoreError.internalCoreFailure(context: "Failed to bootstrap core",
-                                                           failure: FBObject(responseBytes.data, failure))
+                                                           failure: FlatbObject(responseBytes.data, failure))
             }
         }
     }
@@ -53,19 +53,19 @@ public final class Core {
     /// Parse the FeatureManifest from the given json
     /// - Parameter json: Raw JSON to parse the FeatureManifest from
     /// - Returns: A FeatureManifest if parsing succeded, nil otherwise
-    public func parseFeatureManifest(json: String) -> Result<FBObject<FeatureManifest>, Error> {
+    public func parseFeatureManifest(json: String) -> Result<FlatbObject<FeatureManifest>, Error> {
         Result {
             let responseBytes = parse_feature_manifest_from_json(json)
             let byteBuffer = ByteBuffer(cByteBuffer: responseBytes)
             let response = FeatureManifestParsingResponse.getRootAsFeatureManifestParsingResponse(bb: byteBuffer)
             switch response.resultType {
             case .featuremanifest:
-                return FBObject(responseBytes.data, response.result(type: FeatureManifest.self))
+                return FlatbObject(responseBytes.data, response.result(type: FeatureManifest.self))
             case .failure:
                 if let failure = response.result(type: Failure.self) {
                     throw PolyPodCoreError.internalCoreFailure(
                         context: "Failed to load Feature Manifest",
-                        failure: FBObject(responseBytes.data, failure)
+                        failure: FlatbObject(responseBytes.data, failure)
                     )
                 } else {
                     throw PolyPodCoreError.invalidFailure(context: "Failed to load Feature Manifest")

--- a/platform/core/PolyPodCoreSwift/Sources/PolyPodCoreSwift/FBObject.swift
+++ b/platform/core/PolyPodCoreSwift/Sources/PolyPodCoreSwift/FBObject.swift
@@ -1,0 +1,36 @@
+import Foundation
+import PolyPodCore
+import FlatBuffers
+
+@dynamicMemberLookup
+/// A wrapper class used to manage the lifetime of the Flatbuffer memory.
+/// It will make sure to deallocate the memory once the model is no more used.
+public final class FBObject<FBModel> {
+    /// The bytes storage for the fbModel
+    private let rawPointer: UnsafeMutableRawPointer
+    /// The underlying flatbuffer model.
+    private let fbModel: FBModel
+    
+    init(rawPointer: UnsafeMutableRawPointer, fbModel: FBModel) {
+        self.rawPointer = rawPointer
+        self.fbModel = fbModel
+    }
+    
+    convenience init(_ byteByffer: ByteBuffer, _ fbModel: FBModel) {
+        self.init(rawPointer: byteByffer.memory, fbModel: fbModel)
+    }
+    
+    deinit {
+        free_bytes(rawPointer)
+    }
+    
+    public subscript<T>(dynamicMember keyPath: KeyPath<FBModel, T>) -> T {
+        fbModel[keyPath: keyPath]
+    }
+}
+
+extension FBObject where FBModel == FeatureManifest {
+    public func links(at index: Int32) -> Link? {
+        fbModel.links(at: index)
+    }
+}

--- a/platform/core/PolyPodCoreSwift/Sources/PolyPodCoreSwift/FBObject.swift
+++ b/platform/core/PolyPodCoreSwift/Sources/PolyPodCoreSwift/FBObject.swift
@@ -7,17 +7,13 @@ import FlatBuffers
 /// It will make sure to deallocate the memory once the model is no more used.
 public final class FBObject<FBModel> {
     /// The bytes storage for the fbModel
-    private let rawPointer: UnsafeMutableRawPointer
+    private let rawPointer: UnsafeMutablePointer<UInt8>
     /// The underlying flatbuffer model.
     private let fbModel: FBModel
     
-    init(rawPointer: UnsafeMutableRawPointer, fbModel: FBModel) {
+    init(_ rawPointer: UnsafeMutablePointer<UInt8>, _ fbModel: FBModel) {
         self.rawPointer = rawPointer
         self.fbModel = fbModel
-    }
-    
-    convenience init(_ byteByffer: ByteBuffer, _ fbModel: FBModel) {
-        self.init(rawPointer: byteByffer.memory, fbModel: fbModel)
     }
     
     deinit {

--- a/platform/core/PolyPodCoreSwift/Sources/PolyPodCoreSwift/FlatbObject.swift
+++ b/platform/core/PolyPodCoreSwift/Sources/PolyPodCoreSwift/FlatbObject.swift
@@ -5,7 +5,7 @@ import FlatBuffers
 @dynamicMemberLookup
 /// A wrapper class used to manage the lifetime of the Flatbuffer memory.
 /// It will make sure to deallocate the memory once the model is no more used.
-public final class FBObject<FBModel> {
+public final class FlatbObject<FBModel> {
     /// The bytes storage for the fbModel
     private let rawPointer: UnsafeMutablePointer<UInt8>
     /// The underlying flatbuffer model.
@@ -25,7 +25,7 @@ public final class FBObject<FBModel> {
     }
 }
 
-extension FBObject where FBModel == FeatureManifest {
+extension FlatbObject where FBModel == FeatureManifest {
     public func links(at index: Int32) -> Link? {
         fbModel.links(at: index)
     }

--- a/platform/ios/PolyPodApp/Features/Feature.swift
+++ b/platform/ios/PolyPodApp/Features/Feature.swift
@@ -48,7 +48,7 @@ class Feature {
         self.links = links ?? [:]
     }
     
-    convenience init(path: URL, manifest: FeatureManifest) {
+    convenience init(path: URL, manifest: FBObject<FeatureManifest>) {
         var links: [String: String] = [:]
         for idx in 0..<manifest.linksCount {
             if let link = manifest.links(at: idx) {
@@ -76,7 +76,7 @@ class Feature {
     }
 }
 
-private func readManifest(_ basePath: URL) -> FeatureManifest? {
+private func readManifest(_ basePath: URL) -> FBObject<FeatureManifest>? {
     let manifestPath = basePath.appendingPathComponent("manifest.json")
     do {
         let contents = try String(contentsOf: manifestPath)

--- a/platform/ios/PolyPodApp/Features/Feature.swift
+++ b/platform/ios/PolyPodApp/Features/Feature.swift
@@ -48,7 +48,7 @@ class Feature {
         self.links = links ?? [:]
     }
     
-    convenience init(path: URL, manifest: FBObject<FeatureManifest>) {
+    convenience init(path: URL, manifest: FlatbObject<FeatureManifest>) {
         var links: [String: String] = [:]
         for idx in 0..<manifest.linksCount {
             if let link = manifest.links(at: idx) {
@@ -76,7 +76,7 @@ class Feature {
     }
 }
 
-private func readManifest(_ basePath: URL) -> FBObject<FeatureManifest>? {
+private func readManifest(_ basePath: URL) -> FlatbObject<FeatureManifest>? {
     let manifestPath = basePath.appendingPathComponent("manifest.json")
     do {
         let contents = try String(contentsOf: manifestPath)


### PR DESCRIPTION
Instead of deallocating the bytes after  the root level flatbuffer is extracted, deallocate the bytes after the whole model is dropped. The main issues is that the FlatBuffer model does no own the bytes as per [docs](https://github.com/google/flatbuffers/blob/967df08b1dbddc62f867464c2e0d58d8027438ad/swift/Sources/FlatBuffers/ByteBuffer.swift#L170) 

What was done:

- Encapsulate the flatbuffer model and its backing bytes in `FBObject` class. When `FBObject` is deallocated the bytes will be freed.