### PR TITLE
Really fix the default installation mode

### DIFF
--- a/build/npm.js
+++ b/build/npm.js
@@ -42,7 +42,7 @@ const npx = async (...args) => {
     await executeProcess("npx", ...args);
 };
 
-async function npmInstall(name, offline = true) {
+async function npmInstall(name, offline = false) {
     let args = ["--no-audit"];
     if (offline) {
         args.push("--prefer-offline");

--- a/feature-utils/poly-look/package-lock.json
+++ b/feature-utils/poly-look/package-lock.json
@@ -2592,9 +2592,10 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "5.16.2",
+      "version": "5.16.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.4.tgz",
+      "integrity": "sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.9.2",
         "@types/testing-library__jest-dom": "^5.9.1",
@@ -9132,7 +9133,9 @@
       }
     },
     "@testing-library/jest-dom": {
-      "version": "5.16.2",
+      "version": "5.16.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.4.tgz",
+      "integrity": "sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",


### PR DESCRIPTION
I was getting errors when building in the new laptop, and it was our old friend the prefer-offline installation. So first I upgraded pretty-format to basically have a single version of it in package-lock, and eventually fixed the whole thing to a state where it should have been some time ago