### PR TITLE
[🐛] Check origin to get rid of warning

### DIFF
--- a/platform/android/app/src/main/assets/container/container.js
+++ b/platform/android/app/src/main/assets/container/container.js
@@ -15,6 +15,10 @@ const queuedMessages = [];
 
 function initMessaging() {
     window.onmessage = (event) => {
+
+        if (!event.origin.includes("localhost")) {
+            return;
+        }
         // Action notifications have no port
         if (event.ports.length == 0) {
             let iFrame = document.getElementsByTagName("iframe")[0];

--- a/platform/android/app/src/main/assets/container/container.js
+++ b/platform/android/app/src/main/assets/container/container.js
@@ -15,7 +15,6 @@ const queuedMessages = [];
 
 function initMessaging() {
     window.onmessage = (event) => {
-
         if (!event.origin.includes("localhost")) {
             return;
         }

--- a/platform/android/app/src/main/assets/container/container.js
+++ b/platform/android/app/src/main/assets/container/container.js
@@ -15,7 +15,7 @@ const queuedMessages = [];
 
 function initMessaging() {
     window.onmessage = (event) => {
-        if (!event.origin.includes("localhost")) {
+        if (window.location.href.indexOf(event.origin) === 0) {
             return;
         }
         // Action notifications have no port

--- a/platform/ios/PolyPodApp/PodApi/messagePort.js
+++ b/platform/ios/PolyPodApp/PodApi/messagePort.js
@@ -1,6 +1,9 @@
 window.addEventListener("message", receiveMessage, false);
 
-function receiveMessage({ data }) {
+function receiveMessage({ data, origin }) {
+    if (!origin.includes("localhost")) {
+        return;
+    }
     if (data.command === "log") {
         webkit.messageHandlers[data.command].postMessage(data);
     }

--- a/platform/ios/PolyPodApp/PodApi/messagePort.js
+++ b/platform/ios/PolyPodApp/PodApi/messagePort.js
@@ -1,7 +1,7 @@
 window.addEventListener("message", receiveMessage, false);
 
 function receiveMessage({ data, origin }) {
-    if (!origin.includes("localhost")) {
+    if (window.location.href.indexOf(origin) === 0) {
         return;
     }
     if (data.command === "log") {

--- a/platform/ios/PolyPodApp/PodApi/polyNav.js
+++ b/platform/ios/PolyPodApp/PodApi/polyNav.js
@@ -1,7 +1,7 @@
 window.addEventListener(
     "message",
     ({ data: { command, action, origin } }) => {
-        if (!origin.includes("localhost")) {
+        if (window.location.href.indexOf(origin) === 0) {
             return;
         }
         if (command === "triggerPolyNavAction") pod.polyNav.actions[action]();

--- a/platform/ios/PolyPodApp/PodApi/polyNav.js
+++ b/platform/ios/PolyPodApp/PodApi/polyNav.js
@@ -1,6 +1,6 @@
 window.addEventListener(
     "message",
-    ({ data: { command, action, origin } }) => {
+    ({ data: { command, action }, origin }) => {
         if (window.location.href.indexOf(origin) === 0) {
             return;
         }

--- a/platform/ios/PolyPodApp/PodApi/polyNav.js
+++ b/platform/ios/PolyPodApp/PodApi/polyNav.js
@@ -1,4 +1,10 @@
-window.addEventListener("message", ({ data: { command, action } }) => {
-    if (command === "triggerPolyNavAction")
-        pod.polyNav.actions[action]();
-}, false);
+window.addEventListener(
+    "message",
+    ({ data: { command, action, origin } }) => {
+        if (!origin.includes("localhost")) {
+            return;
+        }
+        if (command === "triggerPolyNavAction") pod.polyNav.actions[action]();
+    },
+    false
+);


### PR DESCRIPTION
I've used localhost, which seems reasonable, and no reference to the protocol; this will make CodeQL happy and add a reasonable layer of security
This takes care of [ŧhis warning](https://github.com/polypoly-eu/polyPod/security/code-scanning/36), as well as [this one](https://github.com/polypoly-eu/polyPod/security/code-scanning/34) and [this one](https://github.com/polypoly-eu/polyPod/security/code-scanning/35)