### PR TITLE
fix(poly-look) - prod4pod-1634  fix infographic text replacement

### DIFF
--- a/feature-utils/poly-look/src/react-components/infographic/infographic.jsx
+++ b/feature-utils/poly-look/src/react-components/infographic/infographic.jsx
@@ -21,7 +21,7 @@ const Infographic = ({ image, explanation, legend = {} }) => {
     return Math.min(svg.width / viewBox.width, svg.height / viewBox.height);
   }
   useEffect(() => {
-    const container = d3.select("svg");
+    const container = d3.select(".infographic-svg svg");
 
     Object.keys(image.texts).forEach((key) => {
       const textField = container.select(`#${key}`);

--- a/features/google/src/locales/de/infoScreens/commonInfoScreen.json
+++ b/features/google/src/locales/de/infoScreens/commonInfoScreen.json
@@ -3,8 +3,8 @@
     "baseInfo.title2": "Über diese Daten",
     "bubble.chart": "Dieses Diagramm heißt <strong>Blasendiagramm</strong>. Jede Blase steht für einen Datentyp. Die Anazahl der Blasen zeigt, wieviele Datentypen es gibt. Die Größe jeder Blase hängt davon ab, wie viele Daten sich in der Blase befinden.",
     "bar.chart": "Dieses Diagramm heißt <strong>Balkendiagramm</strong>. Die Länge jedes Balkens ist proportional zu dem Wert, den er darstellt.",
-    "infographic.value.category": "(Anzahl) Kategorie",
+    "infographic.value.category": "(Wert) Kategorie",
     "infographic.x.axis": "Titel X-Achse (Einheit)",   
-    "infographic.y.axis": "Titel Y-Achse (Einheit)"  ,
+    "infographic.y.axis": "Titel Y-Achse (Einheit)",
     "infographic.legend": "Legende"   
 }


### PR DESCRIPTION
The texts in the infographic weren't translated because the selector was too broad and when there are multiple svgs in a page there was no guarantee that you would get the one you wanted.