### PR TITLE
Fix accesslog import

### DIFF
--- a/features/google/src/model/importers/access-log-importer.js
+++ b/features/google/src/model/importers/access-log-importer.js
@@ -36,8 +36,10 @@ export default class AccessLogImporter {
 
         const parser = new AccessLogParser();
 
-        googleAccount.accessLog = await Promise.all(
-            accessLogEntries.map((entry) => parser.parse(entry))
-        );
+        googleAccount.accessLog = (
+            await Promise.all(
+                accessLogEntries.map((entry) => parser.parse(entry))
+            )
+        ).flat();
     }
 }

--- a/features/google/src/views/explore/explore.jsx
+++ b/features/google/src/views/explore/explore.jsx
@@ -26,7 +26,10 @@ const ReportCard = () => {
             </div>
             <p>{i18n.t("explore:reportCard.text")}</p>
             <RoutingWrapper route="/report" history={history}>
-                <PolyButton label={i18n.t("explore:reportCard.button")} className="report-button" />
+                <PolyButton
+                    label={i18n.t("explore:reportCard.button")}
+                    className="report-button"
+                />
             </RoutingWrapper>
         </div>
     );


### PR DESCRIPTION
Quick fix: because all files get two entries (macOS directory and normal directory), the importer was returning an array of two arrays. This slipped as the dataGroups was not taking into account the accesslog, now that it does, the problem became apparent.