### PR TITLE
fix(polyExplorer) - prod4pod-1645 re-add missing css to StoriesPreview

### DIFF
--- a/features/polyExplorer/src/components/storiesPreview/storiesPreview.jsx
+++ b/features/polyExplorer/src/components/storiesPreview/storiesPreview.jsx
@@ -12,7 +12,7 @@ const StoriesPreview = ({ storiesMetadata }) => {
     const history = useHistory();
 
     return (
-        <List className="poly-theme-light">
+        <List className="poly-theme-light stories-preview">
             {Object.values(storiesMetadata).map((story, index) => (
                 <RoutingWrapper
                     key={index}


### PR DESCRIPTION
It turns out some css was left out during refactoring. I've only added one class back as it seems to be enough to fix the StoriesPreview layout.