### PR TITLE
[Feat] {PROD4POD-1648} Add metadata ministory

### DIFF
--- a/features/google/src/model/analyses/analyses.js
+++ b/features/google/src/model/analyses/analyses.js
@@ -2,10 +2,12 @@ import PlaceVisitsAnalysis from "./ministories/place-visits-analysis.js";
 import ActivitySegmentsAnalysis from "./ministories/activity-type-analysis";
 import ActivityByProductAnalysis from "./ministories/activity-by-products.js";
 import ActivitiesOverTimeAnalysis from "./ministories/activities-over-time.js";
+import ReportMetadataAnalysis from "./ministories/report-metadata.js";
 
 export const specificAnalyses = [
     PlaceVisitsAnalysis,
     ActivitySegmentsAnalysis,
     ActivityByProductAnalysis,
     ActivitiesOverTimeAnalysis,
+    ReportMetadataAnalysis,
 ];

--- a/features/google/src/model/analyses/analysisKeys.js
+++ b/features/google/src/model/analyses/analysisKeys.js
@@ -3,4 +3,5 @@ export default {
     groupedPlaceVisits: "groupedPlaceVisits",
     activitiesByProducts: "activitiesByProducts",
     activitiesOverTime: "activitiesOverTime",
+    reportMetadataAnalysis: "reportMetadataAnalysis",
 };

--- a/features/google/src/model/analyses/ministories/report-metadata.js
+++ b/features/google/src/model/analyses/ministories/report-metadata.js
@@ -1,0 +1,19 @@
+import { ReportAnalysis } from "@polypoly-eu/poly-analysis";
+import analysisKeys from "../utils/analysisKeys";
+
+export default class ReportMetadataAnalysis extends ReportAnalysis {
+    async analyze({ size, zipFile, dataAccount, pod }) {
+        const info = await pod.info;
+        dataAccount.reports[analysisKeys.reportMetadata] = {};
+        dataAccount.reports[analysisKeys.reportMetadata].polyPodRuntime =
+            await info.getRuntime();
+        dataAccount.reports[analysisKeys.reportMetadata].polyPodVersion =
+            await info.getVersion();
+
+        dataAccount.reports[analysisKeys.reportMetadata].fileSize = size;
+
+        const entries = await zipFile.getEntries();
+        dataAccount.reports[analysisKeys.reportMetadata].filesCount =
+            entries.length;
+    }
+}

--- a/features/google/src/model/analyses/ministories/report-metadata.js
+++ b/features/google/src/model/analyses/ministories/report-metadata.js
@@ -1,5 +1,5 @@
 import { ReportAnalysis } from "@polypoly-eu/poly-analysis";
-import analysisKeys from "../utils/analysisKeys";
+import analysisKeys from "../analysisKeys";
 
 export default class ReportMetadataAnalysis extends ReportAnalysis {
     async analyze({ size, zipFile, dataAccount, pod }) {

--- a/features/google/src/views/ministories/ministories.js
+++ b/features/google/src/views/ministories/ministories.js
@@ -3,6 +3,7 @@ import PlaceVisitsMinistory from "./placeVisits.jsx";
 import GroupedActivityTypesStory from "./groupedActivityTypes.jsx";
 import ActivitiesByProductsStory from "./activitiesByProduct.jsx";
 import ActivitiesOverTimeMinistory from "./activitiesOverTime.jsx";
+import ReportMetadataReport from "./reportMetadata.jsx";
 
 export const ministories = [
     DataStructureMinistory,
@@ -10,6 +11,7 @@ export const ministories = [
     PlaceVisitsMinistory,
     GroupedActivityTypesStory,
     ActivitiesByProductsStory,
+    ReportMetadataReport,
 ];
 
 export default ministories;

--- a/features/google/src/views/ministories/ministories.js
+++ b/features/google/src/views/ministories/ministories.js
@@ -3,7 +3,6 @@ import PlaceVisitsMinistory from "./placeVisits.jsx";
 import GroupedActivityTypesStory from "./groupedActivityTypes.jsx";
 import ActivitiesByProductsStory from "./activitiesByProduct.jsx";
 import ActivitiesOverTimeMinistory from "./activitiesOverTime.jsx";
-import ReportMetadataReport from "./reportMetadata.jsx";
 
 export const ministories = [
     DataStructureMinistory,
@@ -11,7 +10,6 @@ export const ministories = [
     PlaceVisitsMinistory,
     GroupedActivityTypesStory,
     ActivitiesByProductsStory,
-    ReportMetadataReport,
 ];
 
 export default ministories;

--- a/features/google/src/views/ministories/reportMetadata.jsx
+++ b/features/google/src/views/ministories/reportMetadata.jsx
@@ -16,7 +16,6 @@ class ReportMetadataReport extends ReportStory {
         return {
             fileSize: analysisData.fileSize,
             filesCount: analysisData.filesCount,
-            preferedLanguage: analysisData.preferedLanguage,
             polyPodRuntime: analysisData.polyPodRuntime,
             polyPodVersion: analysisData.polyPodVersion,
         };

--- a/features/google/src/views/ministories/reportMetadata.jsx
+++ b/features/google/src/views/ministories/reportMetadata.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import analysisKeys from "../../model/analyses/analysisKeys";
+import ReportStory from "./reportStory.jsx";
+
+class ReportMetadataReport extends ReportStory {
+    constructor(props) {
+        super(props);
+        this._neededReports = [analysisKeys.reportMetadata];
+    }
+    get title() {
+        return "Report Metadata";
+    }
+
+    get reportData() {
+        const analysisData = this.reports[analysisKeys.reportMetadata];
+        return {
+            fileSize: analysisData.fileSize,
+            filesCount: analysisData.filesCount,
+            preferedLanguage: analysisData.preferedLanguage,
+            polyPodRuntime: analysisData.polyPodRuntime,
+            polyPodVersion: analysisData.polyPodVersion,
+        };
+    }
+
+    _renderSummary() {
+        return (
+            <ul>
+                <li key={1}>
+                    polyPod runtime: {this.reportData.polyPodRuntime}
+                </li>
+                <li key={2}>
+                    polyPod version: {this.reportData.polyPodVersion}
+                </li>
+                <li key={3}>File size: {this.reportData.fileSize}</li>
+                <li key={4}>Files count: {this.reportData.filesCount}</li>
+            </ul>
+        );
+    }
+}
+
+export default ReportMetadataReport;

--- a/features/google/src/views/ministories/reports.js
+++ b/features/google/src/views/ministories/reports.js
@@ -1,5 +1,6 @@
 import DataImportingStatusReport from "./dataImportingStatus.jsx";
+import ReportMetadataReport from "./reportMetadata.jsx";
 
-export const reports = [DataImportingStatusReport];
+export const reports = [DataImportingStatusReport, ReportMetadataReport];
 
 export default reports;


### PR DESCRIPTION
![Captura de pantalla de 2022-06-10 08-59-58](https://user-images.githubusercontent.com/500/173008827-d8593020-2a05-4c31-b39f-fcbd68186abd.png)
Metadata is going to appear *here* **and** at the bottom of the other ministory; I've kinda figured out how to eliminate any of them so I admit any suggestions over that.
It's essentially copypasta from facebook, so we might want to factor that out; only difference is that report language is not used in Google. 