### PR TITLE
PROD4POD-1656 - Add pod unlock screen

### DIFF
--- a/features/google/src/model/analyses/ministories/report-metadata.js
+++ b/features/google/src/model/analyses/ministories/report-metadata.js
@@ -11,7 +11,8 @@ export default class ReportMetadataAnalysis extends ReportAnalysis {
             await info.getVersion();
 
         dataAccount.reports[analysisKeys.reportMetadata].fileSize = size;
-
+        dataAccount.reports[analysisKeys.reportMetadata].isExampleFile =
+            zipFile._file.name.includes("fake");
         const entries = await zipFile.getEntries();
         dataAccount.reports[analysisKeys.reportMetadata].filesCount =
             entries.length;

--- a/features/google/src/views/ministories/reportMetadata.jsx
+++ b/features/google/src/views/ministories/reportMetadata.jsx
@@ -18,6 +18,7 @@ class ReportMetadataReport extends ReportStory {
             filesCount: analysisData.filesCount,
             polyPodRuntime: analysisData.polyPodRuntime,
             polyPodVersion: analysisData.polyPodVersion,
+            isExampleFile: analysisData.isExampleFile,
         };
     }
 
@@ -31,7 +32,8 @@ class ReportMetadataReport extends ReportStory {
                     polyPod version: {this.reportData.polyPodVersion}
                 </li>
                 <li key={3}>File size: {this.reportData.fileSize}</li>
-                <li key={4}>Files count: {this.reportData.filesCount}</li>
+                <li key={4}>File count: {this.reportData.filesCount}</li>
+                <li key={5}>Is the imported file an example?: {this.reportData.isExampleFile?"Yes":"No"}</li>
             </ul>
         );
     }

--- a/platform/android/app/src/main/AndroidManifest.xml
+++ b/platform/android/app/src/main/AndroidManifest.xml
@@ -33,6 +33,11 @@
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
         <activity
+            android:name=".PodUnlockActivity"
+            android:label=""
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+
+        <activity
             android:name=".settings.SettingsActivity"
             android:label="@string/settings_title"
             android:theme="@style/Theme.AppCompat.Light" />

--- a/platform/android/app/src/main/java/coop/polypoly/polypod/PodUnlockActivity.kt
+++ b/platform/android/app/src/main/java/coop/polypoly/polypod/PodUnlockActivity.kt
@@ -1,0 +1,31 @@
+package coop.polypoly.polypod
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.view.View
+
+
+class PodUnlockActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_pod_unlock)
+
+        val button = findViewById<View>(
+            R.id.unlock_button
+        )
+
+        button.setOnClickListener {
+            authenticate()
+        }
+
+        authenticate()
+    }
+
+    private fun authenticate() {
+        Authentication.authenticate(this, newStatus = false) {
+            if (it) {
+                finish()
+            }
+        }
+    }
+}

--- a/platform/android/app/src/main/java/coop/polypoly/polypod/PodUnlockActivity.kt
+++ b/platform/android/app/src/main/java/coop/polypoly/polypod/PodUnlockActivity.kt
@@ -1,9 +1,8 @@
 package coop.polypoly.polypod
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
-
+import androidx.appcompat.app.AppCompatActivity
 
 class PodUnlockActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -9,6 +9,8 @@ import androidx.fragment.app.FragmentActivity
 
 class Authentication {
     companion object {
+        var isAuthenticated = false
+
         private const val desiredLockScreenType =
             BiometricManager.Authenticators.BIOMETRIC_WEAK or
                 BiometricManager.Authenticators.DEVICE_CREDENTIAL
@@ -22,7 +24,8 @@ class Authentication {
 
         fun should_authenticate(context: Context): Boolean {
             return biometricsAvailable(context) &&
-                Preferences.isBiometricEnabled(context)
+                Preferences.isBiometricEnabled(context) &&
+                !isAuthenticated
         }
 
         fun setUp(
@@ -106,6 +109,7 @@ class Authentication {
                 title,
                 Toast.LENGTH_SHORT
             ).show()
+            isAuthenticated = true
 
             authComplete(true)
         }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -20,6 +20,11 @@ class Authentication {
                 !Preferences.isFirstRun(context)
         }
 
+        fun should_authenticate(context: Context): Boolean {
+            return biometricsAvailable(context) &&
+                Preferences.isBiometricEnabled(context)
+        }
+
         fun setUp(
             activity: FragmentActivity,
             newStatus: Boolean,

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -22,7 +22,7 @@ class Authentication {
                 !Preferences.isFirstRun(context)
         }
 
-        fun should_authenticate(context: Context): Boolean {
+        fun shouldAuthenticate(context: Context): Boolean {
             return biometricsAvailable(context) &&
                 Preferences.isBiometricEnabled(context) &&
                 !isAuthenticated

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -65,7 +65,7 @@ class MainActivity : AppCompatActivity() {
                     OnboardingActivity::class.java
                 )
             )
-        } else if (Authentication.should_authenticate(this)) {
+        } else if (Authentication.shouldAuthenticate(this)) {
             startActivity(
                 Intent(
                     this,

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -18,6 +18,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private var onboardingShown = false
+    private var podUnlockShown = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,18 +40,9 @@ class MainActivity : AppCompatActivity() {
             throw ex
         }
 
-        Authentication.authenticate(this) { success ->
-            if (success) {
-                FeatureStorage().installBundledFeatures(this)
-                setContentView(R.layout.activity_main)
-                setSupportActionBar(findViewById(R.id.toolbar))
-            } else {
-                // Since we do not have a dedicated unlocking activity yet,
-                // we simply keep restarting the activity until unlocking
-                // succeeds.
-                recreate()
-            }
-        }
+        FeatureStorage().installBundledFeatures(this)
+        setContentView(R.layout.activity_main)
+        setSupportActionBar(findViewById(R.id.toolbar))
     }
 
     override fun onResume() {
@@ -72,6 +64,14 @@ class MainActivity : AppCompatActivity() {
                 Intent(
                     this,
                     OnboardingActivity::class.java
+                )
+            )
+        } else if (!podUnlockShown && Authentication.should_authenticate(this)) {
+            podUnlockShown = true
+            startActivity(
+                Intent(
+                    this,
+                    PodUnlockActivity::class.java
                 )
             )
         }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -18,7 +18,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     private var onboardingShown = false
-    private var podUnlockShown = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -66,10 +65,7 @@ class MainActivity : AppCompatActivity() {
                     OnboardingActivity::class.java
                 )
             )
-        } else if (
-            !podUnlockShown && Authentication.should_authenticate(this)
-        ) {
-            podUnlockShown = true
+        } else if (Authentication.should_authenticate(this)) {
             startActivity(
                 Intent(
                     this,

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -66,7 +66,9 @@ class MainActivity : AppCompatActivity() {
                     OnboardingActivity::class.java
                 )
             )
-        } else if (!podUnlockShown && Authentication.should_authenticate(this)) {
+        } else if (
+            !podUnlockShown && Authentication.should_authenticate(this)
+        ) {
             podUnlockShown = true
             startActivity(
                 Intent(

--- a/platform/android/app/src/main/res/layout/activity_pod_unlock.xml
+++ b/platform/android/app/src/main/res/layout/activity_pod_unlock.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/onboarding_bg">
+
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageView
+            android:id="@+id/polypod_logo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_logo" />
+
+        <Button
+            android:id="@+id/unlock_button"
+            android:layout_width="300dp"
+            android:layout_height="54dp"
+            android:layout_marginBottom="80dp"
+            android:text="@string/auth_prompt_title"
+            android:textAllCaps="false"
+            android:textColor="@color/colorPrimaryDark"
+            android:textSize="18dp"
+            android:fontFamily="@font/jost_medium"
+            android:background="@drawable/onboarding_button_bg"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/platform/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
+++ b/platform/ios/PolyPodApp/PolyPod.xcodeproj/project.pbxproj
@@ -93,6 +93,8 @@
 		5105EA05281ACEEC0040AE0D /* BindingExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5105EA04281ACEEC0040AE0D /* BindingExtensions.swift */; };
 		5105EA07281AFDBB0040AE0D /* BindingExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5105EA04281ACEEC0040AE0D /* BindingExtensions.swift */; };
 		5B8653022643FC310014208C /* PolyNav.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8653012643FC310014208C /* PolyNav.swift */; };
+		9000F697285894B500241B27 /* UnlockPolyPod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9000F696285894B500241B27 /* UnlockPolyPod.swift */; };
+		9000F69A28589A7D00241B27 /* SharedUIComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9000F69928589A7D00241B27 /* SharedUIComponents.swift */; };
 		901C0588278EE58700BC8364 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C0587278EE58700BC8364 /* CoreDataStack.swift */; };
 		901C058A278F2AF800BC8364 /* CoreData+PolyIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C0589278F2AF800BC8364 /* CoreData+PolyIn.swift */; };
 		901C058B278F2D4A00BC8364 /* CoreData+PolyIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C0589278F2AF800BC8364 /* CoreData+PolyIn.swift */; };
@@ -238,6 +240,8 @@
 		5105EA04281ACEEC0040AE0D /* BindingExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingExtensions.swift; sourceTree = "<group>"; };
 		5B0F7B5F26A924DF00F4EFF4 /* PolyPod.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PolyPod.entitlements; sourceTree = "<group>"; };
 		5B8653012643FC310014208C /* PolyNav.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolyNav.swift; sourceTree = "<group>"; };
+		9000F696285894B500241B27 /* UnlockPolyPod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockPolyPod.swift; sourceTree = "<group>"; };
+		9000F69928589A7D00241B27 /* SharedUIComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedUIComponents.swift; sourceTree = "<group>"; };
 		901C0587278EE58700BC8364 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
 		901C0589278F2AF800BC8364 /* CoreData+PolyIn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreData+PolyIn.swift"; sourceTree = "<group>"; };
 		904D4A6F27905D5B00A75AED /* DispatchToMainQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchToMainQueue.swift; sourceTree = "<group>"; };
@@ -447,6 +451,8 @@
 				E996EBD12756BBE900EAC9F7 /* Log.swift */,
 				906E406B27A82C7F009015B7 /* ActivityViewController.swift */,
 				90E4088127D78E4E006AD362 /* DataProtection.swift */,
+				9000F696285894B500241B27 /* UnlockPolyPod.swift */,
+				9000F69928589A7D00241B27 /* SharedUIComponents.swift */,
 			);
 			path = PolyPod;
 			sourceTree = "<group>";
@@ -959,6 +965,7 @@
 				1A4C21F624A63E4C006CC1FD /* Literal+CoreDataClass.swift in Sources */,
 				E96817F1274D032A00206602 /* Language.swift in Sources */,
 				1A4C21DE24A63DD4006CC1FD /* Term+CoreDataClass.swift in Sources */,
+				9000F697285894B500241B27 /* UnlockPolyPod.swift in Sources */,
 				1A4C21EE24A63E4B006CC1FD /* NamedNode+CoreDataClass.swift in Sources */,
 				E9CF1B722627304800216B70 /* FeatureContainerView.swift in Sources */,
 				1A4C21DF24A63DD4006CC1FD /* Term+CoreDataProperties.swift in Sources */,
@@ -977,6 +984,7 @@
 				1A4C21ED24A63E4B006CC1FD /* DefaultGraph+CoreDataProperties.swift in Sources */,
 				1A4C21F524A63E4C006CC1FD /* Variable+CoreDataProperties.swift in Sources */,
 				E90F89EA2629822400AD7D96 /* OnboardingView.swift in Sources */,
+				9000F69A28589A7D00241B27 /* SharedUIComponents.swift in Sources */,
 				1A4C21F724A63E4C006CC1FD /* Literal+CoreDataProperties.swift in Sources */,
 				1A4C21EF24A63E4B006CC1FD /* NamedNode+CoreDataProperties.swift in Sources */,
 				1ABADC0E24EFB9F300369791 /* Models.swift in Sources */,

--- a/platform/ios/PolyPodApp/PolyPod/ContentView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/ContentView.swift
@@ -80,7 +80,22 @@ struct ContentView: View {
     
     private func securityReminderState() -> ViewState {
         if !Authentication.shared.shouldShowPrompt() {
-            return lockedState()
+            return ViewState(
+                AnyView(
+                    UnlockPolyPod(onCompleted: {
+                        // Checking whether a notification needs to be shown
+                        // used to be in featureListState, where it makes more
+                        // sense, but ever since we added a dedicated
+                        // lockedState, they wouldn't show up anymore, the
+                        // state change in featureListState's onAppear did not
+                        // trigger a rerender, even though it should.
+                        // Yet another SwiftUI bug it seems...
+                        showUpdateNotification = UpdateNotification().showInApp
+                        
+                        state = featureListState()
+                    })
+                )
+            )
         }
         
         return ViewState(
@@ -93,43 +108,6 @@ struct ContentView: View {
                 )
             )
         )
-    }
-    
-    private func lockedState() -> ViewState {
-        return ViewState(
-            AnyView(
-                Text("").onAppear {
-                    authenticateRelentlessly {
-                        // Checking whether a notification needs to be shown
-                        // used to be in featureListState, where it makes more
-                        // sense, but ever since we added a dedicated
-                        // lockedState, they wouldn't show up anymore, the
-                        // state change in featureListState's onAppear did not
-                        // trigger a rerender, even though it should.
-                        // Yet another SwiftUI bug it seems...
-                        showUpdateNotification = UpdateNotification().showInApp
-                        
-                        state = featureListState()
-                    }
-                }
-            )
-        )
-    }
-    
-    private func authenticateRelentlessly(
-        _ completeAction: @escaping () -> Void
-    ) {
-        // Apple doesn't want us to close the app programmatically, e.g. in case
-        // authentication fails. Since we don't have a dedicated screen for the
-        // locked state yet, we simply keep asking the user until they stop
-        // cancelling or leave the app.
-        Authentication.shared.authenticate { success in
-            if success {
-                completeAction()
-                return
-            }
-            authenticateRelentlessly(completeAction)
-        }
     }
     
     private func featureListState() -> ViewState {

--- a/platform/ios/PolyPodApp/PolyPod/OnboardingView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/OnboardingView.swift
@@ -131,31 +131,8 @@ private struct Slide: View {
             Spacer()
             
             if let confirmLabel = confirmLabel {
-                Button(action: confirmAction ?? {}) {
-                    Text(confirmLabel)
-                        .font(.custom("Jost-Medium", size: 14))
-                        .kerning(-0.18)
-                        .foregroundColor(Color.PolyPod.darkForeground)
-                        .frame(minWidth: 296, minHeight: 48)
-                        .background(
-                            RoundedRectangle(cornerRadius: 4)
-                                .fill(Color(fromHex: "#FB8A89"))
-                                .shadow(
-                                    color: Color.black.opacity(0.06),
-                                    radius: 2,
-                                    x: 0,
-                                    y: 1
-                                )
-                                .shadow(
-                                    color: Color.black.opacity(0.1),
-                                    radius: 3,
-                                    x: 0,
-                                    y: 1
-                                )
-                        )
-                }
-                .buttonStyle(PlainButtonStyle())
-                .frame(maxWidth: .infinity, alignment: .center)
+                PrimaryButton(title: confirmLabel,
+                              onAction: confirmAction ?? {})
             }
             
             if let denyLabel = denyLabel {

--- a/platform/ios/PolyPodApp/PolyPod/SharedUIComponents.swift
+++ b/platform/ios/PolyPodApp/PolyPod/SharedUIComponents.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct PrimaryButton: View {
+    let title: LocalizedStringKey
+    let onAction: () -> Void
+
+    var body: some View {
+        Button(action: onAction) {
+            Text(title)
+                .font(.custom("Jost-Medium", size: 14))
+                .kerning(-0.18)
+                .foregroundColor(Color.PolyPod.darkForeground)
+                .frame(minWidth: 296, minHeight: 48)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color(fromHex: "#FB8A89"))
+                        .shadow(
+                            color: Color.black.opacity(0.06),
+                            radius: 2,
+                            x: 0,
+                            y: 1
+                        )
+                        .shadow(
+                            color: Color.black.opacity(0.1),
+                            radius: 3,
+                            x: 0,
+                            y: 1
+                        )
+                )
+        }
+        .buttonStyle(PlainButtonStyle())
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+}
+

--- a/platform/ios/PolyPodApp/PolyPod/UnlockPolyPod.swift
+++ b/platform/ios/PolyPodApp/PolyPod/UnlockPolyPod.swift
@@ -6,7 +6,7 @@ struct UnlockPolyPod: View {
     var onCompleted: () -> Void = {}
 
     var body: some View {
-        VStack(alignment: .center, spacing: 32) {
+        VStack(alignment: .center) {
             Spacer()
             Image("NavIconPolyPodLogo")
             Spacer()

--- a/platform/ios/PolyPodApp/PolyPod/UnlockPolyPod.swift
+++ b/platform/ios/PolyPodApp/PolyPod/UnlockPolyPod.swift
@@ -10,7 +10,7 @@ struct UnlockPolyPod: View {
             Spacer()
             Image("NavIconPolyPodLogo")
             Spacer()
-            PrimaryButton(title: "Unlock", onAction: authenticate)
+            PrimaryButton(title: "auth_prompt_unlock", onAction: authenticate)
         }
         .padding(.vertical, 32)
         .onAppear(perform: authenticate)

--- a/platform/ios/PolyPodApp/PolyPod/UnlockPolyPod.swift
+++ b/platform/ios/PolyPodApp/PolyPod/UnlockPolyPod.swift
@@ -1,5 +1,3 @@
-// Please remove this line and the empty one after it
-
 import SwiftUI
 
 struct UnlockPolyPod: View {

--- a/platform/ios/PolyPodApp/PolyPod/UnlockPolyPod.swift
+++ b/platform/ios/PolyPodApp/PolyPod/UnlockPolyPod.swift
@@ -1,0 +1,34 @@
+// Please remove this line and the empty one after it
+
+import SwiftUI
+
+struct UnlockPolyPod: View {
+    var onCompleted: () -> Void = {}
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 32) {
+            Spacer()
+            Image("NavIconPolyPodLogo")
+            Spacer()
+            PrimaryButton(title: "Unlock", onAction: authenticate)
+        }
+        .padding(.vertical, 32)
+        .onAppear(perform: authenticate)
+    }
+    
+    private func authenticate() {
+        Authentication.shared.authenticate { success in
+            if success {
+                DispatchQueue.main.async {
+                    onCompleted()
+                }
+            }
+        }
+    }
+}
+
+struct UnlockPolyPod_Previews: PreviewProvider {
+    static var previews: some View {
+        UnlockPolyPod()
+    }
+}


### PR DESCRIPTION
Instead of "relentless" authentication add a simple unlock screen.

The original issues was that the app was left in limbo state when User did not log in properly. The root cause is that biometric prompt can be cancelled at any time by the user or by the system(for example when moving the app to background), this cannot be fixed reliably with just some code hacks.

What was done:

- Add a simple Unlock Pod screen, UI could be further improved with next iterations.
- If biometric prompt is dismissed for whatever reason, unlock screen is shown and user can tap on the button to try to unlock the Pod again.

<img width="498" alt="image" src="https://user-images.githubusercontent.com/12482662/173610320-1772010b-a368-43ec-802c-f571eb9ff86a.jpeg">

