### PR TITLE
Fix Authentication screen texts in Android

### DIFF
--- a/platform/android/app/src/main/java/coop/polypoly/polypod/PodUnlockActivity.kt
+++ b/platform/android/app/src/main/java/coop/polypoly/polypod/PodUnlockActivity.kt
@@ -21,7 +21,7 @@ class PodUnlockActivity : AppCompatActivity() {
     }
 
     private fun authenticate() {
-        Authentication.authenticate(this, newStatus = false) {
+        Authentication.authenticate(this, showAuthTexts = true) {
             if (it) {
                 finish()
             }

--- a/platform/android/app/src/main/java/coop/polypoly/polypod/PodUnlockActivity.kt
+++ b/platform/android/app/src/main/java/coop/polypoly/polypod/PodUnlockActivity.kt
@@ -21,7 +21,11 @@ class PodUnlockActivity : AppCompatActivity() {
     }
 
     private fun authenticate() {
-        Authentication.authenticate(this, showAuthTexts = true) {
+        Authentication.authenticate(
+            this,
+            showAuthTexts = true,
+            newBiometricState = false
+        ) {
             if (it) {
                 finish()
             }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -30,14 +30,14 @@ class Authentication {
 
         fun setUp(
             activity: FragmentActivity,
-            newStatus: Boolean,
+            showAuthTexts: Boolean,
             setupComplete: () -> Unit
         ) {
-            authenticate(activity, newStatus) { success ->
+            authenticate(activity, showAuthTexts) { success ->
                 if (success) {
                     Preferences.setBiometricEnabled(
                         activity,
-                        newStatus
+                        showAuthTexts
                     )
                 }
                 setupComplete()
@@ -46,29 +46,28 @@ class Authentication {
 
         fun authenticate(
             activity: FragmentActivity,
-            newStatus: Boolean = false,
+            showAuthTexts: Boolean = false,
             authComplete: ((Boolean) -> Unit)
         ) {
             val isBiometricEnabled = Preferences.isBiometricEnabled(activity)
             if (!biometricsAvailable(activity) ||
-                (!newStatus && !isBiometricEnabled)
+                (!showAuthTexts && !isBiometricEnabled)
             ) {
                 authComplete(true)
                 return
             }
 
             val title =
-                // auth is enabled and the user is trying to disable the setting
-                if (isBiometricEnabled && !newStatus)
-                    activity.getString(R.string.re_auth_prompt_title)
-                else
+                if (showAuthTexts)
                     activity.getString(R.string.auth_prompt_title)
+                else
+                    activity.getString(R.string.re_auth_prompt_title)
 
             val subtitle =
-                if (isBiometricEnabled)
-                    activity.getString(R.string.re_auth_prompt_subtitle)
-                else
+                if (showAuthTexts)
                     activity.getString(R.string.auth_prompt_subtitle)
+                else
+                    activity.getString(R.string.re_auth_prompt_subtitle)
 
             val promptInfo = BiometricPrompt.PromptInfo.Builder()
                 .setTitle(title)

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -31,9 +31,14 @@ class Authentication {
         fun setUp(
             activity: FragmentActivity,
             showAuthTexts: Boolean,
+            newBiometricState: Boolean = false,
             setupComplete: () -> Unit
         ) {
-            authenticate(activity, showAuthTexts) { success ->
+            authenticate(
+                activity,
+                showAuthTexts,
+                newBiometricState
+            ) { success ->
                 if (success) {
                     Preferences.setBiometricEnabled(
                         activity,
@@ -47,11 +52,12 @@ class Authentication {
         fun authenticate(
             activity: FragmentActivity,
             showAuthTexts: Boolean = false,
+            newBiometricState: Boolean = false,
             authComplete: ((Boolean) -> Unit)
         ) {
             val isBiometricEnabled = Preferences.isBiometricEnabled(activity)
             if (!biometricsAvailable(activity) ||
-                (!showAuthTexts && !isBiometricEnabled)
+                (!newBiometricState && !isBiometricEnabled)
             ) {
                 authComplete(true)
                 return

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -58,7 +58,8 @@ class Authentication {
             }
 
             val title =
-                if (isBiometricEnabled)
+                // auth is enabled and the user is trying to disable the setting
+                if (isBiometricEnabled && !newStatus)
                     activity.getString(R.string.re_auth_prompt_title)
                 else
                     activity.getString(R.string.auth_prompt_title)

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -30,7 +30,7 @@ class Authentication {
 
         fun setUp(
             activity: FragmentActivity,
-            showAuthTexts: Boolean,
+            showAuthTexts: Boolean = false,
             newBiometricState: Boolean = false,
             setupComplete: () -> Unit
         ) {
@@ -42,7 +42,7 @@ class Authentication {
                 if (success) {
                     Preferences.setBiometricEnabled(
                         activity,
-                        showAuthTexts
+                        newBiometricState
                     )
                 }
                 setupComplete()

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
@@ -73,7 +73,11 @@ class OnboardingActivity : AppCompatActivity() {
                 )
                 button.visibility = View.VISIBLE
                 button.setOnClickListener {
-                    Authentication.setUp(this, showAuthTexts = true) {
+                    Authentication.setUp(
+                        this,
+                        showAuthTexts = true,
+                        newBiometricState = true
+                    ) {
                         close()
                     }
                 }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
@@ -73,7 +73,7 @@ class OnboardingActivity : AppCompatActivity() {
                 )
                 button.visibility = View.VISIBLE
                 button.setOnClickListener {
-                    Authentication.setUp(this, newStatus = true) {
+                    Authentication.setUp(this, showAuthTexts = true) {
                         close()
                     }
                 }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/settings/MainFragment.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/settings/MainFragment.kt
@@ -53,10 +53,10 @@ class MainFragment : PreferenceFragmentCompat() {
             }
     }
 
-    private fun onAuthRequest(newStatus: Boolean, onReturn: () -> Unit) {
+    private fun onAuthRequest(showAuthTexts: Boolean, onReturn: () -> Unit) {
         Authentication.setUp(
             requireActivity(),
-            newStatus
+            showAuthTexts
         ) {
             onReturn()
             true

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/settings/MainFragment.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/settings/MainFragment.kt
@@ -53,10 +53,11 @@ class MainFragment : PreferenceFragmentCompat() {
             }
     }
 
-    private fun onAuthRequest(showAuthTexts: Boolean, onReturn: () -> Unit) {
+    private fun onAuthRequest(newValue: Boolean, onReturn: () -> Unit) {
         Authentication.setUp(
             requireActivity(),
-            showAuthTexts
+            showAuthTexts = false,
+            newBiometricState = newValue
         ) {
             onReturn()
             true


### PR DESCRIPTION
Following updated diagram flows of authentication https://wiki.polypoly.eu/display/POLYPOD/system+lock+for+polyPod 
we correct the texts shown to the user when they are prompted to the authentication setting.

We simplified the cases, so now show:
- "Login to your polyPod" text (aka `auth_*` texts) when on onboarding, and when polyPod starts over.
- "Authenticate to continue"  text (aka `reauth_*`  texts) when toggle button is pressed, independently of the value changed.

For this we used two different flag variables:  `showAuthTexts` for the UI texts and `newBiometricState` (previously named `newStatus`) to not break the current security flow and make sure UI is as requested.

Note:
tested by security @L-E  🟢 
