### PR TITLE
Do not set file system to prevent file deletion on opening app - bug fix

### DIFF
--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/polyOut/PolyOut.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/polyOut/PolyOut.kt
@@ -121,7 +121,6 @@ open class PolyOut(
             val newFs = fs.filter {
                 File(idToPath(it.key, context)).exists()
             }
-            Preferences.setFileSystem(context, newFs)
             return newFs.keys.map {
                 mutableMapOf<String, String>(
                     "id" to it,


### PR DESCRIPTION
Setting the file system here will replace the entire file system only with the files that the feature can access aka deleting the google import when opening fbImport

More than co-authored by @alexandrosFarhat 