### PR TITLE
PROD4POD-1644/Fix CSS in Facebook import view

### DIFF
--- a/features/facebookImport/src/components/importExplanationExpandable/importExplanationExpandable.css
+++ b/features/facebookImport/src/components/importExplanationExpandable/importExplanationExpandable.css
@@ -38,7 +38,7 @@
     width: 48px;
     height: 48px;
     border-radius: 50%;
-    font-size: 28px;
+    font-size: var(--font-size-xl);
     font-weight: 600;
     display: flex;
     align-items: center;

--- a/features/facebookImport/src/components/importExplanationExpandable/importExplanationExpandable.css
+++ b/features/facebookImport/src/components/importExplanationExpandable/importExplanationExpandable.css
@@ -10,7 +10,6 @@
 .import-view .explanation-expandable .intro {
     width: 100%;
     max-width: var(--max-width);
-    padding: 0 16px 16px 16px;
     box-sizing: border-box;
     margin: 4px auto 72px auto;
 }
@@ -60,7 +59,7 @@
 }
 
 .import-view .explanation-expandable .section-body {
-    padding: 16px 16px 16px 16px;
+    padding: 16px 0;
     width: 100%;
     max-width: var(--max-width);
     box-sizing: border-box;


### PR DESCRIPTION
To address the [PROD4POD-1644 Expansion panel head bars are not correct in Google Importer](https://jira.polypoly.eu/browse/PROD4POD-1644), I had to changed Facebook import view - margins were duplicated due to the implementation of Screen component.

This ticket was under [PROD4POD-1570 Release polyPod 1.6 with Google Feature](https://jira.polypoly.eu/browse/PROD4POD-1570) but I'm having doubts about the priority of this due to feature freeze. 🤔 

