### PR TITLE
fix warning for deprecated `UIDocumentPickerViewController.init()` in ios14

### DIFF
--- a/platform/ios/PolyPodApp/Extensions/ColorExtensions.swift
+++ b/platform/ios/PolyPodApp/Extensions/ColorExtensions.swift
@@ -12,10 +12,7 @@ extension Color {
     }
     
     var compatCgColor: CGColor? {
-        if #available(iOS 14, *) {
-            return cgColor
-        }
-        return UIColor.compatInit(self).cgColor
+        return cgColor
     }
     
     var luminance: Double {

--- a/platform/ios/PolyPodApp/Extensions/UIColorExtensions.swift
+++ b/platform/ios/PolyPodApp/Extensions/UIColorExtensions.swift
@@ -9,22 +9,6 @@ extension UIColor {
      does not work with named colours, e.g. Color.white.
      */
     static func compatInit(_ color: Color) -> UIColor {
-        if #available(iOS 14, *) {
-            return UIColor(color)
-        }
-        let scanner = Scanner(
-            string: color.description.trimmingCharacters(
-                in: CharacterSet.alphanumerics.inverted
-            )
-        )
-        var hexNumber: UInt64 = 0
-        scanner.scanHexInt64(&hexNumber)
-        
-        return UIColor(
-            red: CGFloat((hexNumber & 0xFF000000) >> 24) / 255,
-            green: CGFloat((hexNumber & 0xFF0000) >> 16) / 255,
-            blue: CGFloat((hexNumber & 0xFF00) >> 8) / 255,
-            alpha: CGFloat(hexNumber & 0xFF) / 255
-        )
+        return UIColor(color)
     }
 }

--- a/platform/ios/PolyPodApp/PolyPod/FilePicker.swift
+++ b/platform/ios/PolyPodApp/PolyPod/FilePicker.swift
@@ -1,5 +1,6 @@
 import UIKit
 import MessagePack
+import UniformTypeIdentifiers
 
 struct ExternalFile {
     let url: String
@@ -49,12 +50,19 @@ class FilePicker: NSObject, UIDocumentPickerDelegate {
         }
         currentCompletion = completion
         
-        let documentPickerController = UIDocumentPickerViewController(
-            documentTypes: [mimeToUti(type)],
-            in: .import
-        )
-        documentPickerController.delegate = self
         
+        var documentPickerController: UIDocumentPickerViewController!
+        if #available(iOS 14, *) {
+            // iOS 14 & later
+            let supportedTypes: [UTType] = [UTType(type ?? "")!]
+            documentPickerController = UIDocumentPickerViewController(forOpeningContentTypes: supportedTypes)
+        } else {
+            // iOS 13 or older code
+            let supportedTypes: [String] = [type!]
+            documentPickerController = UIDocumentPickerViewController(documentTypes: supportedTypes, in: .import)
+        }
+        documentPickerController.delegate = self
+
         // This is a workaround for a fairly nasty issue: On iOS 14.4 and 15.0,
         // potentially other versions as well, on _some_ devices, a presentation
         // style of e.g. .pageSheet (same as .automatic on those versions),


### PR DESCRIPTION
Fix warning for method `[UIDocumentPickerViewController - 'init(documentTypes:in:)']` which is deprecated from iOS 14, so need support for both iOS 14 and later. And iOS 13 and earlier.

#### Update after PR review:
Drop code support for <ios14 that was marked with `#available` previously