### PR TITLE
[android] Add borders on home screen tiles - PROD4POD-1697

### DIFF
--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/features/Feature.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/features/Feature.kt
@@ -10,14 +10,13 @@ import coop.polypoly.polypod.PDFBitmap
 import java.util.zip.ZipFile
 
 class Feature(
-    val fileName: String,
+    private val fileName: String,
     val content: ZipFile,
     val context: Context,
     private val manifest: FeatureManifest?
 ) {
     val id: String get() = fileName.replace(".zip", "")
     val name: String get() = manifest?.name ?: id
-    val author: String get() = manifest?.author ?: ""
     val description: String get() = manifest?.description ?: ""
 
     val primaryColor: Int

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenFragment.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenFragment.kt
@@ -31,7 +31,7 @@ class HomeScreenFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         val sectionModels = viewModel.getSectionModels {
             findNavController().navigate(
                 HomeScreenFragmentDirections
@@ -43,15 +43,18 @@ class HomeScreenFragment : Fragment() {
                 Scaffold(
                     modifier = Modifier.padding(bottom = 10.dp),
                     topBar = {
-                        topBar(onInfoClick = {
-                            val direction = HomeScreenFragmentDirections
-                                .actionHomeScreenFragmentToOnboardingActivity()
-                            findNavController().navigate(direction)
-                        }, onSettingsClick = {
-                            val direction = HomeScreenFragmentDirections
-                                .actionHomeScreenFragmentToSettingsActivity()
-                            findNavController().navigate(direction)
-                        })
+                        topBar(
+                            onInfoClick = {
+                                val direction = HomeScreenFragmentDirections
+                                    .actionHomeScreenFragmentToOnboardingActivity() // ktlint-disable max-line-length
+                                findNavController().navigate(direction)
+                            },
+                            onSettingsClick = {
+                                val direction = HomeScreenFragmentDirections
+                                    .actionHomeScreenFragmentToSettingsActivity() // ktlint-disable max-line-length
+                                findNavController().navigate(direction)
+                            }
+                        )
                     }
                 ) {
                     createScreen(sectionModels)
@@ -281,7 +284,8 @@ fun DefaultPreview() {
         title = "Facebook Import",
         description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam", // ktlint-disable max-line-length
         image = null,
-        backgroundColor = Color.Black
+        backgroundColor = Color.Black,
+        borderColor = Color.Red
     ) {}
 
     val tileModels: List<TileModel> = listOf(
@@ -294,7 +298,7 @@ fun DefaultPreview() {
     val sections: List<SectionModel> = listOf(
         SectionModel("Your Data", SectionType.YOUR_DATA, tileModels),
         SectionModel("Data know how", SectionType.DATA_KNOW_HOW, tileModels),
-        SectionModel("Toools", SectionType.TOOLS, tileModels)
+        SectionModel("Tools", SectionType.TOOLS, tileModels)
     )
     createScreen(sectionModels = sections)
 }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenLayouts.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenLayouts.kt
@@ -18,6 +18,7 @@ data class TileLayout(
     val textBottomPadding: Dp,
     val textStartPadding: Dp,
     val textEndPadding: Dp,
+    val borderWidth: Dp,
 ) {
     companion object {
         fun smallCard(width: Float, height: Float): TileLayout {
@@ -34,7 +35,8 @@ data class TileLayout(
                 textTopPadding = 0.dp,
                 textBottomPadding = 0.dp,
                 textStartPadding = 0.dp,
-                textEndPadding = 0.dp
+                textEndPadding = 0.dp,
+                borderWidth = PolyStyle().border.size._1x
             )
         }
 
@@ -52,7 +54,8 @@ data class TileLayout(
                 textTopPadding = PolyStyle().spacing._2x,
                 textBottomPadding = PolyStyle().spacing._2x,
                 textStartPadding = PolyStyle().spacing._3x,
-                textEndPadding = PolyStyle().spacing._4x
+                textEndPadding = PolyStyle().spacing._4x,
+                borderWidth = PolyStyle().border.size._1x
             )
         }
 
@@ -70,7 +73,8 @@ data class TileLayout(
                 textTopPadding = 0.dp,
                 textBottomPadding = 0.dp,
                 textStartPadding = 0.dp,
-                textEndPadding = 0.dp
+                textEndPadding = 0.dp,
+                borderWidth = PolyStyle().border.size._1x
             )
         }
     }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenTiles.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenTiles.kt
@@ -104,7 +104,6 @@ fun BigTileView(tile: Tile) {
                 )
             }
         }
-
     }
 }
 

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenTiles.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenTiles.kt
@@ -2,6 +2,7 @@ package coop.polypoly.polypod.homescreen
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.* // ktlint-disable no-wildcard-imports
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -42,12 +43,17 @@ fun BigTileView(tile: Tile) {
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .background(tile.model.backgroundColor)
+                .border(
+                    width = tile.layout.borderWidth,
+                    color = tile.model.borderColor,
+                    shape = RoundedCornerShape(tile.layout.cornerRadius)
+                )
                 .padding(
                     top = tile.layout.topPadding,
                     start = tile.layout.startPadding,
                     end = tile.layout.endPadding,
-                    bottom = tile.layout.bottomPadding
-                )
+                    bottom = tile.layout.bottomPadding,
+                ),
         ) {
             tile.model.image?.also {
                 Image(
@@ -98,6 +104,7 @@ fun BigTileView(tile: Tile) {
                 )
             }
         }
+
     }
 }
 
@@ -116,6 +123,11 @@ fun MediumTileView(tile: Tile) {
         Row(
             modifier = Modifier
                 .background(tile.model.backgroundColor)
+                .border(
+                    width = tile.layout.borderWidth,
+                    color = tile.model.borderColor,
+                    shape = RoundedCornerShape(tile.layout.cornerRadius)
+                )
         ) {
             tile.model.image?.also {
                 Image(
@@ -185,6 +197,11 @@ fun SmallTileView(tile: Tile) {
         Column(
             modifier = Modifier
                 .background(tile.model.backgroundColor)
+                .border(
+                    width = tile.layout.borderWidth,
+                    color = tile.model.borderColor,
+                    shape = RoundedCornerShape(tile.layout.cornerRadius)
+                )
                 .padding(
                     top = tile.layout.topPadding,
                     start = tile.layout.startPadding,

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenViewModel.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenViewModel.kt
@@ -32,6 +32,7 @@ data class TileModel(
     val description: String,
     val image: Bitmap?,
     val backgroundColor: Color,
+    val borderColor: Color,
     val onSelection: () -> Unit,
 )
 
@@ -102,7 +103,8 @@ class HomeScreenViewModel {
                         feature.name,
                         feature.description,
                         feature.thumbnail,
-                        Color(feature.thumbnailColor)
+                        Color(feature.thumbnailColor),
+                        Color(feature.borderColor),
                     ) {
                         onFeatureSelected(feature.id)
                     }


### PR DESCRIPTION
Add borders specs (width, color) on the home screen tiles.

`borderColor` is specified in the manifest
`borderWidth` is part of the layout, defined in PolyStyle 

#### 🎨 
<img width="544" alt="Screenshot 2022-06-23 at 10 02 25" src="https://user-images.githubusercontent.com/2449310/175249535-63d7977f-372b-46c1-b1da-eb49c2ceca39.png">
