### PR TITLE
Revert origin check for now

### DIFF
--- a/platform/android/app/src/main/assets/container/container.js
+++ b/platform/android/app/src/main/assets/container/container.js
@@ -15,9 +15,6 @@ const queuedMessages = [];
 
 function initMessaging() {
     window.onmessage = (event) => {
-        if (window.location.href.indexOf(event.origin) === 0) {
-            return;
-        }
         // Action notifications have no port
         if (event.ports.length == 0) {
             let iFrame = document.getElementsByTagName("iframe")[0];

--- a/platform/ios/PolyPodApp/PodApi/messagePort.js
+++ b/platform/ios/PolyPodApp/PodApi/messagePort.js
@@ -1,9 +1,6 @@
 window.addEventListener("message", receiveMessage, false);
 
-function receiveMessage({ data, origin }) {
-    if (window.location.href.indexOf(origin) === 0) {
-        return;
-    }
+function receiveMessage({ data }) {
     if (data.command === "log") {
         webkit.messageHandlers[data.command].postMessage(data);
     }

--- a/platform/ios/PolyPodApp/PodApi/polyNav.js
+++ b/platform/ios/PolyPodApp/PodApi/polyNav.js
@@ -1,10 +1,4 @@
-window.addEventListener(
-    "message",
-    ({ data: { command, action }, origin }) => {
-        if (window.location.href.indexOf(origin) === 0) {
-            return;
-        }
-        if (command === "triggerPolyNavAction") pod.polyNav.actions[action]();
-    },
-    false
-);
+window.addEventListener("message", ({ data: { command, action } }) => {
+    if (command === "triggerPolyNavAction")
+        pod.polyNav.actions[action]();
+}, false);


### PR DESCRIPTION
On Android it happens that Importer features are loading due to this change(Loading spinner is shown indefinitely).
From debugging allowing I saw that `event` object does not contain the origin property.

Until we have a good approach on how to fix this, simply revert the change so importers are loading again.