### PR TITLE
Adds a test when merged

### DIFF
--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -2,7 +2,7 @@ name: Test pushes and PRs
 on:
   push:
   pull_request:
-    types: [assigned, opened, ready_for_review]
+    types: [assigned, opened, ready_for_review, closed]
 
 jobs:
   test:


### PR DESCRIPTION
This, in combination to configuration to avoid merge when tests fail, will avoid future problems that arise when a merged PR fails tests. It will have to be combined with a change in configuration that will prevent merge when tests fail.