### PR TITLE
Set the new hash in dorny/path-filters

### DIFF
--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -24,7 +24,7 @@ jobs:
             ~/.cache
           key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('package-lock.json') }}
       - name: Checks paths to rebuild Android
-        uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 #v2.10.2
+        uses: dorny/paths-filter@8c7f485a57f7cad3483dcc0fdf36122a0542f200 #v2.10.2
         id: changes
         with:
           filters: |


### PR DESCRIPTION
Re-sets the hash to the new value, to make this workflow work again