### PR TITLE
{PROD4POD-1505} Sync to make fsevents current... and failing.

### DIFF
--- a/feature-utils/poly-look/package-lock.json
+++ b/feature-utils/poly-look/package-lock.json
@@ -500,7 +500,9 @@
         "react": "^17.0.2"
       }
     },
-    "../silly-i18n": {},
+    "../silly-i18n": {
+      "name": "@polypoly-eu/silly-i18n"
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.1.2",
       "dev": true,


### PR DESCRIPTION
... and failing. The problem is that I think snyk is not able to work properly on symlinked directories in the same project. That's not the case here; in this case, `fsevents` is an optional dependency in all modules where it's included, and I think it's simply not installed. At any rate, syncing lockfiles from time to time might be a good thing; what this actually does is to include in `package-lock.json` the `silly-i18n` dep, which was empty for some reason.