### PR TITLE
Use a normalized canonical form to check the path

### DIFF
--- a/features/google/src/model/importers/utils/lang-constants.js
+++ b/features/google/src/model/importers/utils/lang-constants.js
@@ -14,5 +14,6 @@ export const langConstants = {
 };
 export function matchRegex(path, importer) {
     const importerName = importer.constructor.name;
-    return langConstants[importerName].regex.test(path);
+    const normalizedPath = path.normalize("NFC");
+    return langConstants[importerName].regex.test(normalizedPath);
 }


### PR DESCRIPTION
It's very likely that to avoid fs problems, file names do not use canonical forms. Or it might something else, I really don't know. This passes to canonical form, which should make the comparison work.