### PR TITLE
Fix importer features not loading on iOS

### DIFF
--- a/platform/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
+++ b/platform/ios/PolyPodApp/PodApi/PolyOut/FS/PolyOut+FS.swift
@@ -147,7 +147,7 @@ extension PolyOut {
             forKey: PolyOut.fsKey
         ) as? [String: [String]] ?? [:]
         // List entries of a zip file
-        if url.isEmpty {
+        if !url.isEmpty {
             let cachedEntries = readDirCache[url]
             if cachedEntries != nil {
                 completionHandler(cachedEntries, nil)


### PR DESCRIPTION
Performed the correct check.

This part of the code was refactored with https://github.com/polypoly-eu/polyPod/pull/1011/files.
The breaking change was refactoring `url != ""` to `url.isEmpty`.


P.S. We really need to have some tests asserting that Features are actually loading, this seems to be very fragile. This is the second time in a week I had to hunt down the root cause of the issue, spent like 4 hours in total just doing that...