### PR TITLE
[⚰] {PROD4POD-1730} Eliminate unused/inconsistent translation files

### DIFF
--- a/features/polyExplorer/src/locales/en/dataTypeBubble.json
+++ b/features/polyExplorer/src/locales/en/dataTypeBubble.json
@@ -1,3 +1,0 @@
-{
-    "category.translation": "Translation_EN"
-}


### PR DESCRIPTION
It's only in the `en` locale, it's not really used.