### PR TITLE
[♻] Reorganizes rollup in api to export the correct formats

### DIFF
--- a/platform/feature-api/api/rollup.config.js
+++ b/platform/feature-api/api/rollup.config.js
@@ -1,10 +1,14 @@
 import sucrase from "@rollup/plugin-sucrase";
 
 export default {
-    input: ["src/index.ts", "src/pod-api/spec.ts", "src/pod-api/index.ts"],
+    input: "src/index.ts",
     output: [
         {
-            dir: "dist",
+            file: "dist/index.es.js",
+            format: "esm",
+        },
+        {
+            file: "dist/index.js",
             format: "cjs",
         },
     ],

--- a/platform/podjs/rollup.config.js
+++ b/platform/podjs/rollup.config.js
@@ -8,7 +8,7 @@ export default [
         input: "src/index.ts",
         output: [
             {
-                file: "dist/index.es.js",
+                file: "dist/index.js",
                 format: "esm",
                 globals: {
                     "@polypoly-eu/api": "api",

--- a/platform/podjs/rollup.config.js
+++ b/platform/podjs/rollup.config.js
@@ -14,13 +14,6 @@ export default [
                     "@polypoly-eu/api": "api",
                 },
             },
-            {
-                file: "dist/index.js",
-                format: "cjs",
-                globals: {
-                    "@polypoly-eu/api": "api",
-                },
-            },
         ],
         plugins: [
             json(),


### PR DESCRIPTION
Instead of exporting it piecemeal, let's use `rollup`s tree shaking to bundle only whatever is actually needed

Eliminated also the cjs exported by pod, which is just impossible and possibly not used.

This is a follow-up to #794, which reorganized rollup for 5 modules in a single one... But that was causing problems for #989, namely problems with pod.js tests due to the incorporation of node.js files (like `buffer` in the bundle). This may or may not have caused general problems, but certainly works better now.