### PR TITLE
We don't need failing tests since they will make PRs fail

### DIFF
--- a/dev-utils/poly-cli/src/templates/package.js
+++ b/dev-utils/poly-cli/src/templates/package.js
@@ -24,7 +24,6 @@ export function packageTemplate(
             scripts: {
                 build: "rollup -c",
                 watch: "rollup --watch -c",
-                test: 'echo "Error: no test specified" && exit 1',
             },
             devDependencies: {
                 "@polypoly-eu/rollup-plugin-copy-watch":

--- a/dev-utils/poly-cli/src/templates/package.js
+++ b/dev-utils/poly-cli/src/templates/package.js
@@ -24,7 +24,7 @@ export function packageTemplate(
             scripts: {
                 build: "rollup -c",
                 watch: "rollup --watch -c",
-                test: 'echo "🚨: No tests run"'
+                test: 'echo "🚨: No tests run"',
             },
             devDependencies: {
                 "@polypoly-eu/rollup-plugin-copy-watch":

--- a/dev-utils/poly-cli/src/templates/package.js
+++ b/dev-utils/poly-cli/src/templates/package.js
@@ -24,7 +24,7 @@ export function packageTemplate(
             scripts: {
                 build: "rollup -c",
                 watch: "rollup --watch -c",
-                test: "🚨: No tests run"
+                test: 'echo "🚨: No tests run"'
             },
             devDependencies: {
                 "@polypoly-eu/rollup-plugin-copy-watch":

--- a/dev-utils/poly-cli/src/templates/package.js
+++ b/dev-utils/poly-cli/src/templates/package.js
@@ -24,6 +24,7 @@ export function packageTemplate(
             scripts: {
                 build: "rollup -c",
                 watch: "rollup --watch -c",
+                test: "🚨: No tests run"
             },
             devDependencies: {
                 "@polypoly-eu/rollup-plugin-copy-watch":


### PR DESCRIPTION
Either we add dummy tests, or we simply eliminate this. `build.js` will try to run a test if the script is present, so better to eliminate it