### PR TITLE
[♻] Improve android workflows by avoiding warnings

### DIFF
--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           java-version: 11
           distribution: "temurin"
-          cache: "maven"
+          cache: "gradle"
       - name: Build core with Android bindings
         if: steps.changes.outputs.android == 'true'
         working-directory: platform/core

--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -70,6 +70,11 @@ jobs:
           java-version: 11
           distribution: "temurin"
           cache: "gradle"
+      - name: Setup Gradle Dependencies Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
       - name: Build core with Android bindings
         if: steps.changes.outputs.android == 'true'
         working-directory: platform/core

--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -64,12 +64,12 @@ jobs:
       - name: Test core and features
         if: steps.changes.outputs.apiAndFeatures == 'true'
         run: xvfb-run --auto-servernum ./build.js test
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         if: steps.changes.outputs.android == 'true'
         with:
           java-version: 11
           distribution: "temurin"
-          cache: "gradle"
+          cache: "maven"
       - name: Build core with Android bindings
         if: steps.changes.outputs.android == 'true'
         working-directory: platform/core

--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -76,7 +76,7 @@ android {
         main {
             assets.srcDirs += file('build/generated-assets')
             java.srcDirs += file('src/main/kotlin')
-            java.srcDirs += file('src/main/java')
+            // java.srcDirs += file('src/main/java')
         }
         test {
             java.srcDirs += file('src/test/kotlin')

--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -76,7 +76,6 @@ android {
         main {
             assets.srcDirs += file('build/generated-assets')
             java.srcDirs += file('src/main/kotlin')
-            // java.srcDirs += file('src/main/java')
         }
         test {
             java.srcDirs += file('src/test/kotlin')

--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -150,7 +150,7 @@ dependencies {
     testImplementation 'junit:junit:4.13'   // yuck...
     testImplementation 'androidx.test.ext:junit:1.1.3'
     testImplementation 'androidx.test:runner:1.4.0'
-    testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation 'org.robolectric:robolectric:4.8'
     testImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     testImplementation 'androidx.test:runner:1.4.0'
     testImplementation 'androidx.test:rules:1.4.0'

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/FeatureContainer.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/FeatureContainer.kt
@@ -144,7 +144,7 @@ class FeatureContainer(context: Context, attrs: AttributeSet? = null) :
 
         val regex = """(Chrome)\/(?<major>\d+)[\d\.]""".toRegex()
         val matchResult = regex.find(userAgentString)
-        val (_chrome, chromeVersion) = matchResult!!.destructured
+        val (_, chromeVersion) = matchResult!!.destructured
 
         if (chromeVersion.toInt() <= 53) {
             val message = context.getString(

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/FeatureContainer.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/FeatureContainer.kt
@@ -288,7 +288,7 @@ class FeatureContainer(context: Context, attrs: AttributeSet? = null) :
                     FeatureStorage.activeFeatureId + ": " +
                     consoleMessage.messageLevel() + ": " +
                     consoleMessage.message()
-                when (consoleMessage?.messageLevel()) {
+                when (consoleMessage.messageLevel()) {
                     ConsoleMessage.MessageLevel.ERROR,
                     ConsoleMessage.MessageLevel.WARNING ->
                         logger.warn(message)

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/PodApi.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/PodApi.kt
@@ -276,8 +276,7 @@ open class PodApi(
         }
         val data = endpoint
             .get(endpointId, contentType, authorization)
-        return if (data == null) ValueFactory.newNil()
-        else ValueFactory.newString(data)
+        return ValueFactory.newString(data)
     }
 
     private fun decodePolyOutFetchCallArgs(args: Value): FetchInit {

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/endpoint/Endpoint.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/endpoint/Endpoint.kt
@@ -37,11 +37,11 @@ class Endpoint(
         return endpointsJson[endpointId]
     }
 
-    open fun setEndpointObserver(newObserver: EndpointObserver) {
+    fun setEndpointObserver(newObserver: EndpointObserver) {
         observer = newObserver
     }
 
-    open suspend fun send(
+    suspend fun send(
         endpointId: String,
         body: String,
         contentType: String?,
@@ -75,7 +75,7 @@ class Endpoint(
         }
     }
 
-    open suspend fun get(
+    suspend fun get(
         endpointId: String,
         contentType: String?,
         authToken: String?

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
@@ -42,6 +42,7 @@ open class Network(val context: Context) {
             connection.disconnect()
             return@withContext response
         }
+        return@withContext response
     }
 
     open suspend fun httpGet(

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
@@ -42,7 +42,6 @@ open class Network(val context: Context) {
             connection.disconnect()
             return@withContext response
         }
-        return@withContext response
     }
 
     open suspend fun httpGet(


### PR DESCRIPTION
Several things done here:

* :arrow_up: Upgrade `java-setup` to latest version. Old version was taking a long time in the Ubuntu runner, a looooong time in the iOS runner.
* :arrow_double_up: Upgrade `robolectric` to try and avoid reflection warnings. It was several minors behind anyway.
* :rotating_light: Fixing some linting errors that were revealed by the gradle build (not by the Kotlin linter), mainly to trigger new builds.
* :gear: Set up a cache for gradle