### PR TITLE
:arrow_up: to medium

### DIFF
--- a/features/polyTalkPreview/src/styles.css
+++ b/features/polyTalkPreview/src/styles.css
@@ -41,7 +41,7 @@
 }
 
 .preview h1 {
-    font-family: var(--jost);
+    font-family: var(--jost-medium);
     font-size: var(--font-size-xxl);
     margin-bottom: calc(var(--gdu) * 8);
     margin-top: calc(var(--gdu) * 8);
@@ -49,7 +49,7 @@
 }
 
 .section-title {
-    font-family: var(--jost);
+    font-family: var(--jost-medium);
     font-size: var(--font-size-xl);
     line-height: var(--line-height);
     margin-bottom: 0;


### PR DESCRIPTION
Headlines and subheadlines should have `medium` weight
![Captura de pantalla de 2022-07-06 10-47-42](https://user-images.githubusercontent.com/500/177510031-0c7aacaf-e1e4-44e4-bf77-4d3f14dced39.png)
