### PR TITLE
Split iOS tests

### DIFF
--- a/.github/workflows/daily-instrumentation-test.yml
+++ b/.github/workflows/daily-instrumentation-test.yml
@@ -1,0 +1,43 @@
+name: polyPod Android integration test
+on:
+    schedule:
+      - cron: '31 23 * * *'
+
+jobs:
+    test:
+        name: Test polyPod iOS and Android app
+        runs-on: macOS-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 16
+                  cache: "npm"
+                  cache-dependency-path: "**/package-lock.json"
+            - name: Cache JS dependencies
+              uses: actions/cache@v2
+              id: cache
+              with:
+                  path: "**/node_modules"
+                  key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+            - name: Install modules if needed
+              if: steps.cache.outputs.cache-hit != 'true'
+              run: ./build.js install
+            - name: Build API and features
+              run: ./build.js build
+            - name: Build core
+              working-directory: platform/core
+              run: make
+            - uses: actions/setup-java@v2
+              with:
+                  distribution: 'zulu'
+                  java-version: 11
+                  cache: 'gradle'
+            - name: Test Android
+              uses: ReactiveCircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
+              with:
+                working-directory: platform/android
+                arch: 'x86_64'
+                api-level: 30
+                script: ./gradlew connectedAndroidTest

--- a/.github/workflows/daily-instrumentation-test.yml
+++ b/.github/workflows/daily-instrumentation-test.yml
@@ -1,7 +1,7 @@
 name: polyPod Android integration test
 on:
     schedule:
-      - cron: '31 23 * * *'
+      - cron: '31 13 * * *'
 
 jobs:
     test:

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -1,4 +1,4 @@
-name: polyPod iOS/Android integration test
+name: polyPod iOS test
 on:
     push:
         paths:
@@ -48,21 +48,3 @@ jobs:
             - name: Build and test iOS
               working-directory: platform/ios
               run: make test
-            - uses: actions/setup-java@v2
-              if: |
-                !github.head_ref
-                && ( startsWith(github.ref, 'refs/heads/release') == true || github.ref == 'refs/heads/main' )
-              with:
-                  distribution: 'zulu'
-                  java-version: 11
-                  cache: 'gradle'
-            - name: Test Android
-              uses: ReactiveCircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
-              if: |
-                !github.head_ref
-                && ( startsWith(github.ref, 'refs/heads/release') == true || github.ref == 'refs/heads/main' )
-              with:
-                working-directory: platform/android
-                arch: 'x86_64'
-                api-level: 30
-                script: ./gradlew connectedAndroidTest

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -7,7 +7,6 @@ on:
             - "platform/feature-api/**"
             - "platform/core/**"
             - "platform/ios/**"
-            - "platform/android/**"
     pull_request:
         types: [assigned, opened, ready_for_review]
         paths:
@@ -16,7 +15,6 @@ on:
             - "platform/core/**"
             - "platform/feature-api/**"
             - "platform/ios/**"
-            - "platform/android/**"
 jobs:
     test:
         name: Test polyPod iOS and Android app


### PR DESCRIPTION
Android tests take place in the MacOS runner, which takes a lot and is quite unreliable, and adding insult to injury, it might take up to 4 minutes to set up Java, bringing everything to just south (and sometimes north) of 40 minutes [like here](https://github.com/polypoly-eu/polyPod/runs/7216940598?check_suite_focus=true).
All in all, running those instrumentation tests every time does not make a lot of sense. Besides, I don't think they've ever failed, maybe because they will only catch very catastrophic errors. So this PR splits them in two different github actions, one that will just test iOS (that can't be helped), and another scheduled to be triggered every afternoon that will run the instrumentation tests. We can still run them manually if we want, but we will not have to wait 20 minutes *more* for the Swift/iOS tests to be completed.