### PR TITLE
⌛ Eliminate test failures due to timeouts in pod.js

### DIFF
--- a/platform/podjs/cypress.json
+++ b/platform/podjs/cypress.json
@@ -1,4 +1,5 @@
 {
     "pluginsFile": false,
-    "video": false
+    "video": false,
+    "defaultCommandTimeout": 12000
 }


### PR DESCRIPTION
Occasionally, [pod.js tests time out](https://github.com/polypoly-eu/polyPod/runs/7216821167?check_suite_focus=true) since some commands take a lot of time (4 seconds, sometimes even more)

> It *always* times out locally in my desktop, so this might or might not hide a bug

However, to avoid these timeouts we will just increase the time out for the time being. Maybe investigate the matter further down the line. I have tripled the [default  value](https://docs.cypress.io/guides/references/legacy-configuration#Timeouts). Such a big timeout is probably not needed, but if it does not work, it will not work anyway, and will give us some leeway.