### PR TITLE
fix translation strings bug on settings view - ios

### DIFF
--- a/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     var closeAction: () -> Void = {}
     @State private var activeSection = Sections.main
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             NavigationBar(
@@ -11,20 +11,7 @@ struct SettingsView: View {
                     Image("NavIconBackDark").renderingMode(.original)
                 }),
                 center: AnyView(
-                    Text({ () -> String in
-                        switch activeSection {
-                        case .main:
-                            return "settings_title"
-                        case .imprint:
-                            return "settings_imprint_title"
-                        case .privacyPolicy:
-                            return "settings_privacy_policy_title"
-                        case .termsOfUse:
-                            return "settings_terms_of_use_title"
-                        case .licenses:
-                            return "settings_licenses_title"
-                        }
-                    }())
+                    Text(activeSection.title())
                     .foregroundColor(Color.PolyPod.darkForeground)
                     .font(.custom("Jost-Medium", size: 16))
                     .kerning(-0.16)
@@ -60,6 +47,23 @@ struct SettingsView: View {
 
 private enum Sections {
     case main, imprint, privacyPolicy, termsOfUse, licenses
+}
+
+extension Sections {
+    func title() -> LocalizedStringKey {
+        switch self {
+        case .main:
+            return "settings_title"
+        case .imprint:
+            return "settings_imprint_title"
+        case .privacyPolicy:
+            return "settings_privacy_policy_title"
+        case .termsOfUse:
+            return "settings_terms_of_use_title"
+        case .licenses:
+            return "settings_licenses_title"
+        }
+    }
 }
 
 struct SettingsView_Previews: PreviewProvider {


### PR DESCRIPTION
Fix of the bug 🐛 having translation strings instead of real text on the titles of SettingsView page on iOS devices.

This bug was introduced after the upgrade to iOs 14, with the use of `() -> String in` inside the `Τext` οbject.

To fix this, we add an `extension` of `Section`, so we compute property of title instead of having an ugly switch on the view. we then can call directly `activeSection.title()`


### Before:
<img width="371" alt="Screenshot 2022-07-07 at 17 48 05" src="https://user-images.githubusercontent.com/2449310/177818416-360ee9ba-b4ae-4c2a-9f8b-c7a12b74bedd.png">
<img width="377" alt="Screenshot 2022-07-07 at 17 48 11" src="https://user-images.githubusercontent.com/2449310/177818427-d9bf59b0-8521-47cd-b941-a81bb7926c5a.png">
<img width="392" alt="Screenshot 2022-07-07 at 17 48 21" src="https://user-images.githubusercontent.com/2449310/177818433-e64ebed4-9baa-474a-b7ee-95618b5156d9.png">


### After:

<img width="380" alt="Screenshot 2022-07-07 at 17 52 24" src="https://user-images.githubusercontent.com/2449310/177818435-5377658d-38a2-4b50-b1cd-094c5aafdb2b.png">
<img width="379" alt="Screenshot 2022-07-07 at 17 52 30" src="https://user-images.githubusercontent.com/2449310/177818437-a106f26a-210d-44b3-8724-0c55dcf35299.png">
<img width="381" alt="Screenshot 2022-07-07 at 17 52 45" src="https://user-images.githubusercontent.com/2449310/177818440-6a3e92c5-858c-44c4-b2eb-4674c9c5f603.png">
<img width="377" alt="Screenshot 2022-07-07 at 17 52 53" src="https://user-images.githubusercontent.com/2449310/177818444-4f44b9f0-db22-42a8-b54f-f5e6a4aa6f29.png">



