### PR TITLE
fix - remove onboarding screen on settings triggering in iOS - PROD4POD-1663

### DIFF
--- a/platform/ios/PolyPodApp/PolyPod/Authentication.swift
+++ b/platform/ios/PolyPodApp/PolyPod/Authentication.swift
@@ -25,10 +25,11 @@ class Authentication {
     }
 
     private func isAvailable() -> Bool {
-        return !isSimulator() && LAContext().canEvaluatePolicy(
-            .deviceOwnerAuthentication,
-            error: nil
-        )
+        return !isSimulator() && 
+            LAContext().canEvaluatePolicy(
+                .deviceOwnerAuthentication,
+                error: nil
+            )
     }
 
     func disableCheck() {

--- a/platform/ios/PolyPodApp/PolyPod/ContentView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/ContentView.swift
@@ -77,10 +77,12 @@ struct ContentView: View {
         notification.handleFirstRun()
         return ViewState(
             AnyView(
-                OnboardingView(closeAction: {
-                    FirstRun.write(false)
-                    state = featureListState()
-                })
+                OnboardingView(
+                    closeAction: {
+                        FirstRun.write(false)
+                        state = featureListState()
+                    }
+                )
             )
         )
     }
@@ -104,17 +106,7 @@ struct ContentView: View {
                 )
             )
         }
-
-        return ViewState(
-            AnyView(
-                OnboardingView(
-                    securityOnly: true,
-                    closeAction: {
-                        state = featureListState()
-                    }
-                )
-            )
-        )
+        return featureListState() 
     }
 
     private func featureListState() -> ViewState {
@@ -171,9 +163,11 @@ struct ContentView: View {
     private func infoState() -> ViewState {
         ViewState(
             AnyView(
-                OnboardingView(closeAction: {
-                    state = featureListState()
-                })
+                OnboardingView(
+                    closeAction: {
+                        state = featureListState()
+                    }
+                )
             )
         )
     }

--- a/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
+++ b/platform/ios/PolyPodApp/PolyPod/SettingsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     var closeAction: () -> Void = {}
     @State private var activeSection = Sections.main
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             NavigationBar(
@@ -31,9 +31,9 @@ struct SettingsView: View {
                 )
             )
             .background(Color.PolyPod.lightBackground)
-            
+
             Divider()
-            
+
             switch activeSection {
             case .main:
                 MainSection(activeSection: $activeSection)
@@ -48,7 +48,7 @@ struct SettingsView: View {
             }
         }
     }
-    
+
     private func back() {
         if activeSection == .main {
             closeAction()
@@ -73,7 +73,7 @@ private struct MainSection: View {
     @State private var showVersion = false
     @State private var shareLogs = false
     @State private var isAuthenticationConfigured = Authentication.shared.isSetUp()
-    
+
     var body: some View {
         List {
             Section(header: SettingsHeader("settings_about_section")) {
@@ -91,7 +91,7 @@ private struct MainSection: View {
             .listRowInsets(
                 EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
             )
-            
+
             Section(header: SettingsHeader("settings_sec_section")) {
                 SettingsToggleButton(
                     label: "settings_auth",
@@ -108,7 +108,7 @@ private struct MainSection: View {
             .listRowInsets(
                 EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
             )
-            
+
             Section(header: SettingsHeader("settings_legal_section")) {
                 SettingsButton(
                     label: "settings_imprint_title",
@@ -129,8 +129,8 @@ private struct MainSection: View {
                 if !RuntimeInfo.isProduction {
                     SettingsButton(label: "settings_export_logs",
                                    action: {
-                        shareLogs = true
-                    })
+                                    shareLogs = true
+                                   })
                 }
             }
             .listRowInsets(
@@ -144,11 +144,11 @@ private struct MainSection: View {
 
 private struct SettingsHeader: View {
     private let text: LocalizedStringKey
-    
+
     init(_ text: LocalizedStringKey) {
         self.text = text
     }
-    
+
     var body: some View {
         Text(text)
             .foregroundColor(Color(fromHex: "#3E495B"))
@@ -167,7 +167,7 @@ private struct SettingsHeader: View {
 private struct SettingsButton: View {
     let label: LocalizedStringKey
     let action: () -> Void
-    
+
     var body: some View {
         Button(action: action) {
             Text(label)
@@ -181,9 +181,9 @@ private struct SettingsButton: View {
 private struct SettingsToggleButton: View {
     let label: LocalizedStringKey
     let isToggled: Binding<Bool>
-    
+
     var onChange: ((Bool) -> Void)?
-    
+
     var body: some View {
         VStack {
             Toggle(isOn: isToggled.onChange(toggleChange)) {
@@ -195,20 +195,20 @@ private struct SettingsToggleButton: View {
             .padding(.trailing, 32)
         }.padding(.leading, 32)
     }
-    
+
     func toggleChange(_ value: Bool) {
         if let action = self.onChange {
             action(value)
         }
     }
-    
+
 }
 
 private struct PrivacyPolicyView: View {
     var body: some View {
         HTMLView(content: loadPrivacyPolicyText())
     }
-    
+
     private func loadPrivacyPolicyText() -> String {
         let url = Bundle.main.bundleURL
             .appendingPathComponent("legal")
@@ -234,7 +234,7 @@ private struct LicensesView: View {
             alignment: .topLeading
         )
     }
-    
+
     private func loadLicenseText() -> String {
         let licenseFiles = ["ios-licenses.txt", "js-licenses.txt"]
         let licensesUrl = Bundle.main.bundleURL


### PR DESCRIPTION
### 🔧 
Τo reflect the diagram https://wiki.polypoly.eu/display/POLYPOD/system+lock+for+polyPod of the authentication as requested by security, we remove the show of `onboardingView` when the settings are triggered, case 2.0 of diagram, (`securityReminderState()`)  and show instead directly the main screen with the features list.

(rest of changes are minor linting fixes 🧹 )
