### PR TITLE
fix: prod4pod-1741 - removed max-width from SideSheet

### DIFF
--- a/feature-utils/poly-look/src/react-components/overlays/sideSheet.css
+++ b/feature-utils/poly-look/src/react-components/overlays/sideSheet.css
@@ -1,6 +1,4 @@
 .poly-side-sheet {
-  max-width: var(--max-width);
-  position: absolute;
   width: 100%;
   height: 100%;
   background-color: var(--color-gray-100);

--- a/feature-utils/poly-look/src/react-components/overlays/sideSheet.jsx
+++ b/feature-utils/poly-look/src/react-components/overlays/sideSheet.jsx
@@ -42,7 +42,11 @@ const SideSheet = ({
       {children}
 
       <div className="button-holder">
-        <PolyButton label={okLabel} onClick={onClose} />
+        <PolyButton
+          className="poly-self-centered"
+          label={okLabel}
+          onClick={onClose}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
By removing max-width we ensure that when we'll operate on larger viewports the htrt screens using this component will function correctly.