### PR TITLE
Ignore all public in lexicon

### DIFF
--- a/features/lexicon/.gitignore
+++ b/features/lexicon/.gitignore
@@ -1,4 +1,1 @@
-/public/build/
-/public/pod.js
-/public/poly-look.css
-/public/fonts
+/public


### PR DESCRIPTION
Why isn't just all public ignored here?