### PR TITLE
fix: show reauth texts on onboarding screen [android] - PROD4POD-1698

### DIFF
--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
@@ -75,7 +75,7 @@ class OnboardingActivity : AppCompatActivity() {
                 button.setOnClickListener {
                     Authentication.setUp(
                         this,
-                        showAuthTexts = true,
+                        showAuthTexts = false,
                         newBiometricState = true
                     ) {
                         close()


### PR DESCRIPTION
🐞 Change the text used during onboarding to be "Authenticate to continue". 

just need to call the `Authentication.setUp` with `false` `showAuthTexts` param so we show the `reauth` texts when on onboarding.