### PR TITLE
fix - authentication flow in Android - [PROD4POD-1663]

### DIFF
--- a/platform/android/app/src/androidTest/kotlin/coop/polypoly/polypod/UpdateNotificationTest.kt
+++ b/platform/android/app/src/androidTest/kotlin/coop/polypoly/polypod/UpdateNotificationTest.kt
@@ -49,7 +49,7 @@ class UpdateNotificationTest {
         PreferenceManager.getDefaultSharedPreferences(context)
             .edit().clear().commit()
         Preferences.setFirstRun(context, false)
-        Preferences.setBiometricCheck(context, false)
+        Preferences.setSecurityDoNotAskAgainCheck(context, true)
     }
 
     @After

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -45,12 +45,12 @@ class Authentication {
                         activity,
                         newBiometricState
                     )
-                   if (newBiometricState) {
-                       Preferences.setUserConfiguredAuthentication(
-                           activity.applicationContext,
-                           true
-                       )
-                   }
+                    if (newBiometricState) {
+                        Preferences.setUserConfiguredAuthentication(
+                            activity.applicationContext,
+                            true
+                        )
+                    }
                 }
                 setupComplete()
             }
@@ -69,9 +69,6 @@ class Authentication {
                 authComplete(true)
                 return
             }
-
-            if (!showAuthTexts)
-                MainActivity.onboardingShown = true
 
             val title =
                 if (showAuthTexts)

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -22,7 +22,7 @@ class Authentication {
                 !Preferences.isFirstRun(context)
         }
 
-        fun shouldAuthenticate(context: Context): Boolean {
+        fun canAuthenticate(context: Context): Boolean {
             return biometricsAvailable(context) &&
                 Preferences.isBiometricEnabled(context) &&
                 !isAuthenticated
@@ -62,6 +62,9 @@ class Authentication {
                 authComplete(true)
                 return
             }
+
+            if (!showAuthTexts)
+                MainActivity.onboardingShown = true
 
             val title =
                 if (showAuthTexts)

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Authentication.kt
@@ -15,9 +15,10 @@ class Authentication {
             BiometricManager.Authenticators.BIOMETRIC_WEAK or
                 BiometricManager.Authenticators.DEVICE_CREDENTIAL
 
-        fun shouldShowBiometricsPrompt(context: Context): Boolean {
+        fun shouldShowAuthOnboarding(context: Context): Boolean {
             return biometricsAvailable(context) &&
-                Preferences.isBiometricCheck(context) &&
+                !Preferences.hasUserConfiguredAuthentication(context) &&
+                !Preferences.isSecurityDoNotAskAgainEnabled(context) &&
                 !Preferences.isBiometricEnabled(context) &&
                 !Preferences.isFirstRun(context)
         }
@@ -44,6 +45,12 @@ class Authentication {
                         activity,
                         newBiometricState
                     )
+                   if (newBiometricState) {
+                       Preferences.setUserConfiguredAuthentication(
+                           activity.applicationContext,
+                           true
+                       )
+                   }
                 }
                 setupComplete()
             }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -33,10 +33,7 @@ class MainActivity : AppCompatActivity() {
                 return
             }
 
-            logger.error(
-                "Failed to boostrap core",
-                ex.message
-            )
+            logger.error("Failed to boostrap core", ex.message)
             throw ex
         }
 
@@ -56,23 +53,13 @@ class MainActivity : AppCompatActivity() {
             notification.handleFirstRun()
         }
 
-        val shouldShowOnboarding =
-            firstRun || Authentication.shouldShowBiometricsPrompt(this)
+        val shouldShowOnboarding = firstRun ||
+            Authentication.shouldShowBiometricsPrompt(this)
         if (!onboardingShown && shouldShowOnboarding) {
             onboardingShown = true
-            startActivity(
-                Intent(
-                    this,
-                    OnboardingActivity::class.java
-                )
-            )
+            startActivity(Intent(this, OnboardingActivity::class.java))
         } else if (Authentication.shouldAuthenticate(this)) {
-            startActivity(
-                Intent(
-                    this,
-                    PodUnlockActivity::class.java
-                )
-            )
+            startActivity(Intent(this, PodUnlockActivity::class.java))
         }
 
         if (notification.showInApp) {

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -15,8 +15,9 @@ class MainActivity : AppCompatActivity() {
     companion object {
         @Suppress("JAVA_CLASS_ON_COMPANION")
         private val logger = LoggerFactory.getLogger(javaClass.enclosingClass)
-        var onboardingShown = false
     }
+
+    private var onboardingShown = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -57,7 +58,7 @@ class MainActivity : AppCompatActivity() {
         if (!onboardingShown && shouldShowAuthOnboarding) {
             onboardingShown = true
             startActivity(Intent(this, OnboardingActivity::class.java))
-        }  else if (Authentication.canAuthenticate(this)) {
+        } else if (Authentication.canAuthenticate(this)) {
             startActivity(Intent(this, PodUnlockActivity::class.java))
         }
 

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -9,7 +9,6 @@ import coop.polypoly.core.CoreAlreadyBootstrappedException
 import coop.polypoly.polypod.core.UpdateNotification
 import coop.polypoly.polypod.features.FeatureStorage
 import coop.polypoly.polypod.logging.LoggerFactory
-import java.lang.Exception
 
 @ExperimentalUnsignedTypes
 class MainActivity : AppCompatActivity() {
@@ -52,15 +51,13 @@ class MainActivity : AppCompatActivity() {
             notification.handleFirstRun()
         }
 
-        val shouldShowBiometricsPrompt =
-            Authentication.shouldShowBiometricsPrompt(this)
+        val shouldShowAuthOnboarding = firstRun ||
+            Authentication.shouldShowAuthOnboarding(this)
 
-        if (!onboardingShown && (firstRun || shouldShowBiometricsPrompt)) {
+        if (!onboardingShown && shouldShowAuthOnboarding) {
             onboardingShown = true
             startActivity(Intent(this, OnboardingActivity::class.java))
-        } else if (onboardingShown && shouldShowBiometricsPrompt) {
-            startActivity(Intent(this, OnboardingActivity::class.java))
-        } else if (Authentication.canAuthenticate(this)) {
+        }  else if (Authentication.canAuthenticate(this)) {
             startActivity(Intent(this, PodUnlockActivity::class.java))
         }
 

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -11,6 +11,7 @@ import coop.polypoly.polypod.features.FeatureStorage
 import coop.polypoly.polypod.logging.LoggerFactory
 import java.lang.Exception
 
+@ExperimentalUnsignedTypes
 class MainActivity : AppCompatActivity() {
     companion object {
         @Suppress("JAVA_CLASS_ON_COMPANION")

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -53,12 +53,17 @@ class MainActivity : AppCompatActivity() {
             notification.handleFirstRun()
         }
 
-//        val shouldShowOnboarding = firstRun ||
-//            Authentication.shouldShowBiometricsPrompt(this)
+        val shouldShowOnboarding = firstRun ||
+            Authentication.shouldShowBiometricsPrompt(this)
         if (!onboardingShown && firstRun) {
             onboardingShown = true
             startActivity(Intent(this, OnboardingActivity::class.java))
-        } else if (Authentication.shouldAuthenticate(this)) {
+        }
+        else if (!onboardingShown && shouldShowOnboarding) {
+            onboardingShown = true
+            startActivity(Intent(this, OnboardingActivity::class.java))
+        }
+        else if (Authentication.shouldAuthenticate(this)) {
             startActivity(Intent(this, PodUnlockActivity::class.java))
         }
 

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -52,23 +52,28 @@ class MainActivity : AppCompatActivity() {
             notification.handleFirstRun()
         }
 
-        val shouldShowOnboarding = Authentication.shouldShowBiometricsPrompt(this)
+        val shouldShowBiometricsPrompt =
+            Authentication.shouldShowBiometricsPrompt(this)
 
-        if (!onboardingShown && (firstRun || shouldShowOnboarding)) {
+        if (!onboardingShown && (firstRun || shouldShowBiometricsPrompt)) {
             onboardingShown = true
+            startActivity(Intent(this, OnboardingActivity::class.java))
+        } else if (onboardingShown && shouldShowBiometricsPrompt) {
             startActivity(Intent(this, OnboardingActivity::class.java))
         } else if (Authentication.canAuthenticate(this)) {
             startActivity(Intent(this, PodUnlockActivity::class.java))
         }
-        
+
         if (notification.showInApp) {
             AlertDialog.Builder(this)
-                    .setTitle(notification.title)
-                    .setMessage(notification.text)
-                    .setPositiveButton(R.string.button_update_notification_close) { _, _ ->
-                        notification.handleInAppSeen()
-                    }
-                    .show()
+                .setTitle(notification.title)
+                .setMessage(notification.text)
+                .setPositiveButton(
+                    R.string.button_update_notification_close
+                ) { _, _ ->
+                    notification.handleInAppSeen()
+                }
+                .show()
         }
     }
 }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -53,9 +53,9 @@ class MainActivity : AppCompatActivity() {
             notification.handleFirstRun()
         }
 
-        val shouldShowOnboarding = firstRun ||
-            Authentication.shouldShowBiometricsPrompt(this)
-        if (!onboardingShown && shouldShowOnboarding) {
+//        val shouldShowOnboarding = firstRun ||
+//            Authentication.shouldShowBiometricsPrompt(this)
+        if (!onboardingShown && firstRun) {
             onboardingShown = true
             startActivity(Intent(this, OnboardingActivity::class.java))
         } else if (Authentication.shouldAuthenticate(this)) {

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -16,9 +16,8 @@ class MainActivity : AppCompatActivity() {
     companion object {
         @Suppress("JAVA_CLASS_ON_COMPANION")
         private val logger = LoggerFactory.getLogger(javaClass.enclosingClass)
+        var onboardingShown = false
     }
-
-    private var onboardingShown = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -53,30 +52,23 @@ class MainActivity : AppCompatActivity() {
             notification.handleFirstRun()
         }
 
-        val shouldShowOnboarding = firstRun ||
-            Authentication.shouldShowBiometricsPrompt(this)
-        if (!onboardingShown && firstRun) {
+        val shouldShowOnboarding = Authentication.shouldShowBiometricsPrompt(this)
+
+        if (!onboardingShown && (firstRun || shouldShowOnboarding)) {
             onboardingShown = true
             startActivity(Intent(this, OnboardingActivity::class.java))
-        }
-        else if (!onboardingShown && shouldShowOnboarding) {
-            onboardingShown = true
-            startActivity(Intent(this, OnboardingActivity::class.java))
-        }
-        else if (Authentication.shouldAuthenticate(this)) {
+        } else if (Authentication.canAuthenticate(this)) {
             startActivity(Intent(this, PodUnlockActivity::class.java))
         }
-
+        
         if (notification.showInApp) {
             AlertDialog.Builder(this)
-                .setTitle(notification.title)
-                .setMessage(notification.text)
-                .setPositiveButton(
-                    R.string.button_update_notification_close
-                ) { _, _ ->
-                    notification.handleInAppSeen()
-                }
-                .show()
+                    .setTitle(notification.title)
+                    .setMessage(notification.text)
+                    .setPositiveButton(R.string.button_update_notification_close) { _, _ ->
+                        notification.handleInAppSeen()
+                    }
+                    .show()
         }
     }
 }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
@@ -40,7 +40,7 @@ class OnboardingActivity : AppCompatActivity() {
         )
 
         if (!isInfo) {
-            if (Authentication.shouldShowBiometricsPrompt(this)) {
+            if (Authentication.shouldShowAuthOnboarding(this)) {
                 strings = strings.plus(
                     mapOf(
                         R.id.headline_main to
@@ -85,7 +85,7 @@ class OnboardingActivity : AppCompatActivity() {
                 )
                 doNotAskButton.visibility = View.VISIBLE
                 doNotAskButton.setOnClickListener {
-                    Preferences.setBiometricCheck(this, false)
+                    Preferences.setSecurityDoNotAskAgainCheck(this, true)
                     close()
                 }
             }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
@@ -100,7 +100,7 @@ class OnboardingActivity : AppCompatActivity() {
                     if (carousel.currentItem == (carousel.pageCount - 1)) {
                         close()
                     } else {
-                        carousel.setCurrentItem(carousel.currentItem + 1)
+                        carousel.currentItem = carousel.currentItem + 1
                     }
                 }
             }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/OnboardingActivity.kt
@@ -59,10 +59,9 @@ class OnboardingActivity : AppCompatActivity() {
 
         carousel.pageCount = strings.size
         carousel.setViewListener { requestedPosition ->
-            val position = requestedPosition
 
             val slide = layoutInflater.inflate(R.layout.onboarding_slide, null)
-            strings[position].forEach { (viewId, stringId) ->
+            strings[requestedPosition].forEach { (viewId, stringId) ->
                 slide.findViewById<TextView>(viewId).text = getString(stringId)
             }
             if (slide.findViewById<TextView>(R.id.headline_main).text ==

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
@@ -12,6 +12,7 @@ class Preferences {
         private const val lastNotificationStateKey = "lastNotificationState"
         private const val biometricCheckKey = "biometricCheck"
         private const val biometricEnabledKey = "biometricEnabledKey"
+        private const val userConfiguredAuth = "userConfiguredAuth "
         private const val fsKey = ""
 
         private fun getPrefs(context: Context) =
@@ -40,14 +41,23 @@ class Preferences {
             edit.commit()
         }
 
-        fun setBiometricCheck(context: Context, shouldCheck: Boolean) {
+        fun setSecurityDoNotAskAgainCheck(context: Context, shouldCheck: Boolean) {
             val edit = getPrefs(context).edit()
             edit.putBoolean(biometricCheckKey, shouldCheck)
             edit.commit()
         }
 
-        fun isBiometricCheck(context: Context): Boolean =
-            getPrefs(context).getBoolean(biometricCheckKey, true)
+        fun hasUserConfiguredAuthentication(context: Context): Boolean =
+            getPrefs(context).getBoolean(userConfiguredAuth, false)
+
+        fun setUserConfiguredAuthentication(context: Context, shouldCheck: Boolean) {
+            val edit = getPrefs(context).edit()
+            edit.putBoolean(userConfiguredAuth, shouldCheck)
+            edit.commit()
+        }
+
+        fun isSecurityDoNotAskAgainEnabled(context: Context): Boolean =
+            getPrefs(context).getBoolean(biometricCheckKey, false)
 
         fun setBiometricEnabled(context: Context, shouldCheck: Boolean) {
             val edit = getPrefs(context).edit()

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
@@ -12,7 +12,7 @@ class Preferences {
         private const val lastNotificationStateKey = "lastNotificationState"
         private const val biometricCheckKey = "biometricCheck"
         private const val biometricEnabledKey = "biometricEnabledKey"
-        private const val userConfiguredAuth = "userConfiguredAuth "
+        private const val userConfiguredAuth = "userConfiguredAuth"
         private const val fsKey = ""
 
         private fun getPrefs(context: Context) =
@@ -50,6 +50,9 @@ class Preferences {
             edit.commit()
         }
 
+        fun isSecurityDoNotAskAgainEnabled(context: Context): Boolean =
+            getPrefs(context).getBoolean(biometricCheckKey, false)
+
         fun hasUserConfiguredAuthentication(context: Context): Boolean =
             getPrefs(context).getBoolean(userConfiguredAuth, false)
 
@@ -61,9 +64,6 @@ class Preferences {
             edit.putBoolean(userConfiguredAuth, shouldCheck)
             edit.commit()
         }
-
-        fun isSecurityDoNotAskAgainEnabled(context: Context): Boolean =
-            getPrefs(context).getBoolean(biometricCheckKey, false)
 
         fun setBiometricEnabled(context: Context, shouldCheck: Boolean) {
             val edit = getPrefs(context).edit()

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/Preferences.kt
@@ -41,7 +41,10 @@ class Preferences {
             edit.commit()
         }
 
-        fun setSecurityDoNotAskAgainCheck(context: Context, shouldCheck: Boolean) {
+        fun setSecurityDoNotAskAgainCheck(
+            context: Context,
+            shouldCheck: Boolean
+        ) {
             val edit = getPrefs(context).edit()
             edit.putBoolean(biometricCheckKey, shouldCheck)
             edit.commit()
@@ -50,7 +53,10 @@ class Preferences {
         fun hasUserConfiguredAuthentication(context: Context): Boolean =
             getPrefs(context).getBoolean(userConfiguredAuth, false)
 
-        fun setUserConfiguredAuthentication(context: Context, shouldCheck: Boolean) {
+        fun setUserConfiguredAuthentication(
+            context: Context,
+            shouldCheck: Boolean
+        ) {
             val edit = getPrefs(context).edit()
             edit.putBoolean(userConfiguredAuth, shouldCheck)
             edit.commit()


### PR DESCRIPTION
🔧 fixes security onboarding screen being shown after just disabling authentication

we introduce a new key for `userConfiguredAuth` to mark that user has successfully configured authentication on onboarding prompt
and distinguish from the option "do not ask anymore".
setting this new value makes it possible to check properly and not showing anymore the onboarding when the configuration is off.

+ some more readable namings on vars/functions, and other small nits refactors on the way

co-authored & tested by 🧪 @GhenadiePusca 