### PR TITLE
[🐛] {PROD4POD-1779} Try to fix lockfile-hashing timeout

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -7,6 +7,7 @@ on:
             - "platform/feature-api/**"
             - "platform/core/**"
             - "platform/ios/**"
+            - ".github/workflows/ios-test.yml"
     pull_request:
         types: [assigned, opened, ready_for_review]
         paths:
@@ -28,7 +29,7 @@ jobs:
                   cache: "npm"
                   cache-dependency-path: "**/package-lock.json"
             - name: Cache JS dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               id: cache
               with:
                   path: "**/node_modules"

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -28,19 +28,10 @@ jobs:
                   node-version: 16
                   cache: "npm"
                   cache-dependency-path: "**/package-lock.json"
-            - name: Cache JS dependencies
-              uses: actions/cache@v3
-              id: cache
-              with:
-                  path: "**/node_modules"
-                  key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
             - name: Lock xcode version
               run: cd platform/ios; make lockxcodeversion
-            - name: Install modules if needed
-              if: steps.cache.outputs.cache-hit != 'true'
-              run: ./build.js install
-            - name: Build API and features
-              run: ./build.js build
+            - name: Install modules, build API and features
+              run: ./build.js
             - name: Build core
               working-directory: platform/core
               run: make

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -18,7 +18,7 @@ on:
             - "platform/ios/**"
 jobs:
     test:
-        name: Test polyPod iOS and Android app
+        name: Test polyPod iOS app
         runs-on: macOS-latest
         steps:
             - name: Checkout repository

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -23,9 +23,9 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version: 18
                   cache: "npm"
                   cache-dependency-path: "**/package-lock.json"
             - name: Lock xcode version


### PR DESCRIPTION
## Initial idea

The timeout has happened in #1076, so it's likely it's not triggered here. Anway, it's a bit over the brink, so maybe an upgrade of the cache code will fix it; among other things, it changes node from version 12 to version 16 (although, for some reason, that part is written in Csharp?).
Anyway, if this does not work, there are no easy alternatives. [This PR is waiting to be vetted](https://github.com/actions/runner/pull/1844), so I'm afraid we will have to disconnect the cache (it's very likely it's not making any good in this specific runner, too)

## Resolution

Eliminate cache. Best case scenario, we were obtaining marginal gains; installing modules took anywhere from 2 minutes to 6 minutes; but downloading and uncompressing the cache never took less than 4 minutes. So even in the best case scenario we were _losing_ around two minutes; I have seen uncompression times of up to 11 minutes, so it's really a very bad bet and needs to be eliminated. The fact that the hashing was also timing out was only the last nail in the coffin.

I have also upgraded the action that sets up node, and used a version for node, 18, which is different from the "main" one (still 16). Can give us a taste of some possible failures, before we upgrade; besides, that way we have at least two versions of node tested.