### PR TITLE
[🐛] {PROD4POD-1747} Upgrade to avoid kotlin "improper locking" bug

### DIFF
--- a/platform/android/polyOut/build.gradle
+++ b/platform/android/polyOut/build.gradle
@@ -16,12 +16,12 @@ compileTestKotlin {
 
 dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.30'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.3.8'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.1'
 
     testImplementation "org.junit.jupiter:junit-jupiter:5.6.2"
     testImplementation 'com.google.truth:truth:1.0.1'
     testImplementation 'com.google.truth.extensions:truth-java8-extension:1.0.1'
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.0'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0'
 }
 
 test {


### PR DESCRIPTION
Just upgrade to advised version