### PR TITLE
[♻] {PROD4POD-1618} Avoid swift timeouts

### DIFF
--- a/platform/ios/PolyPodApp/PolyPodTests/PolyOutTests.swift
+++ b/platform/ios/PolyPodApp/PolyPodTests/PolyOutTests.swift
@@ -177,7 +177,7 @@ class PolyOutTests: XCTestCase {
             newURL = newUrl
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 10.0)
+        wait(for: [expectation], timeout: 20.0)
         return newURL
     }
 

--- a/platform/ios/PolyPodApp/PolyPodUITests/UpdateNotificationTest.swift
+++ b/platform/ios/PolyPodApp/PolyPodUITests/UpdateNotificationTest.swift
@@ -73,7 +73,7 @@ class UpdateNotificationTest: XCTestCase {
             ]
         }
         app.launch()
-        let background = app.wait(for: .runningForeground, timeout: 60)
+        let background = app.wait(for: .runningForeground, timeout: 120)
         XCTAssertTrue(background)
     }
 


### PR DESCRIPTION
Basically doubling timeouts where they were happening.