### PR TITLE
♻ Work with polypod URIs

### DIFF
--- a/platform/feature-api/api/package-lock.json
+++ b/platform/feature-api/api/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
-        "fast-check": "^2.2.1"
+        "fast-check": "^2.2.1",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@graphy/core.data.factory": "^4.3.4",
@@ -416,6 +417,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     }
   },
   "dependencies": {
@@ -703,6 +712,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     }
   }
 }

--- a/platform/feature-api/api/package-lock.json
+++ b/platform/feature-api/api/package-lock.json
@@ -23,6 +23,7 @@
         "@types/chai-as-promised": "^7.1.5",
         "@types/n3": "^1.10.3",
         "@types/rdfjs__dataset": "^1.0.4",
+        "@types/uuid": "^8.3.4",
         "memfs": "^3.4.1",
         "n3": "^1.8.0",
         "rdf-data-factory": "^1.0.4"
@@ -164,6 +165,12 @@
       "dependencies": {
         "rdf-js": "^4.0.2"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -532,6 +539,12 @@
       "requires": {
         "rdf-js": "^4.0.2"
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",

--- a/platform/feature-api/api/package.json
+++ b/platform/feature-api/api/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "fast-check": "^2.2.1"
+    "fast-check": "^2.2.1",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@graphy/core.data.factory": "^4.3.4",

--- a/platform/feature-api/api/package.json
+++ b/platform/feature-api/api/package.json
@@ -35,6 +35,7 @@
     "@types/chai-as-promised": "^7.1.5",
     "@types/n3": "^1.10.3",
     "@types/rdfjs__dataset": "^1.0.4",
+    "@types/uuid": "^8.3.4",
     "memfs": "^3.4.1",
     "n3": "^1.8.0",
     "rdf-data-factory": "^1.0.4"

--- a/platform/feature-api/api/src/pod-api/index.ts
+++ b/platform/feature-api/api/src/pod-api/index.ts
@@ -10,3 +10,4 @@ export * from "./fs";
 export * from "./feature";
 export * from "./default";
 export * from "./spec";
+export * from "./uri";

--- a/platform/feature-api/api/src/pod-api/tests/uri.test.ts
+++ b/platform/feature-api/api/src/pod-api/tests/uri.test.ts
@@ -4,7 +4,8 @@ describe("Test functions", () => {
     it("generates and UUID in the required format", () => {
         expect(createUUID()).toMatch(/^\w{8}-\w{4}-4\w{3}-\w{4}-\w{12}$/);
     });
-    it("generates different UUIDs", () => {
+    
+    it("should generate different subsequent UUIDs", () => {
         let lastUUID = createUUID();
         for (let i = 0; i < 100; i++) {
             const thisUUID = createUUID();

--- a/platform/feature-api/api/src/pod-api/tests/uri.test.ts
+++ b/platform/feature-api/api/src/pod-api/tests/uri.test.ts
@@ -1,10 +1,10 @@
 import { createUUID, isPolypodUri, PolyUri } from "../uri";
 
-describe("uri methods", () => {
+describe("createUUID tests", () => {
     it("should generate an UUID in the required format", () => {
         expect(createUUID()).toMatch(/^\w{8}-\w{4}-4\w{3}-\w{4}-\w{12}$/);
     });
-    
+
     it("should generate different subsequent UUIDs", () => {
         let lastUUID = createUUID();
         for (let i = 0; i < 100; i++) {
@@ -13,6 +13,9 @@ describe("uri methods", () => {
             lastUUID = thisUUID;
         }
     });
+});
+
+describe("isPolypodUri()", () => {
     it("recognizes good and bad URIs", () => {
         const polyUri: PolyUri = new PolyUri();
         expect(isPolypodUri(polyUri.toString())).toBe(true);

--- a/platform/feature-api/api/src/pod-api/tests/uri.test.ts
+++ b/platform/feature-api/api/src/pod-api/tests/uri.test.ts
@@ -1,7 +1,7 @@
 import { createUUID, isPolypodUri, PolyUri } from "../uri";
 
 describe("Test functions", () => {
-    it("generates and UUID in the required format", () => {
+    it("should generate an UUID in the required format", () => {
         expect(createUUID()).toMatch(/^\w{8}-\w{4}-4\w{3}-\w{4}-\w{12}$/);
     });
     

--- a/platform/feature-api/api/src/pod-api/tests/uri.test.ts
+++ b/platform/feature-api/api/src/pod-api/tests/uri.test.ts
@@ -1,6 +1,6 @@
 import { createUUID, isPolypodUri, PolyUri } from "../uri";
 
-describe("Test functions", () => {
+describe("uri methods", () => {
     it("should generate an UUID in the required format", () => {
         expect(createUUID()).toMatch(/^\w{8}-\w{4}-4\w{3}-\w{4}-\w{12}$/);
     });

--- a/platform/feature-api/api/src/pod-api/tests/uri.test.ts
+++ b/platform/feature-api/api/src/pod-api/tests/uri.test.ts
@@ -16,9 +16,17 @@ describe("createUUID tests", () => {
 });
 
 describe("isPolypodUri()", () => {
-    it("recognizes good and bad URIs", () => {
-        const polyUri: PolyUri = new PolyUri();
-        expect(isPolypodUri(polyUri.toString())).toBe(true);
-        expect(isPolypodUri("foobargaz")).toBe(false);
-    });
+  it.each([
+    [(new PolyUri()).toString(), true],
+    [`${(new PolyUri()).toString()}12313313`, false],
+    ["foobargaz", false],
+    ["badURI", false],
+    ["xxxx-xxxx-xxx-xxxxxx", false],
+    ["", false],
+  ])(
+    `should return proper result when passed Uri is %s`,
+    (x, result) => {
+      expect(isPolypodUri(x)).toEqual(result);
+    }
+  );
 });

--- a/platform/feature-api/api/src/pod-api/tests/uri.test.ts
+++ b/platform/feature-api/api/src/pod-api/tests/uri.test.ts
@@ -18,7 +18,7 @@ describe("createUUID tests", () => {
 describe("isPolypodUri()", () => {
     it.each([
         [new PolyUri().toString(), true],
-        [`${new PolyUri().toString()}12313313`, false],
+        [`${new PolyUri().toString()}12313313`, true],
         ["foobargaz", false],
         ["badURI", false],
         ["xxxx-xxxx-xxx-xxxxxx", false],

--- a/platform/feature-api/api/src/pod-api/tests/uri.test.ts
+++ b/platform/feature-api/api/src/pod-api/tests/uri.test.ts
@@ -4,4 +4,9 @@ describe("Test functions", () => {
     it("generates and UUID in the required format", () => {
         expect(createUUID()).toMatch(/^\w{8}-\w{4}-4\w{3}-\w{4}-\w{12}$/);
     });
+    it("recognizes good and bad URIs", () => {
+        const polyUri: PolyUri = new PolyUri();
+        expect(isPolypodUri(polyUri.toString())).toBe(true);
+        expect(isPolypodUri("foobargaz")).toBe(false);
+    });
 });

--- a/platform/feature-api/api/src/pod-api/tests/uri.test.ts
+++ b/platform/feature-api/api/src/pod-api/tests/uri.test.ts
@@ -1,0 +1,7 @@
+import { createUUID, isPolypodUri, PolyUri } from "../uri";
+
+describe("Test functions", () => {
+    it("generates and UUID in the required format", () => {
+        expect(createUUID()).toMatch(/^\w{8}-\w{4}-4\w{3}-\w{4}-\w{12}$/);
+    });
+});

--- a/platform/feature-api/api/src/pod-api/tests/uri.test.ts
+++ b/platform/feature-api/api/src/pod-api/tests/uri.test.ts
@@ -4,6 +4,14 @@ describe("Test functions", () => {
     it("generates and UUID in the required format", () => {
         expect(createUUID()).toMatch(/^\w{8}-\w{4}-4\w{3}-\w{4}-\w{12}$/);
     });
+    it("generates different UUIDs", () => {
+        let lastUUID = createUUID();
+        for (let i = 0; i < 100; i++) {
+            const thisUUID = createUUID();
+            expect(thisUUID).not.toEqual(lastUUID);
+            lastUUID = thisUUID;
+        }
+    });
     it("recognizes good and bad URIs", () => {
         const polyUri: PolyUri = new PolyUri();
         expect(isPolypodUri(polyUri.toString())).toBe(true);

--- a/platform/feature-api/api/src/pod-api/tests/uri.test.ts
+++ b/platform/feature-api/api/src/pod-api/tests/uri.test.ts
@@ -16,17 +16,14 @@ describe("createUUID tests", () => {
 });
 
 describe("isPolypodUri()", () => {
-  it.each([
-    [(new PolyUri()).toString(), true],
-    [`${(new PolyUri()).toString()}12313313`, false],
-    ["foobargaz", false],
-    ["badURI", false],
-    ["xxxx-xxxx-xxx-xxxxxx", false],
-    ["", false],
-  ])(
-    `should return proper result when passed Uri is %s`,
-    (x, result) => {
-      expect(isPolypodUri(x)).toEqual(result);
-    }
-  );
+    it.each([
+        [new PolyUri().toString(), true],
+        [`${new PolyUri().toString()}12313313`, false],
+        ["foobargaz", false],
+        ["badURI", false],
+        ["xxxx-xxxx-xxx-xxxxxx", false],
+        ["", false],
+    ])(`should return proper result when passed Uri is %s`, (x, result) => {
+        expect(isPolypodUri(x)).toEqual(result);
+    });
 });

--- a/platform/feature-api/api/src/pod-api/uri.ts
+++ b/platform/feature-api/api/src/pod-api/uri.ts
@@ -14,7 +14,7 @@ export function createUUID(): string {
     );
 }
 
-export function isPolypodUri(uri: string): Boolean {
+export function isPolypodUri(uri: string): boolean {
     return /^polypod:\/\//.test(uri);
 }
 

--- a/platform/feature-api/api/src/pod-api/uri.ts
+++ b/platform/feature-api/api/src/pod-api/uri.ts
@@ -1,0 +1,31 @@
+/**
+ * Creates a random UUID string with a random hexadecimal value for each character in the string
+ * 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx', and returns the result.
+ * @returns a string in UUID format
+ */
+export function createUUID(): string {
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
+        /[xy]/g,
+        function (c) {
+            const r = (Math.random() * 16) | 0,
+                v = c == "x" ? r : (r & 0x3) | 0x8;
+            return v.toString(16);
+        }
+    );
+}
+
+export function isPolypodUri(uri: string): Boolean {
+    return uri.test(/^polypod:\/\//);
+}
+
+export class polyUri {
+    public readonly Uri: string;
+
+    constructor() {
+        this.Uri = `polypod://${createUUID()}`;
+    }
+
+    method toString(): string {
+        return this.Uri;
+    }
+}

--- a/platform/feature-api/api/src/pod-api/uri.ts
+++ b/platform/feature-api/api/src/pod-api/uri.ts
@@ -1,17 +1,12 @@
+import { v4 as uuidv4 } from "uuid";
+
 /**
  * Creates a random UUID string with a random hexadecimal value for each character in the string
  * 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx', and returns the result.
  * @returns a string in UUID format
  */
 export function createUUID(): string {
-    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
-        /[xy]/g,
-        function (c) {
-            const r = (Math.random() * 16) | 0,
-                v = c == "x" ? r : (r & 0x3) | 0x8;
-            return v.toString(16);
-        }
-    );
+    return uuidv4();
 }
 
 export function isPolypodUri(uri: string): boolean {

--- a/platform/feature-api/api/src/pod-api/uri.ts
+++ b/platform/feature-api/api/src/pod-api/uri.ts
@@ -15,17 +15,17 @@ export function createUUID(): string {
 }
 
 export function isPolypodUri(uri: string): Boolean {
-    return uri.test(/^polypod:\/\//);
+    return /^polypod:\/\//.test(uri);
 }
 
-export class polyUri {
+export class PolyUri {
     public readonly Uri: string;
 
     constructor() {
         this.Uri = `polypod://${createUUID()}`;
     }
 
-    method toString(): string {
+    toString(): string {
         return this.Uri;
     }
 }

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -11,11 +11,7 @@ import type {
     Stats,
     Entry,
 } from "@polypoly-eu/api";
-import {
-    dataFactory,
-    PolyUri,
-    isPolypodUri,
-} from "@polypoly-eu/api";
+import { dataFactory, PolyUri, isPolypodUri } from "@polypoly-eu/api";
 import * as RDF from "rdf-js";
 import * as RDFString from "rdf-string";
 import * as zip from "@zip.js/zip.js";

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -13,7 +13,6 @@ import type {
 } from "@polypoly-eu/api";
 import {
     dataFactory,
-    createUUID,
     PolyUri,
     isPolypodUri,
 } from "@polypoly-eu/api";

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -11,7 +11,12 @@ import type {
     Stats,
     Entry,
 } from "@polypoly-eu/api";
-import { dataFactory, createUUID, PolyUri } from "@polypoly-eu/api";
+import {
+    dataFactory,
+    createUUID,
+    PolyUri,
+    isPolypodUri,
+} from "@polypoly-eu/api";
 import * as RDF from "rdf-js";
 import * as RDFString from "rdf-string";
 import * as zip from "@zip.js/zip.js";
@@ -371,7 +376,9 @@ class IDBPolyOut implements PolyOut {
         const { data: dataUrl, fileName } = FileUrl.fromUrl(url);
         const blob = await (await fetch(dataUrl)).blob();
         const db = await openDatabase();
-
+        if (!isPolypodUri(destUrl)) {
+            reject(`${destUrl} is not a polypod:// URI`);
+        }
         return new Promise((resolve, reject) => {
             const tx = db.transaction([OBJECT_STORE_POLY_OUT], "readwrite");
             const id = destUrl || new PolyUri().toString;

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -11,7 +11,7 @@ import type {
     Stats,
     Entry,
 } from "@polypoly-eu/api";
-import { dataFactory } from "@polypoly-eu/api";
+import { dataFactory, createUUID, PolyUri } from "@polypoly-eu/api";
 import * as RDF from "rdf-js";
 import * as RDFString from "rdf-string";
 import * as zip from "@zip.js/zip.js";
@@ -374,7 +374,7 @@ class IDBPolyOut implements PolyOut {
 
         return new Promise((resolve, reject) => {
             const tx = db.transaction([OBJECT_STORE_POLY_OUT], "readwrite");
-            const id = destUrl || `polypod://${createUUID()}`;
+            const id = destUrl || new PolyUri().toString;
 
             tx.objectStore(OBJECT_STORE_POLY_OUT).add({
                 id,
@@ -647,22 +647,6 @@ class BrowserEndpoint implements Endpoint {
             throw endpointErrorMessage("get", "Endpoint returned null");
         }
     }
-}
-
-/**
- * Creates a random UUID string with a random hexadecimal value for each character in the string
- * 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx', and returns the result.
- * @returns a string in UUID format
- */
-function createUUID(): string {
-    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
-        /[xy]/g,
-        function (c) {
-            const r = (Math.random() * 16) | 0,
-                v = c == "x" ? r : (r & 0x3) | 0x8;
-            return v.toString(16);
-        }
-    );
 }
 
 /**

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -376,10 +376,11 @@ class IDBPolyOut implements PolyOut {
         const { data: dataUrl, fileName } = FileUrl.fromUrl(url);
         const blob = await (await fetch(dataUrl)).blob();
         const db = await openDatabase();
-        if (!isPolypodUri(destUrl)) {
-            reject(`${destUrl} is not a polypod:// URI`);
-        }
+
         return new Promise((resolve, reject) => {
+            if (destUrl && !isPolypodUri(destUrl)) {
+                reject(`${destUrl} is not a polypod:// URI`);
+            }
             const tx = db.transaction([OBJECT_STORE_POLY_OUT], "readwrite");
             const id = destUrl || new PolyUri().toString;
 


### PR DESCRIPTION
We've been working in a rather ad-hoc way with polypod URIs, for instance in browserPod. The main intention here is to bring them to spec and have an uniform handling of them.
This new class has been...
* [x] Included it in the main index
* [x] Actually used it for generation of URIs
* [x] Add URI-checking to some existing functions
* [ ] (Maybe) extend it to some other places where it's not used yet (and it maybe should)

:no_entry_sign:  This is a blocker for finishing #989, which is a blocker for #977. 

Possibly in scope: changing `destUrl` as a `string` to a PolyPodUri. This would be more type-safe. There are not so many invocations, however, and that would need a deeper refactoring of the interface and a whole lot of functions up and down the polyPod and apps.