### PR TITLE
add GitHub pull-request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+<!-- 
+    Thank you for your contribution to the polyPod repo. 🌻
+
+    Please, make sure that:
+    - You wait till the build is finished and is green
+    - Tests for the changes have been added, if possible (for bug fixes / new features)
+    - Docs have been reviewed and added / updated, if needed (for bug fixes / new features)
+    - Commits in this PR are minimal and have descriptive commit messages.
+
+    Before submitting this PR, please fill the following information on the following sections.
+-->
+
+
+# ✍️ Description
+<!-- 
+    Please, include a summary of the changes you made here and the related issue.
+    Some questions to help you give more context:
+     - What is the current behavior?
+     - Why we need this change/addition?
+     - What is the new behavior (if this a feature change)?
+     - What should we expect after this change/addition? 
+     - How did you test it?
+     - Does this introduce a breaking change?
+     - Are there any dependencies that are required for this change?
+ -->
+
+<!-- Link here the related JIRA issue in case of a bug / feature -->
+### 🏗️ Fixes #(jira-issue-number)
+
+
+<!-- Optional -->
+## ℹ️ Other information
+<!-- 
+    Any other information that is important to this PR. 
+    e.g. if regards a frontend UI change, add some screenshots 📸
+    of how the app looked before and how it looks after the change.
+-->
+
+
+♥️ Thank you!


### PR DESCRIPTION
Following discussion in https://wiki.polypoly.eu/display/POLYPOD/Proposal+for+Pull-Requests+template 
this is the  template for Github PRs as the merged outcome out of the preferences of the team.

So, when this will be merged, when we create a new pull request, we will see the template content automatically loaded into the description field.

We will only require to fill-in the requested information and 🧹 delete the comments or image placeholders (as here ⏬ ) from the message. 

For the whole dev experience as discussed in the wiki page, we need to accompany this change with the installation of this add-on https://github.com/zachwhaley/squashed-merge-message on our browsers that copies the PR's description into the squash&merge commit's message, so we will keep all the needed information there automatically. 🎊 

#### 🎨 Example after installing the add-on:
**Automatic** result when clicking 'squash and merge` button on this PR:
<img width="931" alt="image" src="https://user-images.githubusercontent.com/2449310/180827035-1a296f44-5a69-4ac7-ad43-4e76b897a166.png">
