### PR TITLE
[♻] eslint should also check mjs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -24,7 +24,6 @@ module.exports = {
     },
     ignorePatterns: [
         "*.conf.*",
-        "*.config.*",
         "*.bundled.*",
         "**/dist/*",
         "**/docs/*",

--- a/build/index.js
+++ b/build/index.js
@@ -64,7 +64,7 @@ async function main() {
         return exitCode;
     }
 
-    const eslintOptions = ["--ext", ".ts,.js,.tsx,.jsx", "."];
+    const eslintOptions = ["--ext", ".ts,.js,.tsx,.jsx,.mjs", "."];
 
     if (
         (!existsSync("node_modules") &&

--- a/feature-utils/poly-look/storybook/web-dev-server.config.mjs
+++ b/feature-utils/poly-look/storybook/web-dev-server.config.mjs
@@ -4,25 +4,25 @@
 const hmr = process.argv.includes("--hmr");
 
 export default /** @type {import('@web/dev-server').DevServerConfig} */ ({
-    nodeResolve: true,
-    open: "/demo/",
-    watch: !hmr,
+  nodeResolve: true,
+  open: "/demo/",
+  watch: !hmr,
 
-    /** Compile JS for older browsers. Requires @web/dev-server-esbuild plugin */
-    // esbuildTarget: 'auto'
+  /** Compile JS for older browsers. Requires @web/dev-server-esbuild plugin */
+  // esbuildTarget: 'auto'
 
-    /** Set appIndex to enable SPA routing */
-    // appIndex: 'demo/index.html',
+  /** Set appIndex to enable SPA routing */
+  // appIndex: 'demo/index.html',
 
-    /** Confgure bare import resolve plugin */
-    // nodeResolve: {
-    //   exportConditions: ['browser', 'development']
-    // },
+  /** Confgure bare import resolve plugin */
+  // nodeResolve: {
+  //   exportConditions: ['browser', 'development']
+  // },
 
-    plugins: [
-        /** Use Hot Module Replacement by uncommenting. Requires @open-wc/dev-server-hmr plugin */
-        // hmr && hmrPlugin({ exclude: ['**/*/node_modules/**/*'], presets: [presets.litElement] }),
-    ],
+  plugins: [
+    /** Use Hot Module Replacement by uncommenting. Requires @open-wc/dev-server-hmr plugin */
+    // hmr && hmrPlugin({ exclude: ['**/*/node_modules/**/*'], presets: [presets.litElement] }),
+  ],
 
-    // See documentation for all available options
+  // See documentation for all available options
 });

--- a/features/facebookImport/rollup.config.mjs
+++ b/features/facebookImport/rollup.config.mjs
@@ -9,9 +9,6 @@ import svg from "rollup-plugin-svg";
 import genPodjs from "@polypoly-eu/podjs/rollup-plugin-gen-podjs/genPodjs.js";
 import sillyI18n from "@polypoly-eu/silly-i18n/rollup-plugin.js";
 
-const fallbackURL = "http://localhost:8000";
-const fallbackAuthorization = "username:password";
-
 const externalPackages = {
     "@polypoly-eu/poly-look": "polyLook",
     react: "React",


### PR DESCRIPTION
# ✍️ Description

While doing #1090, I realized `.mjs` code, which was introduced for rollup configurations in #903, was not being linted. For two reasons:
1. That extension is not linted by default
2. They were all `*.config.*` files which were also excluded explicitly.

I don't really see a good reason for this to happen any more; rollup config files have become complex enough for them to be linted along the rest of the files. This is what this PR does; it also fixes linting errors found (which will supersede #1090, BTW, at least in the state it's in this draft)


♥️ Thank you!
