### PR TITLE
[🐛] {PROD4POD-1790} Upgraded d3 + d3-color

### DIFF
--- a/feature-utils/poly-look/package-lock.json
+++ b/feature-utils/poly-look/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@polypoly-eu/silly-i18n": "file:../silly-i18n",
-        "d3": "^7.0.4",
+        "d3": "^7.6.1",
         "d3-sankey": "^0.12.3",
         "lit-element": "^2.5.1",
         "lit-html": "^1.4.1",
@@ -495,10 +495,7 @@
     },
     "../poly-import": {
       "name": "@polypoly-eu/poly-import",
-      "dev": true,
-      "dependencies": {
-        "react": "^17.0.2"
-      }
+      "dev": true
     },
     "../silly-i18n": {
       "name": "@polypoly-eu/silly-i18n"
@@ -4130,16 +4127,16 @@
       "license": "MIT"
     },
     "node_modules/d3": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.4.4.tgz",
-      "integrity": "sha512-97FE+MYdAlV3R9P74+R3Uar7wUKkIFu89UWMjEaDhiJ9VxKvqaMxauImy8PC2DdBkdM2BxJOIoLxPrcZUyrKoQ==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
+      "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
         "d3-brush": "3",
         "d3-chord": "3",
         "d3-color": "3",
-        "d3-contour": "3",
+        "d3-contour": "4",
         "d3-delaunay": "6",
         "d3-dispatch": "3",
         "d3-drag": "3",
@@ -4170,8 +4167,9 @@
       }
     },
     "node_modules/d3-array": {
-      "version": "3.1.1",
-      "license": "ISC",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
+      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -4219,10 +4217,11 @@
       }
     },
     "node_modules/d3-contour": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
+      "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
       "dependencies": {
-        "d3-array": "2 - 3"
+        "d3-array": "^3.2.0"
       },
       "engines": {
         "node": ">=12"
@@ -8758,10 +8757,7 @@
       }
     },
     "@polypoly-eu/poly-import": {
-      "version": "file:../poly-import",
-      "requires": {
-        "react": "^17.0.2"
-      }
+      "version": "file:../poly-import"
     },
     "@polypoly-eu/rollup-plugin-copy-watch": {
       "version": "file:../../dev-utils/rollup-plugin-copy-watch",
@@ -10222,16 +10218,16 @@
       "dev": true
     },
     "d3": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.4.4.tgz",
-      "integrity": "sha512-97FE+MYdAlV3R9P74+R3Uar7wUKkIFu89UWMjEaDhiJ9VxKvqaMxauImy8PC2DdBkdM2BxJOIoLxPrcZUyrKoQ==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
+      "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
       "requires": {
         "d3-array": "3",
         "d3-axis": "3",
         "d3-brush": "3",
         "d3-chord": "3",
         "d3-color": "3",
-        "d3-contour": "3",
+        "d3-contour": "4",
         "d3-delaunay": "6",
         "d3-dispatch": "3",
         "d3-drag": "3",
@@ -10259,7 +10255,9 @@
       }
     },
     "d3-array": {
-      "version": "3.1.1",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
+      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
       "requires": {
         "internmap": "1 - 2"
       }
@@ -10289,9 +10287,11 @@
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
     },
     "d3-contour": {
-      "version": "3.0.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
+      "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
       "requires": {
-        "d3-array": "2 - 3"
+        "d3-array": "^3.2.0"
       }
     },
     "d3-delaunay": {

--- a/feature-utils/poly-look/package.json
+++ b/feature-utils/poly-look/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@polypoly-eu/silly-i18n": "file:../silly-i18n",
-    "d3": "^7.0.4",
+    "d3": "^7.6.1",
     "d3-sankey": "^0.12.3",
     "lit-element": "^2.5.1",
     "lit-html": "^1.4.1",

--- a/features/google/package-lock.json
+++ b/features/google/package-lock.json
@@ -10,7 +10,7 @@
         "@polypoly-eu/poly-analysis": "file:../../feature-utils/poly-analysis",
         "@polypoly-eu/poly-import": "file:../../feature-utils/poly-import",
         "@polypoly-eu/silly-i18n": "file:../../feature-utils/silly-i18n",
-        "d3": "^7.0.1",
+        "d3": "^7.6.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.2.0"
@@ -510,10 +510,7 @@
       }
     },
     "../../feature-utils/poly-import": {
-      "name": "@polypoly-eu/poly-import",
-      "dependencies": {
-        "react": "^17.0.2"
-      }
+      "name": "@polypoly-eu/poly-import"
     },
     "../../feature-utils/poly-look": {
       "name": "@polypoly-eu/poly-look",
@@ -522,7 +519,7 @@
       "license": "MIT",
       "dependencies": {
         "@polypoly-eu/silly-i18n": "file:../silly-i18n",
-        "d3": "^7.0.4",
+        "d3": "^7.6.1",
         "d3-sankey": "^0.12.3",
         "lit-element": "^2.5.1",
         "lit-html": "^1.4.1",
@@ -3804,9 +3801,10 @@
       }
     },
     "../../feature-utils/poly-look/node_modules/d3-color": {
-      "version": "3.0.1",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -7750,15 +7748,16 @@
       }
     },
     "node_modules/d3": {
-      "version": "7.3.0",
-      "license": "ISC",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
+      "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
         "d3-brush": "3",
         "d3-chord": "3",
         "d3-color": "3",
-        "d3-contour": "3",
+        "d3-contour": "4",
         "d3-delaunay": "6",
         "d3-dispatch": "3",
         "d3-drag": "3",
@@ -7789,8 +7788,9 @@
       }
     },
     "node_modules/d3-array": {
-      "version": "3.1.1",
-      "license": "ISC",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
+      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -7830,17 +7830,19 @@
       }
     },
     "node_modules/d3-color": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-contour": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
+      "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
       "dependencies": {
-        "d3-array": "2 - 3"
+        "d3-array": "^3.2.0"
       },
       "engines": {
         "node": ">=12"
@@ -8965,10 +8967,7 @@
       }
     },
     "@polypoly-eu/poly-import": {
-      "version": "file:../../feature-utils/poly-import",
-      "requires": {
-        "react": "^17.0.2"
-      }
+      "version": "file:../../feature-utils/poly-import"
     },
     "@polypoly-eu/poly-look": {
       "version": "file:../../feature-utils/poly-look",
@@ -8984,7 +8983,7 @@
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
         "babel-jest": "^27.5.1",
-        "d3": "^7.0.4",
+        "d3": "^7.6.1",
         "d3-sankey": "^0.12.3",
         "identity-obj-proxy": "^3.0.0",
         "lit-element": "^2.5.1",
@@ -11426,7 +11425,9 @@
           }
         },
         "d3-color": {
-          "version": "3.0.1",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+          "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
           "dev": true
         },
         "d3-contour": {
@@ -13679,14 +13680,16 @@
       }
     },
     "d3": {
-      "version": "7.3.0",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
+      "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
       "requires": {
         "d3-array": "3",
         "d3-axis": "3",
         "d3-brush": "3",
         "d3-chord": "3",
         "d3-color": "3",
-        "d3-contour": "3",
+        "d3-contour": "4",
         "d3-delaunay": "6",
         "d3-dispatch": "3",
         "d3-drag": "3",
@@ -13714,7 +13717,9 @@
       }
     },
     "d3-array": {
-      "version": "3.1.1",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
+      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
       "requires": {
         "internmap": "1 - 2"
       }
@@ -13739,12 +13744,16 @@
       }
     },
     "d3-color": {
-      "version": "3.0.1"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
     },
     "d3-contour": {
-      "version": "3.0.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
+      "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
       "requires": {
-        "d3-array": "2 - 3"
+        "d3-array": "^3.2.0"
       }
     },
     "d3-delaunay": {

--- a/features/google/package.json
+++ b/features/google/package.json
@@ -21,7 +21,7 @@
     "@polypoly-eu/poly-analysis": "file:../../feature-utils/poly-analysis",
     "@polypoly-eu/poly-import": "file:../../feature-utils/poly-import",
     "@polypoly-eu/silly-i18n": "file:../../feature-utils/silly-i18n",
-    "d3": "^7.0.1",
+    "d3": "^7.6.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0"


### PR DESCRIPTION
This d3-color version should take care of the snyk warning, but I don't think our code was really affected. Anyway, keeping up to date with some modules as in this case, which is used extensively in visualization, is probably a good thing.

# ✍️ Description

Upgrades d3 and d3-color in two submodules. Only the google feature had an affected `d3-color`, but this way we uniformize the versions we're using in both modules.


### 🏗️ Fixes PROD4POD-1790

Although this is simply a general heath fix, not really a vulnerability that affected our products.

♥️ Thank you!
