### PR TITLE
fix markdown on the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@
  -->
 
 <!-- Link here the related JIRA issue in case of a bug / feature -->
-### 🏗️ Fixes #(jira-issue-number)
+### 🏗️ Fixes (#jira-issue-number or link)
 
 
 <!-- Optional -->
@@ -36,5 +36,7 @@
     of how the app looked before and how it looks after the change.
 -->
 
+
+<!-- Please, delete comments when you are done -->
 
 ♥️ Thank you!


### PR DESCRIPTION
## ✍️ Description
Correcting some markdowns on the PR template
mainly to trigger a PR to display to team members how the template on GitHub will appear
and that the description is copied into the `squash merge` commit message.


#### 🏗️ Fixes #(jira-issue-number)
not-applied-here 


### ℹ️ Other information
not-applied-here


(above sections if are empty can be deleted in proper PRs - leaving them here to display the way the template will be)

♥️ Thank you!
