### PR TITLE
[:rotating_light:] Minor refactoring of browserPod.ts to eliminate IDE linting warnings

### DIFF
--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -569,7 +569,7 @@ type EndpointKeyId = keyof EndpointJSON;
  * @returns EndpointInfo | null
  */
 function getEndpoint(endpointId: EndpointKeyId): EndpointInfo | null {
-    return (endpointsJson as EndpointJSON)[endpointId] || null;
+    return (endpointsJson as unknown as EndpointJSON)[endpointId] || null;
 }
 
 /**
@@ -792,7 +792,7 @@ function luminance(featureColor: string): number {
 /**
  * It determines the foreground and background colors for the navbar based on the primary color of the
  * app.
- * @param {Manifest} file
+ * @param {Manifest} manifest
  * @returns { fg: string; bg: string } object
  */
 function determineNavBarColors(manifest: Manifest): { fg: string; bg: string } {
@@ -815,8 +815,6 @@ function createNavBarFrame(title: string): HTMLElement {
     frame.style.display = "block";
     frame.style.width = "100%";
     frame.style.height = "50px";
-    frame.frameBorder = "0";
-    frame.scrolling = "no";
     frame.id = NAV_FRAME_ID;
 
     const navBarColors = determineNavBarColors(window.manifest);


### PR DESCRIPTION
# ✍️ Description

While doing #989, these linting errors were revealed by the IDE.

- Documentation error file → manifest
- Casting needs an intermediate `unknown`
- Deprecated atributes

♥️ Thank you!
