### PR TITLE
Fix iOS update notification tests

### DIFF
--- a/platform/ios/PolyPodApp/PolyPodUITests/UpdateNotificationTest.swift
+++ b/platform/ios/PolyPodApp/PolyPodUITests/UpdateNotificationTest.swift
@@ -97,5 +97,6 @@ class UpdateNotificationTest: XCTestCase {
 
     private func closeInAppNotification() {
         findInAppNotificationCloseButton().tap()
+        sleep(1)
     }
 }


### PR DESCRIPTION
# ✍️ Description

The iOS notification tests fail for me quite consistently locally, the
same notification shows up twice even though it was previously closed.

Adding a `sleep` after the `tap` of the close button seems to fix it.

### 🏗️ Fixes (#jira-issue-number or link)

There's no Jira issue.