### PR TITLE
Adapt to NDK r25

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,7 +56,6 @@ jobs:
     - if: matrix.language == 'java'
       name: Build Android
       run: |
-        export NDK_HOME=$ANDROID_NDK_LATEST_HOME
         ./build.js
         cd platform/android
         make -C ../core android_bindings

--- a/.github/workflows/daily-instrumentation-test.yml
+++ b/.github/workflows/daily-instrumentation-test.yml
@@ -29,7 +29,6 @@ jobs:
             - name: Build core
               working-directory: platform/core
               run: |
-                export NDK_HOME=$ANDROID_NDK_LATEST_HOME
                 make android_bindings
             - uses: actions/setup-java@v2
               with:

--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -79,7 +79,6 @@ jobs:
         if: steps.changes.outputs.android == 'true'
         working-directory: platform/core
         run: |
-          export NDK_HOME=$ANDROID_NDK_LATEST_HOME
           make android_bindings
       - name: Test android
         if: steps.changes.outputs.android == 'true'

--- a/platform/core/Makefile
+++ b/platform/core/Makefile
@@ -24,21 +24,13 @@ android_core_libraries := $(patsubst %, $(jni_libs_copy_path)/%/libpolypod_core.
 cargo_ndk_version = 2.10.0
 
 ifeq ($(OS),Windows_NT)
-	ndk_download_url = $(google_repo)/$(ndk_lib)-windows-x86_64.zip
-	# Need on Windows, to allow interpreting escaping characters
 	os_echo := echo -e
 else
 	os_echo := echo
 	ifeq ($(shell uname -s),Darwin)
-		ndk_download_url = $(google_repo)/$(ndk_lib)-darwin-x86_64.zip
 		macos := true
 	endif
-	ifeq ($(shell uname -s),Linux)
-		ndk_download_url = $(google_repo)/$(ndk_lib)-linux-x86_64.zip
-	endif
 endif
-
-
 
 # ============  Rust core ============ #
 

--- a/platform/core/Makefile
+++ b/platform/core/Makefile
@@ -24,6 +24,7 @@ android_core_libraries := $(patsubst %, $(jni_libs_copy_path)/%/libpolypod_core.
 cargo_ndk_version = 2.10.0
 
 ifeq ($(OS),Windows_NT)
+    # Need on Windows, to allow interpreting escaping characters
 	os_echo := echo -e
 else
 	os_echo := echo

--- a/platform/core/README.md
+++ b/platform/core/README.md
@@ -26,7 +26,7 @@ make ios_bindings
 
 - Building android core:
 
-    Prerequisite: You should install NDK (it is recommended to use Android Studio for installing it). Version r24 should be installed. Make sure that either `NDK_HOME` or `ANDROID_NDK_HOME`(specifying the path to NDK) is exported as an environment variable on your system.
+    Prerequisite: You should install NDK (it is recommended to use Android Studio for installing it). Version r25 should be installed. Make sure that either `NDK_HOME` or `ANDROID_NDK_HOME`(specifying the path to NDK) is exported as an environment variable on your system.
 
 ```shell
 make android_bindings


### PR DESCRIPTION
# ✍️ Description
GH environment released NDK r25 support -> https://github.com/actions/virtual-environments/releases. 

What has been done:

- [x] Delete the re-export for `ANDROID_NDK_LATEST_HOME` variable. GH updated to point to standard paths, such as `NDK_Home` -> https://github.com/actions/virtual-environments/pull/5984
- [x] Deleted some ndk download leftovers from the makefile.
- [x] Update the documentation to specify NDK r25.
