### PR TITLE
Eliminate copying the test feature to the device

### DIFF
--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -220,54 +220,11 @@ task copyThirdPartyLicenses(type: Copy) {
     into "build/generated-assets/3rd-party-licenses"
 }
 
-task installAppOnDevice {
-    // This is needed to install the Java package into the device
-    dependsOn "assembleDebug"
-    doLast {
-        exec {
-            logger.info("Trying to install app")
-            def adb = android.getAdbExecutable().absolutePath
-            commandLine adb, 'install', "$buildDir/outputs/apk/debug/app-debug.apk"
-            logger.info("Application installed onto the device")
-        }
-    }
-}
-
 task copyEndpoints(type: Copy) {
     def path = "../../../../polyPod-config"
     assert file(path).exists()
     from path
     into "build/generated-assets/config-assets"
-}
-
-task packageTestFeature(type: Zip) {
-    // This needs the prior installation of the package, thus the dependency
-    dependsOn installAppOnDevice
-    archiveFileName = "test.zip"
-    destinationDirectory = file("$buildDir")
-    from "$projectDir/../../../features/test/dist"
-}
-
-task copyTestFeatureOntoDevice {
-    dependsOn packageTestFeature
-    def adb = android.getAdbExecutable().absolutePath
-    def tempPath = "/data/local/tmp/test.zip"
-    def packageName = android.defaultConfig.applicationId
-    def featurePath = "files/features"
-    doLast {
-        exec {
-            commandLine adb, 'push', "--sync", "$buildDir/test.zip", tempPath
-            logger.info("test feature copied onto the device")
-        }
-        exec {
-            commandLine adb, 'shell', "run-as", packageName, "mkdir", '-p', featurePath
-            logger.info("Feature directory created on the device")
-        }
-        exec {
-            commandLine adb, 'shell', "run-as", packageName, "cp", tempPath, featurePath
-            logger.info("test feature moved to features directory on the device")
-        }
-    }
 }
 
 tasks.whenTaskAdded { task ->
@@ -277,14 +234,6 @@ tasks.whenTaskAdded { task ->
         task.dependsOn copyThirdPartyLicenses
         task.dependsOn copyEndpoints
     }
-
-    // This avoids circular dependencies in those cases
-    if (
-        task.name == "connectedDebugAndroidTest" ||
-        task.name == "connectedReleaseAndroidTest" ||
-        task.name == "generateDebugAndroidTestAssets"
-    )
-        task.dependsOn copyTestFeatureOntoDevice
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {


### PR DESCRIPTION
# ✍️ Description

At the moment, every time we deploy the tests, the build process will
copy over the feature named "test" to the device.

Now that we're always bundling - but not displaying - it, we can just
add a preference for forcing it to show up, and execute the tests in
it that way, so we don't need this logic anymore. It's sometimes
causing trouble when trying to run the tests - happened to me again
just now - and it's not worth debugging if we don't need it.

Related to PROD4POD-1721.