### PR TITLE
Sync Oxigraph store into IndexedDB

### DIFF
--- a/platform/feature-api/api/src/pod-api/api.ts
+++ b/platform/feature-api/api/src/pod-api/api.ts
@@ -40,7 +40,6 @@ export interface Matcher {
  * on, except for internal purposes of the Feature.
  */
 export interface PolyIn {
-    store: unknown;
     /**
      * Queries the Pod for triples matching the given filter. For each property ([[Matcher.subject]],
      * [[Matcher.predicate]], [[Matcher.object]]) that is specified in the argument, the result set is narrowed to only

--- a/platform/feature-api/api/src/pod-api/default.ts
+++ b/platform/feature-api/api/src/pod-api/default.ts
@@ -46,7 +46,6 @@ export class DefaultPod implements Pod {
      */
     get polyIn(): PolyIn {
         return {
-            store: this.store,
             match: async (matcher) =>
                 Array.from(
                     this.store.match(

--- a/platform/podjs/package-lock.json
+++ b/platform/podjs/package-lock.json
@@ -12,8 +12,7 @@
         "fp-ts": "^2.8.2",
         "io-ts": "^2.2.16",
         "oxigraph": "^0.3.5",
-        "rdf-js": "^4.0.2",
-        "rdf-string": "^1.6.0"
+        "rdf-js": "^4.0.2"
       },
       "devDependencies": {
         "@types/node": "^14.14.21",
@@ -355,28 +354,11 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/rdf-data-factory": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.0.tgz",
-      "integrity": "sha512-g8feOVZ/KL1OK2Pco/jDBDFh4m29QDsOOD+rWloG9qFvIzRFchGy2CviLUX491E0ByewXxMpaq/A3zsWHQA16A==",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      }
-    },
     "node_modules/rdf-js": {
       "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/rdf-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.0.tgz",
-      "integrity": "sha512-6vQVlEobIHralPtx8V9vtgxA+fwnzZjZv6lRz8dfymILZF6Fl3QJwyRaOAvYaUQc1JMmshGI/wlYlaxin2AldQ==",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
       }
     },
     "node_modules/rollup": {
@@ -619,27 +601,10 @@
         "unpipe": "1.0.0"
       }
     },
-    "rdf-data-factory": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.0.tgz",
-      "integrity": "sha512-g8feOVZ/KL1OK2Pco/jDBDFh4m29QDsOOD+rWloG9qFvIzRFchGy2CviLUX491E0ByewXxMpaq/A3zsWHQA16A==",
-      "requires": {
-        "@rdfjs/types": "*"
-      }
-    },
     "rdf-js": {
       "version": "4.0.2",
       "requires": {
         "@rdfjs/types": "*"
-      }
-    },
-    "rdf-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.0.tgz",
-      "integrity": "sha512-6vQVlEobIHralPtx8V9vtgxA+fwnzZjZv6lRz8dfymILZF6Fl3QJwyRaOAvYaUQc1JMmshGI/wlYlaxin2AldQ==",
-      "requires": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
       }
     },
     "rollup": {

--- a/platform/podjs/package.json
+++ b/platform/podjs/package.json
@@ -23,8 +23,7 @@
     "fp-ts": "^2.8.2",
     "io-ts": "^2.2.16",
     "oxigraph": "^0.3.5",
-    "rdf-js": "^4.0.2",
-    "rdf-string": "^1.6.0"
+    "rdf-js": "^4.0.2"
   },
   "devDependencies": {
     "@types/node": "^14.14.21",


### PR DESCRIPTION
@RichardSto I had a go at persisting the Oxigraph store in IndexedDB. With this PR, I'm populating the store using the `Store#load` method during intilization, and call the `Store#dump` method and write the result into IndexedDB  on every call to `PolyIn#add` and `PolyIn#delete`. Multiple calls during the same event loop cycle only cause one write to IndexedDB.

Any reason you exposed Oxigraph's store in the public API? I made it private with the changes here since otherwise we cannot make sure that all write operations are synced to IndexedDB.