### PR TITLE
Make tests pass with oxigraph

### DIFF
--- a/features/example/src/index.jsx
+++ b/features/example/src/index.jsx
@@ -8,15 +8,15 @@ function Quad({ quad }) {
                 <tbody>
                     <tr>
                         <th>Subject</th>
-                        <td>{JSON.stringify(quad.subject)}</td>
+                        <td>{quad.subject.toString()}</td>
                     </tr>
                     <tr>
                         <th>Predicate</th>
-                        <td>{JSON.stringify(quad.predicate)}</td>
+                        <td>{quad.predicate.toString()}</td>
                     </tr>
                     <tr>
                         <th>Object</th>
-                        <td>{JSON.stringify(quad.object)}</td>
+                        <td>{quad.object.toString()}</td>
                     </tr>
                 </tbody>
             </table>

--- a/features/test/cypress/integration/tests.spec.js
+++ b/features/test/cypress/integration/tests.spec.js
@@ -1,7 +1,6 @@
 const testIds = [
     "simpleJavaScriptCall",
     "podApiResolves",
-    "canCallPolyInAddWithNoQuads",
     "addSupportsQuadsWithDefaultGraph",
     "canPassEmptyMatcherToPolyInMatch",
     "canPassMatcherWithSubjectToPolyInMatch",

--- a/features/test/src/index.html
+++ b/features/test/src/index.html
@@ -45,10 +45,10 @@
         <!-- TODO: Figure out if we actually need this, otherwise remove -->
         <div style="display: none">
             <h1>Input</h1>
-            <input id="input.1" />
-            <input id="input.2" />
-            <input id="input.3" />
-            <input id="input.4" />
+            <input id="input.1" value="http://example.com/subject"/>
+            <input id="input.2" value="http://example.com/predicate"/>
+            <input id="input.3" value="http://example.com/object"/>
+            <input id="input.4" value="http://example.com/graph"/>
         </div>
 
         <div class="test-controls">

--- a/features/test/src/test.ts
+++ b/features/test/src/test.ts
@@ -25,11 +25,6 @@ const tests = {
         await pod;
     },
 
-    async canCallPolyInAddWithNoQuads(): Promise<void> {
-        console.log("canCallPolyInAddWithNoQuads()");
-        await polyIn.add();
-    },
-
     async _canCallPolyInAddWithSingleQuad(): Promise<void> {
         console.log("canCallPolyInAddWithSingleQuad()");
         const quad = QuadBuilder.fromInputs().build();

--- a/platform/feature-api/api/src/rdf-spec/gen.ts
+++ b/platform/feature-api/api/src/rdf-spec/gen.ts
@@ -44,31 +44,19 @@ export function gens<Q extends RDF.BaseQuad = RDF.Quad>(
           fc.hexaString().map((id) => factory.variable(id))
         : undefined;
 
-    const variables = variable ? [variable] : [];
-
-    const term = fc.oneof(
-        namedNode,
-        blankNode,
-        literal,
-        fc.constant(factory.defaultGraph()),
-        ...variables
-    );
-
-    const subject = fc.oneof(namedNode, blankNode, ...variables);
-    const predicate = fc.oneof(namedNode, ...variables);
-    const object = fc.oneof(namedNode, literal, blankNode, ...variables);
+    const term = fc.oneof(namedNode, blankNode, literal);
+    const subject = fc.oneof(namedNode, blankNode);
     const graph = fc.oneof(
         fc.constant(factory.defaultGraph()),
         namedNode,
-        blankNode,
-        ...variables
+        blankNode
     );
 
     const triple = fc
-        .tuple(subject, predicate, object)
+        .tuple(subject, namedNode, term)
         .map(([s, p, o]) => factory.quad(s, p, o));
     const quad = fc
-        .tuple(subject, predicate, object, graph)
+        .tuple(subject, namedNode, term, graph)
         .map(([s, p, o, g]) => factory.quad(s, p, o, g));
 
     return {

--- a/platform/feature-api/api/src/rdf/index.ts
+++ b/platform/feature-api/api/src/rdf/index.ts
@@ -149,26 +149,15 @@ export class Quad implements RDF.Quad {
 }
 
 const prototypes = {
-    subject: [
-        NamedNode.prototype,
-        BlankNode.prototype,
-        Variable.prototype,
-        Quad.prototype,
-    ],
-    predicate: [NamedNode.prototype, Variable.prototype],
+    subject: [NamedNode.prototype, BlankNode.prototype, Quad.prototype],
+    predicate: [NamedNode.prototype],
     object: [
         NamedNode.prototype,
         Literal.prototype,
         BlankNode.prototype,
-        Variable.prototype,
         Quad.prototype,
     ],
-    graph: [
-        DefaultGraph.prototype,
-        NamedNode.prototype,
-        BlankNode.prototype,
-        Variable.prototype,
-    ],
+    graph: [DefaultGraph.prototype, NamedNode.prototype, BlankNode.prototype],
 };
 
 /**

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -116,20 +116,29 @@ class OxigraphPolyIn implements PolyIn {
         );
     }
 
+    private checkQuad(quad: RDF.Quad): void {
+        if (quad.graph.termType != "DefaultGraph")
+            throw new Error("Only default graph allowed");
+    }
+
     async add(quad: RDF.Quad): Promise<void> {
         const store = await this.store;
+        this.checkQuad(quad);
         store.add(quad);
         await this.sync(store);
     }
 
     async delete(quad: RDF.Quad): Promise<void> {
         const store = await this.store;
+        this.checkQuad(quad);
         store.delete(quad);
         await this.sync(store);
     }
 
     async has(quad: RDF.Quad): Promise<boolean> {
-        return (await this.store).has(quad);
+        const store = await this.store;
+        this.checkQuad(quad);
+        return store.has(quad);
     }
 
     async query(query: string): Promise<SPARQLQueryResult> {


### PR DESCRIPTION
@RichardSto I had to make following changes to make the tests pass with Oxigraph:

1. The tests for the `example` feature failed because they relied on `JSON.stringify(term)` producing a string that conatins the value of the respective term. However, since Oxigraph's objects are managed by WASM the only property on the object that isn't a getter is `ptr` which holds the relative memory address. So I had to replace `JSON.stringify(term)` with `term.toString()`.
2. Since you changed the API from `polyIn.add(...quads)` to `polyIn.add(quad)`, I had to remove the test testing that `polyIn.add` can be called with no arguments.
3. The `test` feature was creating named nodes to test the API with from an empty string. But Oxigraph is more strict than the previous implementation, and throws an error when creating a named node from an invalid IRI.
4. Unlike the previous implementation, Oxigpraph doesn't allow variables to be used were a term is expected. So I adjusted the constraint check in the feature API, and the code generating test RDF data accordingly.
5. You have removed the check that throws an error when calling `polyIn.add/delete/has` with a quad that is not using the default graph. I restored that logic since the test testing for this behavior was failing.