### PR TITLE
[Fix] Address build warnings by adding as external dep

### DIFF
--- a/platform/feature-api/api/rollup.config.js
+++ b/platform/feature-api/api/rollup.config.js
@@ -19,7 +19,7 @@ export default [
                 transforms: ["typescript"],
             }),
         ],
-        external: ["chai", "fast-check", "chai-as-promised"],
+        external: ["chai", "fast-check", "chai-as-promised", "uuid"],
     },
     {
         input: "src/pod-api/mock-pod.ts",
@@ -45,6 +45,7 @@ export default [
             "chai-as-promised",
             "memfs",
             "@rdfjs/dataset",
+            "uuid",
         ],
     },
 ];


### PR DESCRIPTION
# ✍️ Description

This addresses rollup warnings that were showing up in the build, such as this one:

![Captura de pantalla de 2022-08-23 10-38-39](https://user-images.githubusercontent.com/500/186113043-fd0c432d-85f4-487b-a54d-163c0727833d.png)


## ℹ️ Other information

This adds the `uuid` to the list of external dependencies. Avoids that warning, also prevents the bundled code from failing when embedded in a page.

♥️ Thank you!
