### PR TITLE
[Fix] Eliminates warning for circular dependencies

### DIFF
--- a/platform/podjs/rollup.config.js
+++ b/platform/podjs/rollup.config.js
@@ -26,6 +26,14 @@ export default [
         ],
         context: "window",
         external: ["chai"],
+        onwarn: (warning) => {
+            if (
+                warning.code === "CIRCULAR_DEPENDENCY" &&
+                warning.cycle[0].match(/fast-check/)
+            ) {
+                return;
+            }
+        },
     },
     {
         input: "src/pod.ts",
@@ -45,5 +53,13 @@ export default [
             }),
         ],
         context: "window",
+        onwarn: (warning) => {
+            if (
+                warning.code === "CIRCULAR_DEPENDENCY" &&
+                warning.cycle[0].match(/fast-check/)
+            ) {
+                return;
+            }
+        },
     },
 ];


### PR DESCRIPTION
# ✍️ Description

Circular dependency warnings create noise in the build, obscure other, more important issues. In general, we have suppressed them.
![Captura de pantalla de 2022-08-23 11-17-30](https://user-images.githubusercontent.com/500/186121236-18b37acf-1514-4476-a61c-61eb7896dfb9.png)

We're just following the same pattern here. Warning event is detected, and eliminated in the case it's related to fast-check, which is what's causing it (not our code)


♥️ Thank you!
