### PR TITLE
PolyLook: Add tokens for themes and buttons

### DIFF
--- a/feature-utils/poly-look/src/css/themes.css
+++ b/feature-utils/poly-look/src/css/themes.css
@@ -2,7 +2,6 @@
 .poly-theme {
   --theme-font-base: var(--jost);
   --theme-font-medium: var(--jost-medium);
-  --theme-info-button-color: var(--color-gray-300);
   color: var(--theme-secondary-color);
   font-family: var(--jost);
   font-weight: 400;
@@ -33,13 +32,20 @@
   --theme-small-print-color: var(--color-gray-400);
 }
 
-
+.poly-theme-light, .poly-theme-dark {
+  --pl-button-color-fill-primary: var(--theme-secondary-color);
+  --pl-button-color-color-primary: var(--theme-primary-color);
+  --theme-info-button-color: var(--color-gray-300);
+}
 
 .poly-theme-coop {
   --theme-primary-color: var(--color-red-50);
   --theme-secondary-color: var(--color-indigo-950);
   --theme-tertiary-color: var(--color-red-300);
   --theme-small-print-color: var(--color-gray-500);
+  --theme-info-button-color: var(--color-gray-300);
+  --pl-button-color-fill-primary: var(--theme-tertiary-color);
+  --pl-button-color-color-primary: var(--theme-secondary-color);
 }
 
 .poly-theme h1,

--- a/feature-utils/poly-look/src/css/themes.css
+++ b/feature-utils/poly-look/src/css/themes.css
@@ -2,6 +2,7 @@
 .poly-theme {
   --theme-font-base: var(--jost);
   --theme-font-medium: var(--jost-medium);
+  --theme-info-button-color: var(--color-gray-300);
   color: var(--theme-secondary-color);
   font-family: var(--jost);
   font-weight: 400;
@@ -21,15 +22,24 @@
 .poly-theme-light {
   --theme-primary-color: var(--color-gray-50);
   --theme-secondary-color: var(--color-indigo-950);
+  --theme-tertiary-color: var(--color-red-300);
   --theme-small-print-color: var(--color-gray-500);
-  --theme-info-button-color: var(--color-gray-300);
 }
 
 .poly-theme-dark {
   --theme-primary-color: var(--color-indigo-950);
   --theme-secondary-color: var(--color-gray-50);
+  --theme-tertiary-color: var(--color-red-300);
   --theme-small-print-color: var(--color-gray-400);
-  --theme-info-button-color: var(--color-gray-300);
+}
+
+
+
+.poly-theme-coop {
+  --theme-primary-color: var(--color-red-50);
+  --theme-secondary-color: var(--color-indigo-950);
+  --theme-tertiary-color: var(--color-red-300);
+  --theme-small-print-color: var(--color-gray-500);
 }
 
 .poly-theme h1,

--- a/feature-utils/poly-look/src/react-components/buttons/polyButton.css
+++ b/feature-utils/poly-look/src/react-components/buttons/polyButton.css
@@ -20,12 +20,17 @@
   opacity: 0.38;
 }
 
-.poly-button.filled {
-  background-color: var(--theme-secondary-color);
-  color: var(--theme-primary-color);
+.poly-button.primary {
+  background-color: var(--pl-button-color-fill-primary);
+  color: var(--pl-button-color-color-primary);
 }
 
-.poly-button.outline {
+.poly-button.primary-medium {
+  background-color: var(--theme-tertiary-color);
+  color: var(--color-indigo-950);
+}
+
+.poly-button.secondary {
   border: 1px solid var(--theme-secondary-color);
   color: var(--theme-secondary-color);
   background-color: var(--transparent);

--- a/feature-utils/poly-look/src/react-components/buttons/polyButton.jsx
+++ b/feature-utils/poly-look/src/react-components/buttons/polyButton.jsx
@@ -8,15 +8,16 @@ import "./polyButton.css";
  * @param {Object} props
  * @param {string} [props.label] - Button text
  * @param {boolean} [props.centered] - If the button should center itself.
- * @param {string} [props.type = "filled"] - Type of the button
+ * @param {string} [props.type = "primary"] - Type of the button
  */
 
 const types = {
-  filled: "filled",
-  outline: "outline",
+  primary: "primary",
+  medium: "primary-medium",
+  secondary: "secondary",
 };
 
-const PolyButton = ({ label, type = "filled", ...otherProps }) => {
+const PolyButton = ({ label, type = "primary", ...otherProps }) => {
   return (
     <button
       {...otherProps}

--- a/features/google/src/components/dialog/dialog.jsx
+++ b/features/google/src/components/dialog/dialog.jsx
@@ -13,7 +13,7 @@ const Dialog = ({ title, message, backButton, proceedButton }) => {
                     <PolyButton
                         onClick={backButton.onClick}
                         label={backButton.text}
-                        type="outline"
+                        type="secondary"
                     />
                 ) : null}
                 <PolyButton

--- a/features/google/src/components/importExplanationExpandable/importExplanationExpandable.jsx
+++ b/features/google/src/components/importExplanationExpandable/importExplanationExpandable.jsx
@@ -145,12 +145,12 @@ const ImportExplanationExpandable = ({
                 ></p>
                 <InfoBox textContent={i18n.t("import:request.info.2")} />
                 <PolyButton
-                    className="bg-red"
+                    type="medium"
                     onClick={() => handleRequestStatus()}
                     label={i18n.t("import:request.button")}
                 ></PolyButton>
                 <PolyButton
-                    type="outline"
+                    type="secondary"
                     onClick={() => handleExampleDataRequest()}
                     label={i18n.t("import:request.example.data")}
                 ></PolyButton>
@@ -172,12 +172,12 @@ const ImportExplanationExpandable = ({
                 <img src="./images/download.svg" alt="document" />
                 <p>{i18n.t("import:download.3")}</p>
                 <PolyButton
-                    className="bg-red"
+                    type="medium"
                     onClick={() => handleDownloadDataLinkClick()}
                     label={i18n.t("import:download.button.1")}
                 ></PolyButton>
                 <PolyButton
-                    type="outline"
+                    type="secondary"
                     onClick={() => onUpdateImportStatus(importSteps.import)}
                     label={i18n.t("import:download.button.2")}
                 ></PolyButton>
@@ -219,7 +219,7 @@ const ImportExplanationExpandable = ({
                     )}
                 </div>
                 <PolyButton
-                    type="outline"
+                    type="secondary"
                     onClick={handleSelectFile}
                     label={
                         selectedFiles.length
@@ -228,7 +228,7 @@ const ImportExplanationExpandable = ({
                     }
                 ></PolyButton>
                 <PolyButton
-                    className="bg-red"
+                    type="medium"
                     onClick={handleImportFile}
                     label={i18n.t(
                         selectedFiles.length > 1
@@ -251,14 +251,14 @@ const ImportExplanationExpandable = ({
                     <>
                         <RoutingWrapper history={history} route="/overview">
                             <PolyButton
-                                className="bg-red"
+                                type="medium"
                                 label={i18n.t("import:explore.button")}
                             ></PolyButton>
                         </RoutingWrapper>
                     </>
                 ) : (
                     <PolyButton
-                        className="bg-red"
+                        type="medium"
                         label={i18n.t("import:explore.button")}
                         disabled="disabled"
                     ></PolyButton>

--- a/features/google/src/views/overview/overview.jsx
+++ b/features/google/src/views/overview/overview.jsx
@@ -128,7 +128,7 @@ const Overview = () => {
                         },
                     })
                 }
-                type="outline"
+                type="secondary"
             ></PolyButton>
             <RoutingWrapper history={history} route="/explore">
                 <PolyButton label={i18n.t("common:explore")}></PolyButton>

--- a/features/polypolyMembership/src/index.jsx
+++ b/features/polypolyMembership/src/index.jsx
@@ -1,14 +1,19 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { Screen, PolyButton } from "@polypoly-eu/poly-look";
 import i18n from "!silly-i18n";
 
 import "./styles.css";
 
 const App = () => {
     return (
-        <div>
+        <Screen
+            className="membership poly-theme-coop"
+            layout="poly-standard-layout"
+        >
             <h1>{i18n.t("common:welcome", { feature: "This feature" })}</h1>
-        </div>
+            <PolyButton label="example" />
+        </Screen>
     );
 };
 


### PR DESCRIPTION
# ✍️ Description
<!-- 
    Please, include a summary of the changes you made here and the related issue.
    Some questions to help you give more context:
     - What is the current behavior?
     - Why we need this change/addition?
     - What is the new behavior (if this a feature change)?
     - What should we expect after this change/addition? 
     - How did you test it?
     - Does this introduce a breaking change?
     - Are there any dependencies that are required for this change?
 -->

- [x] **Create "coop" theme in PolyLook** and added in Membership feature with a button as an example. 
        `--theme-primary-color` is the background color, since that variable is already used in the Screen component.
        `--theme-secondary-color` is the text color
        `--theme-tertiary-color` is `--color-red-300` for the three themes that we already have.
     
- [ ] **Add buttons' tokens and implement them in PolyButton**

- [ ] **Fix button types in PolyButton**: "primary" and "secondary" buttons, instead of "filled" and "outline".
       There is something that I am not sure how to address here, it's what I've called the `primary-medium` button.


<!-- Link here the related JIRA issue in case of a bug / feature -->
### 🏗️ Fixes (#jira-issue-number or link)


<!-- Optional -->
## ℹ️ Other information
<!-- 
    Any other information that is important to this PR. 
    e.g. if regards a frontend UI change, add some screenshots 📸
    of how the app looked before and how it looks after the change.
-->


<!-- Please, delete comments when you are done -->

♥️ Thank you!
