### PR TITLE
[🐛] Suppress only the warnings we're interested in

### DIFF
--- a/platform/podjs/rollup.config.js
+++ b/platform/podjs/rollup.config.js
@@ -3,7 +3,7 @@ import resolve from "@rollup/plugin-node-resolve";
 import sucrase from "@rollup/plugin-sucrase";
 import json from "@rollup/plugin-json";
 
-function supressSomeWarnings(warning, warn, code, regex) {
+function suppressSomeWarnings(warning, warn, code, regex) {
     if (warning.code === code && warning.cycle[0].match(regex)) {
         return;
     } else {
@@ -35,7 +35,7 @@ export default [
         context: "window",
         external: ["chai"],
         onwarn: (warning, warn) =>
-            supressSomeWarnings(
+            suppressSomeWarnings(
                 warning,
                 warn,
                 "CIRCULAR_DEPENDENCY",
@@ -61,7 +61,7 @@ export default [
         ],
         context: "window",
         onwarn: (warning, warn) =>
-            supressSomeWarnings(
+            suppressSomeWarnings(
                 warning,
                 warn,
                 "CIRCULAR_DEPENDENCY",

--- a/platform/podjs/rollup.config.js
+++ b/platform/podjs/rollup.config.js
@@ -3,6 +3,14 @@ import resolve from "@rollup/plugin-node-resolve";
 import sucrase from "@rollup/plugin-sucrase";
 import json from "@rollup/plugin-json";
 
+function supressSomeWarnings(warning, warn, code, regex) {
+    if (warning.code === code && warning.cycle[0].match(regex)) {
+        return;
+    } else {
+        warn(warning);
+    }
+}
+
 export default [
     {
         input: "src/index.ts",
@@ -26,14 +34,13 @@ export default [
         ],
         context: "window",
         external: ["chai"],
-        onwarn: (warning) => {
-            if (
-                warning.code === "CIRCULAR_DEPENDENCY" &&
-                warning.cycle[0].match(/fast-check/)
-            ) {
-                return;
-            }
-        },
+        onwarn: (warning, warn) =>
+            supressSomeWarnings(
+                warning,
+                warn,
+                "CIRCULAR_DEPENDENCY",
+                /fast-check/
+            ),
     },
     {
         input: "src/pod.ts",
@@ -53,13 +60,12 @@ export default [
             }),
         ],
         context: "window",
-        onwarn: (warning) => {
-            if (
-                warning.code === "CIRCULAR_DEPENDENCY" &&
-                warning.cycle[0].match(/fast-check/)
-            ) {
-                return;
-            }
-        },
+        onwarn: (warning, warn) =>
+            supressSomeWarnings(
+                warning,
+                warn,
+                "CIRCULAR_DEPENDENCY",
+                /fast-check|chai\.js/
+            ),
     },
 ];

--- a/platform/podjs/rollup.config.js
+++ b/platform/podjs/rollup.config.js
@@ -3,7 +3,7 @@ import resolve from "@rollup/plugin-node-resolve";
 import sucrase from "@rollup/plugin-sucrase";
 import json from "@rollup/plugin-json";
 
-function suppressSomeWarnings(warning, warn, code, regex) {
+function suppressMatchingWarnings(warning, warn, code, regex) {
     if (warning.code != code || !warning.cycle[0].match(regex)) warn(warning);
 }
 
@@ -35,7 +35,7 @@ export default [
         ...common,
         external: ["chai"],
         onwarn: (warning, warn) =>
-            suppressSomeWarnings(
+            suppressMatchingWarnings(
                 warning,
                 warn,
                 "CIRCULAR_DEPENDENCY",
@@ -52,7 +52,7 @@ export default [
         ],
         ...common,
         onwarn: (warning, warn) =>
-            suppressSomeWarnings(
+            suppressMatchingWarnings(
                 warning,
                 warn,
                 "CIRCULAR_DEPENDENCY",

--- a/platform/podjs/rollup.config.js
+++ b/platform/podjs/rollup.config.js
@@ -4,12 +4,21 @@ import sucrase from "@rollup/plugin-sucrase";
 import json from "@rollup/plugin-json";
 
 function suppressSomeWarnings(warning, warn, code, regex) {
-    if (warning.code === code && warning.cycle[0].match(regex)) {
-        return;
-    } else {
-        warn(warning);
-    }
+    if (warning.code != code || !warning.cycle[0].match(regex)) warn(warning);
 }
+
+const common = {
+    plugins: [
+        json(),
+        resolve(),
+        commonjs(),
+        sucrase({
+            exclude: ["node_modules/**"],
+            transforms: ["typescript"],
+        }),
+    ],
+    context: "window",
+};
 
 export default [
     {
@@ -23,16 +32,7 @@ export default [
                 },
             },
         ],
-        plugins: [
-            json(),
-            resolve(),
-            commonjs(),
-            sucrase({
-                exclude: ["node_modules/**"],
-                transforms: ["typescript"],
-            }),
-        ],
-        context: "window",
+        ...common,
         external: ["chai"],
         onwarn: (warning, warn) =>
             suppressSomeWarnings(
@@ -50,16 +50,7 @@ export default [
                 format: "iife",
             },
         ],
-        plugins: [
-            json(),
-            resolve(),
-            commonjs(),
-            sucrase({
-                exclude: ["node_modules/**"],
-                transforms: ["typescript"],
-            }),
-        ],
-        context: "window",
+        ...common,
         onwarn: (warning, warn) =>
             suppressSomeWarnings(
                 warning,

--- a/platform/podjs/rollup.config.js
+++ b/platform/podjs/rollup.config.js
@@ -3,10 +3,6 @@ import resolve from "@rollup/plugin-node-resolve";
 import sucrase from "@rollup/plugin-sucrase";
 import json from "@rollup/plugin-json";
 
-function suppressMatchingWarnings(warning, warn, code, regex) {
-    if (warning.code != code || !warning.cycle[0].match(regex)) warn(warning);
-}
-
 const common = {
     plugins: [
         json(),
@@ -18,6 +14,13 @@ const common = {
         }),
     ],
     context: "window",
+    onwarn: (warning, warn) => {
+        if (
+            warning.code != "CIRCULAR_DEPENDENCY" ||
+            !warning.cycle[0].match(/fast-check|chai\.js/)
+        )
+            warn(warning);
+    },
 };
 
 export default [
@@ -34,13 +37,6 @@ export default [
         ],
         ...common,
         external: ["chai"],
-        onwarn: (warning, warn) =>
-            suppressMatchingWarnings(
-                warning,
-                warn,
-                "CIRCULAR_DEPENDENCY",
-                /fast-check/
-            ),
     },
     {
         input: "src/pod.ts",
@@ -51,12 +47,5 @@ export default [
             },
         ],
         ...common,
-        onwarn: (warning, warn) =>
-            suppressMatchingWarnings(
-                warning,
-                warn,
-                "CIRCULAR_DEPENDENCY",
-                /fast-check|chai\.js/
-            ),
     },
 ];


### PR DESCRIPTION


<!-- 
    Thank you for your contribution to the polyPod repo. 🌻

    Please, make sure that:
    - You wait till the build is finished and is green
    - Tests for the changes have been added, if possible (for bug fixes / new features)
    - Docs have been reviewed and added / updated, if needed (for bug fixes / new features)
    - Commits in this PR are minimal and have descriptive commit messages.

    Before submitting this PR, please fill the following information on the following sections.
-->


# ✍️ Description

The code has been DRYed. I've created a better regex, because the previous one, as indicated by @snoack in #1126, was eliminating every warning.

This one takes care of the two kinds of warnings that were there

## ℹ️ Other information

There are a couple of places where the same pattern was used to suppress warnings.  If this new code is OK for everyone (it was already used in a couple of places), I can also refactor those within this same PR.

♥️ Thank you!
