### PR TITLE
feat: prod4pod-1829 - add theming support to Storybook

### DIFF
--- a/feature-utils/poly-look/storybook/.storybook/react/preview.js
+++ b/feature-utils/poly-look/storybook/.storybook/react/preview.js
@@ -1,9 +1,0 @@
-export const parameters = {
-    actions: { argTypesRegex: "^on[A-Z].*" },
-    controls: {
-        matchers: {
-            color: /(background|color)$/i,
-            date: /Date$/,
-        },
-    },
-};

--- a/feature-utils/poly-look/storybook/.storybook/react/preview.jsx
+++ b/feature-utils/poly-look/storybook/.storybook/react/preview.jsx
@@ -1,0 +1,57 @@
+import "../../../src/css/index.js";
+import "../../stories/react-components/demo.css";
+import "../../stories/react-components/fontFamily.css";
+
+const withTheme = (Story, context) => {
+  const theme = context.globals.theme;
+  switch (theme) {
+    case "side-by-side": {
+      return (
+        <>
+          <div className="poly-theme poly-theme-light theme-holder holder-left">
+            <Story />
+          </div>
+          <div className="poly-theme poly-theme-dark theme-holder holder-right">
+            <Story />
+          </div>
+        </>
+      );
+    }
+    default: {
+      return (
+        <div className={`poly-theme poly-theme-${theme}`}>
+          <Story />
+        </div>
+      );
+    }
+  }
+};
+
+export const decorators = [withTheme];
+
+export const globalTypes = {
+  theme: {
+    name: "Theme",
+    description: "Global theme for components",
+    defaultValue: "light",
+    toolbar: {
+      icon: "circlehollow",
+      items: [
+        { value: "light", icon: "circlehollow", title: "light" },
+        { value: "dark", icon: "circle", title: "dark" },
+        { value: "side-by-side", icon: "sidebar", title: "side by side" },
+      ],
+      showName: true,
+    },
+  },
+};
+
+export const parameters = {
+  actions: { argTypesRegex: "^on[A-Z].*" },
+  controls: {
+    matchers: {
+      color: /(background|color)$/i,
+      date: /Date$/,
+    },
+  },
+};

--- a/feature-utils/poly-look/storybook/.storybook/react/preview.jsx
+++ b/feature-utils/poly-look/storybook/.storybook/react/preview.jsx
@@ -1,3 +1,5 @@
+import { withDesign } from "storybook-addon-designs";
+
 import "../../../src/css/index.js";
 import "../../stories/react-components/demo.css";
 import "../../stories/react-components/fontFamily.css";
@@ -27,7 +29,7 @@ const withTheme = (Story, context) => {
   }
 };
 
-export const decorators = [withTheme];
+export const decorators = [withTheme, withDesign];
 
 export const globalTypes = {
   theme: {

--- a/feature-utils/poly-look/storybook/stories/react-components/buttons/icon.stories.js
+++ b/feature-utils/poly-look/storybook/stories/react-components/buttons/icon.stories.js
@@ -1,14 +1,9 @@
 import React from "react";
-import { withDesign } from "storybook-addon-designs";
 import { IconButton } from "../../../../src/react-components/buttons/";
-
-import "../../../../src/css/index.js";
-import "../fontFamily.css";
 
 export default {
   title: "Visuals/Atoms/Button/Icon",
   component: IconButton,
-  decorators: [withDesign],
   argTypes: {
     onClick: { action: "clicked" },
     fillDirection: {

--- a/feature-utils/poly-look/storybook/stories/react-components/buttons/polyButton.stories.js
+++ b/feature-utils/poly-look/storybook/stories/react-components/buttons/polyButton.stories.js
@@ -1,18 +1,13 @@
 import React from "react";
-import { withDesign } from "storybook-addon-designs";
 import { PolyButton } from "../../../../src/react-components/buttons/";
-
-import "../../../../src/css/index.js";
-import "../fontFamily.css";
 
 export default {
   title: "Visuals/Atoms/Button/PolyButton",
   component: PolyButton,
-  decorators: [withDesign],
   argTypes: {
     onClick: { action: "clicked" },
-    theme: {
-      options: ["dark", "light"],
+    type: {
+      options: ["filled", "outline"],
       control: { type: "radio" },
     },
     className: {
@@ -22,17 +17,13 @@ export default {
   },
 };
 
-const Template = (args) => (
-  <div className={`poly-theme poly-theme-${args.theme || "dark"}`}>
-    <PolyButton {...args} />
-  </div>
-);
+const Template = (args) => <PolyButton {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
   label: "Button",
   disabled: false,
-  theme: "dark",
+  type: "filled",
 };
 Default.parameters = {
   design: {

--- a/feature-utils/poly-look/storybook/stories/react-components/demo.css
+++ b/feature-utils/poly-look/storybook/stories/react-components/demo.css
@@ -8,3 +8,22 @@
   padding: 16px;
   box-sizing: border-box;
 }
+
+.theme-holder {
+  padding: 1rem;
+  position: absolute;
+  top: 0;
+  width: 50vw;
+  height: 100vh;
+  bottom: 0;
+  overflow: auto;
+  box-sizing: border-box;
+}
+.holder-left {
+  left: 0;
+  right: 50vh;
+}
+.holder-right {
+  left: 50vw;
+  right: 0;
+}

--- a/feature-utils/poly-look/storybook/stories/react-components/infographic.stories.js
+++ b/feature-utils/poly-look/storybook/stories/react-components/infographic.stories.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { Infographic } from "../../../src/react-components";
 
-import "../../../src/css/index.js";
-import "./fontFamily.css";
 import svg from "!!raw-loader!../../assets/images/nodes.svg";
 
 export default {

--- a/feature-utils/poly-look/storybook/stories/react-components/legend.stories.js
+++ b/feature-utils/poly-look/storybook/stories/react-components/legend.stories.js
@@ -5,9 +5,6 @@ import {
   CircleLegend,
 } from "../../../src/react-components";
 
-import "../../../src/css/index.js";
-import "./fontFamily.css";
-
 export default {
   title: "Visuals/Molecules/Legends",
 };

--- a/feature-utils/poly-look/storybook/stories/react-components/overlays/sideSheet.stories.js
+++ b/feature-utils/poly-look/storybook/stories/react-components/overlays/sideSheet.stories.js
@@ -1,9 +1,5 @@
 import React from "react";
-import { withDesign } from "storybook-addon-designs";
 import { SideSheet } from "../../../../src/react-components";
-
-import "../../../../src/css/index.js";
-import "../fontFamily.css";
 
 const textFiller = `Lorem ipsum dolor sit amet, consectetur adipiscing
 elit.Morbi volutpat, lectus vitae facilisis mattis, leo sem fringilla tortor,
@@ -22,7 +18,6 @@ eros. Donec luctus purus enim, sit amet sagittis leo vulputate at.`;
 export default {
   component: SideSheet,
   title: "Visuals/Molecules/SideSheet",
-  decorators: [withDesign],
   argTypes: {
     okLabel: { control: "text" },
     onOk: { action: "clicked" },

--- a/feature-utils/poly-look/storybook/stories/react-components/overlays/sideSwiper.stories.js
+++ b/feature-utils/poly-look/storybook/stories/react-components/overlays/sideSwiper.stories.js
@@ -1,8 +1,5 @@
 import React, { useState } from "react";
 import { SideSwiper } from "../../../../src/react-components/";
-import "../../../../src/css/index.js";
-import "../fontFamily.css";
-import "../demo.css";
 
 export default {
   component: SideSwiper,

--- a/feature-utils/poly-look/storybook/stories/react-components/slideshow.stories.js
+++ b/feature-utils/poly-look/storybook/stories/react-components/slideshow.stories.js
@@ -1,11 +1,9 @@
 import React from "react";
-import { withDesign } from "storybook-addon-designs";
 import { Slideshow } from "../../../src/react-components";
 
 export default {
   title: "Visuals/Molecules/Slideshow",
   component: Slideshow,
-  decorators: [withDesign],
 };
 
 const Template = (args) => <Slideshow {...args} />;

--- a/feature-utils/poly-look/storybook/stories/react-components/tooltip.stories.js
+++ b/feature-utils/poly-look/storybook/stories/react-components/tooltip.stories.js
@@ -1,9 +1,6 @@
 import React from "react";
 import { Tooltip } from "../../../src/react-components";
 
-import "../../../src/css/index.js";
-import "./fontFamily.css";
-
 export default {
   title: "Visuals/Molecules/Tooltip",
   component: Tooltip,


### PR DESCRIPTION
# ✍️ Description
Since we are in the process of improving our theming and looking at better usage of design tokens, this PR is supporting that effort by adding theming support to Storybook.


### 🏗️ Fixes [prod4pod-1875](https://jira.polypoly.eu/browse/PROD4POD-1875)


## ℹ️ Other information
The main changes are in `preview.jsx` and they were done by adapting this [blog post](https://storybook.js.org/blog/how-to-add-a-theme-switcher-to-storybook/) to our needs.
We now have the possibility or toggling the themes directly from the toolbar without having to do any more manual wiring ourselves. 
 
![sb-update](https://user-images.githubusercontent.com/17316907/187411556-54bab994-8f1b-41f6-8897-ba02607d877f.JPG)

