### PR TITLE
Fix Android tests

### DIFF
--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -34,13 +34,11 @@ class MainActivity : AppCompatActivity(), LifecycleEventObserver {
             logger.info("Core is bootstrapped!")
         } catch (ex: Exception) {
             logger.info(ex.message)
-            (ex as? CoreFailure)?.also {
-                // Ignore CoreAlreadyBootstrapped error, as it is not breaking.
-                if (it.code == CoreExceptionCode.CoreAlreadyBootstrapped) {
-                    return
-                }
-            }
-            throw ex
+            // Ignore CoreAlreadyBootstrapped error, as it is not breaking.
+            if ((ex as? CoreFailure)?.code
+                != CoreExceptionCode.CoreAlreadyBootstrapped
+            )
+                throw ex
         }
 
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)


### PR DESCRIPTION
# ✍️ Description

The tests initialise the Main activity multiple times, which does
apparently not really happen during normal usage of the app.

There was an error in the logic that tried to ignore multiple
initialisations of the core - it would create the activity, but not
populate it at all.