### PR TITLE
PROD4POD-1884 - Fix Screen component overlap

### DIFF
--- a/dev-utils/poly-cli/src/static/templates/index.jsx
+++ b/dev-utils/poly-cli/src/static/templates/index.jsx
@@ -6,7 +6,7 @@ import "./styles.css";
 
 const App = () => {
     return (
-        <div>
+        <div className="feature-container">
             <h1>{i18n.t("common:welcome", { feature: "This feature" })}</h1>
         </div>
     );

--- a/dev-utils/poly-cli/src/static/templates/preview/index.jsx
+++ b/dev-utils/poly-cli/src/static/templates/preview/index.jsx
@@ -118,7 +118,7 @@ const App = () => {
     }, []);
 
     return (
-        <div className="preview-screen-container">
+        <div className="feature-container">
             <div className="poly-nav-bar-separator-overlay" />
             <Screen
                 className="poly-theme-light background-white"

--- a/feature-utils/poly-look/src/css/layout.css
+++ b/feature-utils/poly-look/src/css/layout.css
@@ -16,7 +16,7 @@
   font-size: var(--font-size-xl);
 }
 
-.preview-screen-container {
+.feature-container {
   position: absolute;
   z-index: 99;
   width: 100%;

--- a/features/amazonDataImporterPreview/src/index.jsx
+++ b/features/amazonDataImporterPreview/src/index.jsx
@@ -118,7 +118,7 @@ const App = () => {
     }, []);
 
     return (
-        <div className="preview-screen-container">
+        <div className="feature-container">
             <div className="poly-nav-bar-separator-overlay" />
             <Screen
                 className="poly-theme-light background-white"

--- a/features/companyDataCleanerPreview/src/index.jsx
+++ b/features/companyDataCleanerPreview/src/index.jsx
@@ -117,7 +117,7 @@ const App = () => {
     }, []);
 
     return (
-        <div className="preview-screen-container">
+        <div className="feature-container">
             <div className="poly-nav-bar-separator-overlay" />
             <Screen
                 className="poly-theme-light background-white"

--- a/features/cooperativeMembershipPreview/src/index.jsx
+++ b/features/cooperativeMembershipPreview/src/index.jsx
@@ -117,7 +117,7 @@ const App = () => {
     }, []);
 
     return (
-        <div className="preview-screen-container">
+        <div className="feature-container">
             <div className="poly-nav-bar-separator-overlay" />
             <Screen
                 className="poly-theme-light background-white"

--- a/features/featureStorePreview/src/index.jsx
+++ b/features/featureStorePreview/src/index.jsx
@@ -118,7 +118,7 @@ const App = () => {
     }, []);
 
     return (
-        <div className="preview-screen-container">
+        <div className="feature-container">
             <div className="poly-nav-bar-separator-overlay" />
             <Screen
                 className="poly-theme-light background-white"

--- a/features/gdprDataImporterPreview/src/index.jsx
+++ b/features/gdprDataImporterPreview/src/index.jsx
@@ -117,7 +117,7 @@ const App = () => {
     }, []);
 
     return (
-        <div className="preview-screen-container">
+        <div className="feature-container">
             <div className="poly-nav-bar-separator-overlay" />
             <Screen
                 className="poly-theme-light background-white"

--- a/features/netflixDataImporterPreview/src/index.jsx
+++ b/features/netflixDataImporterPreview/src/index.jsx
@@ -118,7 +118,7 @@ const App = () => {
     }, []);
 
     return (
-        <div className="preview-screen-container">
+        <div className="feature-container">
             <div className="poly-nav-bar-separator-overlay" />
             <Screen
                 className="poly-theme-light background-white"

--- a/features/polyTalkPreview/src/index.jsx
+++ b/features/polyTalkPreview/src/index.jsx
@@ -118,7 +118,7 @@ const App = () => {
     }, []);
 
     return (
-        <div className="preview-screen-container">
+        <div className="feature-container">
             <div className="poly-nav-bar-separator-overlay" />
             <Screen
                 className="poly-theme-light background-white"

--- a/features/polypediaPreview/src/index.jsx
+++ b/features/polypediaPreview/src/index.jsx
@@ -118,7 +118,7 @@ const App = () => {
     }, []);
 
     return (
-        <div className="preview-screen-container">
+        <div className="feature-container">
             <div className="poly-nav-bar-separator-overlay" />
             <Screen
                 className="poly-theme-light background-white"

--- a/features/polypolyMembership/src/index.jsx
+++ b/features/polypolyMembership/src/index.jsx
@@ -7,11 +7,13 @@ import "./styles.css";
 
 const App = () => {
     return (
-        <Screen className="membership" layout="poly-standard-layout">
-            <h1>{i18n.t("common:welcome", { feature: "This feature" })}</h1>
-            <PolyButton label="example" />
-            <PolyButton type="outline" label="example secondary button" />
-        </Screen>
+        <div className="feature-container">
+            <Screen className="membership" layout="poly-standard-layout">
+                <h1>{i18n.t("common:welcome", { feature: "This feature" })}</h1>
+                <PolyButton label="example" />
+                <PolyButton type="outline" label="example secondary button" />
+            </Screen>
+        </div>
     );
 };
 

--- a/features/polypolyMembershipPreview/src/index.jsx
+++ b/features/polypolyMembershipPreview/src/index.jsx
@@ -118,7 +118,7 @@ const App = () => {
     }, []);
 
     return (
-        <div className="preview-screen-container">
+        <div className="feature-container">
             <div className="poly-nav-bar-separator-overlay" />
             <Screen
                 className="poly-theme-light background-white"


### PR DESCRIPTION
# ✍️ Description

Every time we implemented the `Screen` component in a new feature, it covered the nav bar on the top. We have been fixing it in each feature, but it happened every time that we created a new one. 

In order to create a more permanent solution, I have created a `feature-container` class in `poly-look` and added it to the "feature" and "preview-feature" templates in `poly-cli`. This fixes the problem for potential new features.

I have also added/replaced that class for the current features that didn't have it yet.

### 🏗️ Fixes [PROD4POD-1884](https://jira.polypoly.eu/browse/PROD4POD-1884)


## ℹ️ Other information

[How it looked like.](https://jira.polypoly.eu/secure/attachment/14665/How%20it%20looks%202.png)
[How it looks now.](https://jira.polypoly.eu/secure/attachment/14663/How%20it%20should%20look%202.png)
