### PR TITLE
:rotating_light: Address linting warnings

### DIFF
--- a/platform/feature-api/api/src/pod-api/mock-store.ts
+++ b/platform/feature-api/api/src/pod-api/mock-store.ts
@@ -6,10 +6,11 @@ export interface MockStore {
 }
 
 export class MockStore implements MockStore {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     update(_query: string): Promise<void> {
         return new Promise(() => null);
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     query(_query: string): Promise<SPARQLQueryResult> {
         return new Promise(() => false);
     }


### PR DESCRIPTION
# ✍️ Description

Since they must adhere to a specific interface, it seems the most sensible thing to just disable the warning

♥️ Thank you!
