### PR TITLE
[♻] Speculatively eliminate possibly unused port declaration

### DIFF
--- a/platform/ios/PolyPodApp/FeatureContainer/initIframe.js
+++ b/platform/ios/PolyPodApp/FeatureContainer/initIframe.js
@@ -1,4 +1,4 @@
-const { port1, port2 } = new MessageChannel();
+const { port1 } = new MessageChannel();
 
 function initIframe(el) {
     port1.start();
@@ -6,5 +6,4 @@ function initIframe(el) {
         // incoming msgpack-encoded events:
         webkit.messageHandlers.event.postMessage(event.data);
     };
-    el.contentWindow.postMessage("", "*", [port2]);
 }


### PR DESCRIPTION
# ✍️ Description

This was attempted in #1128, but it was possibly out of scope. However, we need to understand what it does and why we need it here. `port2` is not mentioned once in the iOS Swift code. There's no message handler installed, in the same way there's one for `port1`. The code was introduced in a commit with a bunch of changes, without really addressing any specific need that we knew about.

So I will speculatively eliminate it here.

* If tests fail, we're good, we needed it.
* If they don't, let's build and test the app. If building or testing fail somewhere, let's add some test to the Swift test set that's able to detect what kind of behavior or functionality. this was adding

At any rate, the outcome I expect from this PR (and consequent merging or not) is to better understand the codebase and how the iOS interacts with the polyPod.

♥️ Thank you!
