### PR TITLE
feat(polyLook) - prod4pod-1879 add icon options to PolyButton

### DIFF
--- a/feature-utils/poly-look/src/css/design-system-tokens/spacing.css
+++ b/feature-utils/poly-look/src/css/design-system-tokens/spacing.css
@@ -1,7 +1,7 @@
 :root {
 /* Spacing units for margins, padding, grid, position (top, bottom, right, left) 
 
-Potencial use for future "Figma tokens" variables. Currectly used in Banner component as example. */
+Potential use for future "Figma tokens" variables. Currently used in Banner and PolyButton component as example. */
   --pl-space-1x: 4px;
   --pl-space-2x: calc(var(--pl-space-1x) * 2);
   --pl-space-3x: calc(var(--pl-space-1x) * 3);
@@ -12,4 +12,8 @@ Potencial use for future "Figma tokens" variables. Currectly used in Banner comp
   --pl-space-8x: calc(var(--pl-space-1x) * 8);
   --pl-space-9x: calc(var(--pl-space-1x) * 9);
   --pl-space-10x: calc(var(--pl-space-1x) * 10);
+
+  --pl-small-button-spacing-gap: var(--pl-space-1x);
+  --pl-small-button-spacing-padding-vert: var(--pl-space-2x);
+  --pl-small-button-spacing-padding-hor: var(--pl-space-3x);
 }

--- a/feature-utils/poly-look/src/css/icons.css
+++ b/feature-utils/poly-look/src/css/icons.css
@@ -1,0 +1,8 @@
+:root {
+  --pl-icon-small: 16px;
+}
+
+.poly-icon-small {
+  width: var(--pl-icon-small);
+  height: var(--pl-icon-small);
+}

--- a/feature-utils/poly-look/src/css/index.js
+++ b/feature-utils/poly-look/src/css/index.js
@@ -2,6 +2,7 @@ import "./styles.css";
 import "./colors.css";
 import "./design-tokens.css";
 import "./themes.css";
+import "./icons.css";
 import "./font.css";
 import "./layout.css";
 import "./design-system-tokens/radius.css";

--- a/feature-utils/poly-look/src/react-components/buttons/polyButton.css
+++ b/feature-utils/poly-look/src/react-components/buttons/polyButton.css
@@ -3,7 +3,6 @@
   font-size: 18px;
   padding: 4px 12px;
   height: 48px;
-  width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -30,3 +29,25 @@
   color: var(--pl-button-color-text-secondary);
   background-color: var(--pl-button-color-fill-secondary);
 }
+
+.poly-button.small {
+  padding: var(--pl-small-button-spacing-padding-vert)
+    var(--pl-small-button-spacing-padding-hor);
+}
+
+.poly-button .icon {
+  display: inherit;
+}
+
+.poly-button .icon-left {
+  margin-right: var(--pl-small-button-spacing-gap);
+}
+
+.poly-button .icon-right {
+  margin-left: var(--pl-small-button-spacing-gap);
+}
+
+.poly-button.large {
+  width: 100%;
+}
+

--- a/feature-utils/poly-look/src/react-components/buttons/polyButton.jsx
+++ b/feature-utils/poly-look/src/react-components/buttons/polyButton.jsx
@@ -5,10 +5,17 @@ import "./polyButton.css";
  * Basic button.
  * In addition to `label` and `centered` any valid button HTML attributes
  * are allowed.
+ * If either `iconLeft` or `iconRight` are specified, the button size will
+ * be set to small.
  * @param {Object} props
  * @param {string} [props.label] - Button text
  * @param {boolean} [props.centered] - If the button should center itself.
  * @param {string} [props.type = "filled"] - Type of the button
+ * @param {string} [props.size = "large"] - Size of the button
+ * @param {JSX} [props.iconLeft] - Optional icon to be displayed on the left side
+ * of the label.
+ * @param {JSX} [props.iconRight] - Optional icon to be displayed on the right
+ * side of the label.
  */
 
 const types = {
@@ -16,15 +23,43 @@ const types = {
   outline: "outline",
 };
 
-const PolyButton = ({ label, type = "filled", ...otherProps }) => {
+const sizes = {
+  large: "large",
+  small: "small",
+};
+
+const PolyButton = ({
+  label,
+  type = "filled",
+  size = "large",
+  iconLeft,
+  iconRight,
+  ...otherProps
+}) => {
   return (
     <button
       {...otherProps}
       className={`poly-button ${types[type]} ${
-        otherProps.className || ""
-      }`.trim()}
+        iconLeft || iconRight ? sizes.small : sizes[size]
+      } ${otherProps.className || ""}`.trim()}
     >
+      {iconLeft && (
+        <span
+          data-testid="test-icon"
+          className="poly-icon-small icon icon-left"
+        >
+          {iconLeft}
+        </span>
+      )}
       {label}
+      {iconRight && (
+        <span
+          data-testid="test-icon"
+          className="poly-icon-small icon icon-right"
+        >
+          {iconRight}
+        </span>
+      )}
     </button>
   );
 };

--- a/feature-utils/poly-look/storybook/.storybook/react/preview.jsx
+++ b/feature-utils/poly-look/storybook/.storybook/react/preview.jsx
@@ -21,7 +21,9 @@ const withTheme = (Story, context) => {
     }
     default: {
       return (
-        <div className={`poly-theme poly-theme-${theme}`}>
+        <div
+          className={`poly-theme poly-theme-${theme} theme-holder single-holder`}
+        >
           <Story />
         </div>
       );

--- a/feature-utils/poly-look/storybook/stories/react-components/buttons/polyButton.stories.js
+++ b/feature-utils/poly-look/storybook/stories/react-components/buttons/polyButton.stories.js
@@ -13,10 +13,19 @@ export default {
     className: {
       type: "string",
     },
+    size: {
+      control: { type: "radio" },
+      options: ["small", "large"],
+    },
     centered: { type: "boolean" },
   },
 };
 
+const InlineSVG = () => (
+  <svg viewBox="0 0 100 100">
+    <path d="M 10 10 H 90 V 90 H 10 L 10 10" fill="currentColor" />
+  </svg>
+);
 const Template = (args) => <PolyButton {...args} />;
 
 export const Default = Template.bind({});
@@ -31,9 +40,18 @@ Default.parameters = {
     url: "https://www.figma.com/file/qIrr4QJrmYGqVQHQoCECux/polyPod-design-system?node-id=2891%3A2856",
   },
 };
+
 export const Disabled = Template.bind({});
 Disabled.args = {
   ...Default.args,
   disabled: true,
 };
 Disabled.parameters = { ...Default.parameters };
+
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  ...Default.args,
+  iconLeft: <InlineSVG />,
+  iconRight: <InlineSVG />,
+};
+WithIcon.parameters = { ...Default.parameters };

--- a/feature-utils/poly-look/storybook/stories/react-components/demo.css
+++ b/feature-utils/poly-look/storybook/stories/react-components/demo.css
@@ -18,7 +18,9 @@
   bottom: 0;
   overflow: auto;
   box-sizing: border-box;
+  background-color: var(--pl-screen-color-fill);
 }
+
 .holder-left {
   left: 0;
   right: 50vh;
@@ -26,4 +28,9 @@
 .holder-right {
   left: 50vw;
   right: 0;
+}
+
+.single-holder {
+  left: 0;
+  width: 100%;
 }

--- a/feature-utils/poly-look/test/react-components/buttons/polyButton.test.js
+++ b/feature-utils/poly-look/test/react-components/buttons/polyButton.test.js
@@ -5,18 +5,29 @@ import "@testing-library/jest-dom";
 import { PolyButton } from "../../../src/react-components";
 
 describe("PolyButton", () => {
-  test("Creates a basic button", () => {
+  it("creates a basic button", () => {
     const onClick = jest.fn();
-    const { getByText } = render(
+    const { getByText, queryAllByTestId } = render(
       <PolyButton label={"button"} onClick={onClick} />
     );
+
     expect(getByText("button")).toBeTruthy();
+    expect(queryAllByTestId("test-icon").length).toBe(0);
+
     fireEvent.click(getByText("button"));
     expect(onClick).toBeCalled();
   });
 
-  test("Created a disabled button", () => {
+  it("created a disabled button", () => {
     const { getByText } = render(<PolyButton label={"button"} disabled />);
     expect(getByText("button")).toBeDisabled();
+  });
+
+  it("renders the icons", () => {
+    const Icon = () => <svg></svg>;
+    const { queryAllByTestId } = render(
+      <PolyButton iconLeft={<Icon />} iconRight={<Icon />} />
+    );
+    expect(queryAllByTestId("test-icon").length).toBe(2);
   });
 });


### PR DESCRIPTION
# ✍️ Description
This PR adds icon(s) to the PollyButton component.

While in practice we would only use one of the icon options, there are no code restrictions for that.

Initially I had planned for `iconLeft` and `iconRight` to accept either a string representing a path  or a component as prop (current implementation) and let the button decide how to render that.
After some consideration to theming I've decided to get rid of the `img` support and keep only the component as prop approach. That's done to encourage the inline SVG approach to icons.
I haven't added any css rule for the fill because I'm not sure how the icons would look like, so I'll leave it up to the dev using this component to decide.

<!-- Link here the related JIRA issue in case of a bug / feature -->
### 🏗️ Fixes [PROD4POD-1879](https://jira.polypoly.eu/browse/PROD4POD-1879)



## ℹ️ Other information
In the examples below, the square is an inline SVG with fill set to `currentColor`. For theming that would be the ideal approach.

![icon_all](https://user-images.githubusercontent.com/17316907/188896028-70fbe019-3026-49b7-b49e-e1e729726a10.JPG)

