### PR TITLE
[♻] `unescape` is deprecated

### DIFF
--- a/features/facebookImport/test/mocks/zipfile-mock.js
+++ b/features/facebookImport/test/mocks/zipfile-mock.js
@@ -85,7 +85,7 @@ export class ZipFileMock {
     }
 
     addTextEntry(fileName, stringContent) {
-        const escapedString = unescape(encodeURIComponent(stringContent));
+        const escapedString = decodeURI(encodeURIComponent(stringContent));
         this.addEncodingEntry(fileName, escapedString);
     }
 


### PR DESCRIPTION
I bumped into this while refactoring facebookImport.

# ✍️ Description

Changed one instance of unescape. The other one, in `jsonStringifyWithUtfEscape` is tricky, since it's apparently relying on some undocumented feature.
The other one is tricky, since it's apparently relying on some undocumented feature. ~But I need to look into it, since I'm not totally sure we still need it after #1158 ~
Well, it's used to generate mock JSON files with the same weird encoding that Facebook has. After #1158, we might need to invert the `decode` function we added there. Might still be in scope.

 ♥️ Thank you!
