### PR TITLE
Deal with missing analyses

### DIFF
--- a/features/facebookImport/src/locales/de/explore.json
+++ b/features/facebookImport/src/locales/de/explore.json
@@ -9,5 +9,6 @@
     "reportCard.button": "Mehr erfahren",
     "details.button": "Details ansehen",
     "analysis.label.techDemo": "Tech Demo",
-    "scroll": "Scrollen Sie weiter, um mehr zu sehen"
+    "scroll": "Scrollen Sie weiter, um mehr zu sehen",
+    "details.noAnalyses": "Leider können wir auf Grundlage Ihrer Daten keine Erkenntnisse präsentieren. Wenn Sie glauben, dass es sich um einen Fehler handelt, nehmen Sie bitte Kontakt mit uns auf und helfen Sie uns weiter."
 }

--- a/features/facebookImport/src/locales/en/explore.json
+++ b/features/facebookImport/src/locales/en/explore.json
@@ -9,5 +9,6 @@
     "reportCard.button": "Learn more",
     "details.button": "View details",
     "analysis.label.techDemo": "Tech demo",
-    "scroll": "Scroll to view more"
+    "scroll": "Scroll to view more",
+    "details.noAnalyses": "Unfortunately, we were unable to present any insights based on the data you imported. If you think this is a bug, please get in touch and help us out."
 }

--- a/features/facebookImport/src/views/explore/explore.jsx
+++ b/features/facebookImport/src/views/explore/explore.jsx
@@ -83,45 +83,53 @@ const ExploreView = () => {
                     message={i18n.t("explore:loading")}
                 />
             );
+
+        function renderMinistory(ministory, index) {
+            const content = (
+                <>
+                    <h1>{ministory.title}</h1>
+                    {ministory.label !== null && (
+                        <label>
+                            {i18n.t(
+                                `explore:analysis.label.${ministory.label}`
+                            )}
+                        </label>
+                    )}
+                    {ministory.render()}
+                </>
+            );
+            return ministory.hasDetails() ? (
+                <RoutingWrapper
+                    key={index}
+                    history={history}
+                    route="/explore/details"
+                    stateChange={{
+                        ActiveStoryClass: ministory.constructor.name,
+                    }}
+                >
+                    <ClickableCard
+                        key={index}
+                        buttonText={i18n.t("explore:details.button")}
+                    >
+                        {content}
+                    </ClickableCard>
+                </RoutingWrapper>
+            ) : (
+                <Card key={index}>{content}</Card>
+            );
+        }
+
+        const activeMinistories = ministories
+            .map((MinistoryClass) => new MinistoryClass({ account }))
+            .filter(({ active }) => active);
         return (
             <List>
                 <ReportCard />
-                {ministories.map((MinistoryClass, index) => {
-                    const ministory = new MinistoryClass({
-                        account,
-                    });
-                    if (!ministory.active) return;
-                    const content = (
-                        <>
-                            <h1>{ministory.title}</h1>
-                            {ministory.label !== null && (
-                                <label>
-                                    {i18n.t(
-                                        `explore:analysis.label.${ministory.label}`
-                                    )}
-                                </label>
-                            )}
-                            {ministory.render()}
-                        </>
-                    );
-                    return ministory.hasDetails() ? (
-                        <RoutingWrapper
-                            key={index}
-                            history={history}
-                            route="/explore/details"
-                            stateChange={{ ActiveStoryClass: MinistoryClass }}
-                        >
-                            <ClickableCard
-                                key={index}
-                                buttonText={i18n.t("explore:details.button")}
-                            >
-                                {content}
-                            </ClickableCard>
-                        </RoutingWrapper>
-                    ) : (
-                        <Card key={index}>{content}</Card>
-                    );
-                })}
+                {!activeMinistories.length ? (
+                    <Card>{i18n.t("explore:details.noAnalyses")}</Card>
+                ) : (
+                    activeMinistories.map(renderMinistory)
+                )}
             </List>
         );
     };

--- a/features/facebookImport/src/views/ministories/dataImportingStatus.jsx
+++ b/features/facebookImport/src/views/ministories/dataImportingStatus.jsx
@@ -7,7 +7,7 @@ import i18n from "!silly-i18n";
 class DataImportingStatusReport extends ReportStory {
     constructor(props) {
         super(props);
-        this._neededReports = [analysisKeys.importersData];
+        this.neededReports = [analysisKeys.importersData];
     }
     get title() {
         return i18n.t("report:status");

--- a/features/facebookImport/src/views/ministories/missingKnownJsonFiles.jsx
+++ b/features/facebookImport/src/views/ministories/missingKnownJsonFiles.jsx
@@ -6,7 +6,7 @@ import ReportStory from "./reportStory.jsx";
 class MissingKnownJSONFilesReport extends ReportStory {
     constructor(props) {
         super(props);
-        this._neededReports = [analysisKeys.missingKnownFileNames];
+        this.neededReports = [analysisKeys.missingKnownFileNames];
     }
     get title() {
         return "Missing known JSON files";

--- a/features/facebookImport/src/views/ministories/offFacebookEventsTypes.jsx
+++ b/features/facebookImport/src/views/ministories/offFacebookEventsTypes.jsx
@@ -6,7 +6,7 @@ import ReportStory from "./reportStory.jsx";
 class OffFacebookEventsTypesReport extends ReportStory {
     constructor(props) {
         super(props);
-        this._neededReports = [analysisKeys.offFacebookEventTypes];
+        this.neededReports = [analysisKeys.offFacebookEventTypes];
     }
 
     get title() {

--- a/features/facebookImport/src/views/ministories/reportMetadata.jsx
+++ b/features/facebookImport/src/views/ministories/reportMetadata.jsx
@@ -5,7 +5,7 @@ import ReportStory from "./reportStory.jsx";
 class ReportMetadataReport extends ReportStory {
     constructor(props) {
         super(props);
-        this._neededReports = [analysisKeys.reportMetadata];
+        this.neededReports = [analysisKeys.reportMetadata];
     }
     get title() {
         return "Report Metadata";

--- a/features/facebookImport/src/views/ministories/unknownTopLevelFolders.jsx
+++ b/features/facebookImport/src/views/ministories/unknownTopLevelFolders.jsx
@@ -6,7 +6,7 @@ import ReportStory from "./reportStory.jsx";
 class UnknownTopLevelFoldersReport extends ReportStory {
     constructor(props) {
         super(props);
-        this._neededReports = [analysisKeys.unknownFolderNames];
+        this.neededReports = [analysisKeys.unknownFolderNames];
     }
     get title() {
         return "Unknown top-level folders";


### PR DESCRIPTION
# ✍️ Description
For a variety of reasons, it can happen that there are no analyses in
the account object. With this change, we deal with that in two ways:

1. We show a message to the user when no stories could be rendered.
2. The report works even if there aren't any (report) analyses.

### 🏗️ Fixes (PROD4POD-1895)