### PR TITLE
Rename importercontext to facebookcontext

### DIFF
--- a/features/facebookImport/rollup.config.mjs
+++ b/features/facebookImport/rollup.config.mjs
@@ -76,7 +76,7 @@ export default (commandLineArgs) => {
             // overwite the default warning function
             if (
                 warning.code === "CIRCULAR_DEPENDENCY" &&
-                warning.cycle[0].match(/(d3-|importer-context)/)
+                warning.cycle[0].match(/(d3-|facebook-context)/)
             ) {
                 return;
             } else {

--- a/features/facebookImport/src/components/buttons/infoButton/infoButton.jsx
+++ b/features/facebookImport/src/components/buttons/infoButton/infoButton.jsx
@@ -1,10 +1,10 @@
 import React, { useContext } from "react";
-import { ImporterContext } from "../../../context/importer-context.jsx";
+import { FacebookContext } from "../../../context/facebook-context.jsx";
 
 import "./infoButton.css";
 
 const InfoButton = ({ infoScreen }) => {
-    const { createPopUp } = useContext(ImporterContext);
+    const { createPopUp } = useContext(FacebookContext);
 
     const handleClick = () => {
         createPopUp({ type: infoScreen });

--- a/features/facebookImport/src/components/routeButton.jsx
+++ b/features/facebookImport/src/components/routeButton.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { useHistory } from "react-router-dom";
-import { ImporterContext } from "../context/importer-context.jsx";
+import { FacebookContext } from "../context/facebook-context.jsx";
 
 const RouteButton = ({
     route,
@@ -10,7 +10,7 @@ const RouteButton = ({
     onClick = () => {},
 }) => {
     const { handleBack, changeNavigationState, navigationState } =
-        useContext(ImporterContext);
+        useContext(FacebookContext);
     const history = useHistory();
 
     let changedNavigationState = navigationState;

--- a/features/facebookImport/src/context/facebook-context.jsx
+++ b/features/facebookImport/src/context/facebook-context.jsx
@@ -5,7 +5,7 @@ import { useHistory, useLocation } from "react-router-dom";
 
 import popUps from "../popUps";
 
-export const ImporterContext = React.createContext();
+export const FacebookContext = React.createContext();
 
 function updatePodNavigation(pod, history, handleBack, location) {
     pod.polyNav.actions = {
@@ -28,7 +28,7 @@ function updateTitle(pod, location, popUp) {
     );
 }
 
-export const ImporterProvider = ({ children }) => {
+export const FacebookProvider = ({ children }) => {
     const [pod, setPod] = useState(null);
     const [isLoading, setIsLoading] = useState(true);
     const [globalError, setGlobalError] = useState(null);
@@ -72,7 +72,7 @@ export const ImporterProvider = ({ children }) => {
     });
 
     return (
-        <ImporterContext.Provider
+        <FacebookContext.Provider
             value={{
                 pod,
                 handleBack,
@@ -89,6 +89,6 @@ export const ImporterProvider = ({ children }) => {
             }}
         >
             {children}
-        </ImporterContext.Provider>
+        </FacebookContext.Provider>
     );
 };

--- a/features/facebookImport/src/facebookImporter.jsx
+++ b/features/facebookImport/src/facebookImporter.jsx
@@ -9,9 +9,9 @@ import {
 } from "react-router-dom";
 
 import {
-    ImporterProvider,
-    ImporterContext,
-} from "./context/importer-context.jsx";
+    FacebookProvider,
+    FacebookContext,
+} from "./context/facebook-context.jsx";
 import {
     INITIAL_HISTORY_STATE,
     PolyImportContext,
@@ -33,7 +33,7 @@ import "./styles.css";
 
 const FacebookImporter = () => {
     const { pod, globalError, setGlobalError, isLoading, popUp, closePopUp } =
-        useContext(ImporterContext);
+        useContext(FacebookContext);
 
     const { files } = useContext(PolyImportContext);
 
@@ -110,16 +110,16 @@ const FacebookImporterApp = () => {
 
     return (
         <Router history={history}>
-            <ImporterProvider>
+            <FacebookProvider>
                 <PolyImportProvider
-                    parentContext={ImporterContext}
+                    parentContext={FacebookContext}
                     dataImporters={dataImporters}
                     DataAccount={FacebookAccount}
                 >
                     <div className="poly-nav-bar-separator-overlay" />
                     <FacebookImporter />
                 </PolyImportProvider>
-            </ImporterProvider>
+            </FacebookProvider>
         </Router>
     );
 };

--- a/features/facebookImport/src/popUps/baseInfoPopUp/baseInfoPopUp.jsx
+++ b/features/facebookImport/src/popUps/baseInfoPopUp/baseInfoPopUp.jsx
@@ -1,12 +1,12 @@
 import React, { useContext } from "react";
-import { ImporterContext } from "../../context/importer-context.jsx";
+import { FacebookContext } from "../../context/facebook-context.jsx";
 
 import i18n from "!silly-i18n";
 
 import "./baseInfoPopUp.css";
 
 const BaseInfoPopUp = ({ infoChildren }) => {
-    const { closePopUp } = useContext(ImporterContext);
+    const { closePopUp } = useContext(FacebookContext);
 
     return (
         <div className="base-info">

--- a/features/facebookImport/src/views/explore/explore.jsx
+++ b/features/facebookImport/src/views/explore/explore.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useRef } from "react";
 import { useHistory } from "react-router-dom";
-import { ImporterContext } from "../../context/importer-context.jsx";
+import { FacebookContext } from "../../context/facebook-context.jsx";
 import {
     List,
     Card,
@@ -20,7 +20,7 @@ import "./explore.css";
 import { ministories } from "../ministories/ministories.js";
 
 const ExploreView = () => {
-    const { reportResult, setReportResult } = useContext(ImporterContext);
+    const { reportResult, setReportResult } = useContext(FacebookContext);
     const { account } = useContext(PolyImportContext);
 
     const history = useHistory();

--- a/features/facebookImport/src/views/import/import.jsx
+++ b/features/facebookImport/src/views/import/import.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
-import { ImporterContext } from "../../context/importer-context.jsx";
+import { FacebookContext } from "../../context/facebook-context.jsx";
 import { FileSelectionError, FileImportError } from "@polypoly-eu/poly-import";
 import { PolyImportContext, ProgressBar, Screen } from "@polypoly-eu/poly-look";
 import ImportExplanationExpandable from "../../components/importExplanationExpandable/importExplanationExpandable.jsx";
@@ -60,7 +60,7 @@ async function writeImportStatus(pod, status) {
 
 const Import = () => {
     const { pod, setGlobalError, runWithLoadingScreen } =
-        useContext(ImporterContext);
+        useContext(FacebookContext);
     const { files, handleRemoveFile, refreshFiles } =
         useContext(PolyImportContext);
     const [importStatus, setImportStatus] = useState(importSteps.beginning);

--- a/features/facebookImport/src/views/report/report.jsx
+++ b/features/facebookImport/src/views/report/report.jsx
@@ -1,13 +1,13 @@
 import React, { useContext, useState } from "react";
 import RouteButton from "../../components/buttons/routeButton.jsx";
-import { ImporterContext } from "../../context/importer-context.jsx";
+import { FacebookContext } from "../../context/facebook-context.jsx";
 
 import i18n from "!silly-i18n";
 
 import "./report.css";
 
 const ReportView = ({ reportStories }) => {
-    const { setReportResult, handleBack } = useContext(ImporterContext);
+    const { setReportResult, handleBack } = useContext(FacebookContext);
     const [loading, setLoading] = useState(false);
 
     const handleSendReport = async () => {

--- a/features/google/rollup.config.mjs
+++ b/features/google/rollup.config.mjs
@@ -78,7 +78,7 @@ export default (commandLineArgs) => {
             // overwite the default warning function
             if (
                 warning.code === "CIRCULAR_DEPENDENCY" &&
-                warning.cycle[0].match(/(d3-|importer-context)/)
+                warning.cycle[0].match(/(d3-|google-context)/)
             ) {
                 return;
             } else {


### PR DESCRIPTION
# ✍️ As title
I think this clashes with poly-import, which does something completely different and then we have google-context. So it only makes sense to have facebook-context 
