### PR TITLE
[🐛] PROD4POD-1752

### DIFF
--- a/platform/android/app/src/main/AndroidManifest.xml
+++ b/platform/android/app/src/main/AndroidManifest.xml
@@ -50,7 +50,7 @@
 
         <receiver
             android:name=".AppUpdateReceiver"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>

--- a/platform/android/app/src/main/AndroidManifest.xml
+++ b/platform/android/app/src/main/AndroidManifest.xml
@@ -43,7 +43,6 @@
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
         <activity
-
             android:name=".settings.SettingsActivity"
             android:exported="false"
             android:label="@string/settings_title"


### PR DESCRIPTION
# ✍️ Description

Change exported to false so that it can't be used from other applications. This is tentative, since it might be used from the integrations tests,

Essentially follows suggestion by setting exported to `false`

### 🏗️ Fixes PROD4POD-1752


 ♥️ Thank you! 
