### PR TITLE
Tweak GitHub Actions

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -9,7 +9,7 @@ on:
             - "platform/ios/**"
             - ".github/workflows/ios-test.yml"
     pull_request:
-        types: [assigned, opened, ready_for_review]
+        types: [opened]
         paths:
             - "feature-utils/**"
             - "features/**"

--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -2,7 +2,7 @@ name: Test pushes and PRs
 on:
   push:
   pull_request:
-    types: [assigned, opened, ready_for_review ]
+    types: [opened]
 
 jobs:
   test:

--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -2,7 +2,7 @@ name: Test pushes and PRs
 on:
   push:
   pull_request:
-    types: [assigned, opened, ready_for_review, closed]
+    types: [assigned, opened, ready_for_review ]
 
 jobs:
   test:


### PR DESCRIPTION
# ✍️ Description

Now, additionally to the tests that are run when a push happens, it runs additional tests when certain things happen in a PR. This is not really necessary, since PRs follow the same code path that would follow the latest commit. Duplicated tests can be useful to detect flappers, but this specific test does not have a lot of them. Will leave just one duplicated test to take care of that, and that's that.

♥️ Thank you!
