### PR TITLE
[♻] Address deprecations and other warnings in Kotlin

### DIFF
--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenContainers.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenContainers.kt
@@ -28,8 +28,8 @@ fun yourDataContainers(
         when (val type = containersConfig[index % containersConfig.count()]) {
             ContainerType.LARGELEFT -> Container(
                 type = type,
-                tiles = theseTiles.mapIndexed { idx, tileModel ->
-                    if (idx == 0) {
+                tiles = theseTiles.mapIndexed { tileIndex, tileModel ->
+                    if (tileIndex == 0) {
                         Tile(
                             tileModel,
                             bigTileStyle,
@@ -61,7 +61,7 @@ fun yourDataContainers(
             )
             ContainerType.LARGERIGHT -> Container(
                 type = type,
-                tiles = theseTiles.mapIndexed { idx, tileModel ->
+                tiles = theseTiles.mapIndexed { tileIndex, tileModel ->
                     if (theseTiles.count() < tilesPerContainer) {
                         Tile(
                             tileModel,
@@ -70,7 +70,7 @@ fun yourDataContainers(
                             TileType.SMALL
                         )
                     } else {
-                        if (idx == theseTiles.count() - 1) {
+                        if (tileIndex == theseTiles.count() - 1) {
                             Tile(
                                 tileModel,
                                 bigTileStyle,

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenContainers.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/homescreen/HomeScreenContainers.kt
@@ -24,12 +24,12 @@ fun yourDataContainers(
         ContainerType.ROW
     )
 
-    return chunked.mapIndexed { index, tiles ->
+    return chunked.mapIndexed { index, theseTiles ->
         when (val type = containersConfig[index % containersConfig.count()]) {
             ContainerType.LARGELEFT -> Container(
                 type = type,
-                tiles = tiles.mapIndexed { index, tileModel ->
-                    if (index == 0) {
+                tiles = theseTiles.mapIndexed { idx, tileModel ->
+                    if (idx == 0) {
                         Tile(
                             tileModel,
                             bigTileStyle,
@@ -49,7 +49,7 @@ fun yourDataContainers(
             )
             ContainerType.ROW -> Container(
                 type = type,
-                tiles = tiles.map { tileModel ->
+                tiles = theseTiles.map { tileModel ->
                     Tile(
                         tileModel,
                         smallTileStyle,
@@ -61,8 +61,8 @@ fun yourDataContainers(
             )
             ContainerType.LARGERIGHT -> Container(
                 type = type,
-                tiles = tiles.mapIndexed { index, tileModel ->
-                    if (tiles.count() < tilesPerContainer) {
+                tiles = theseTiles.mapIndexed { idx, tileModel ->
+                    if (theseTiles.count() < tilesPerContainer) {
                         Tile(
                             tileModel,
                             smallTileStyle,
@@ -70,7 +70,7 @@ fun yourDataContainers(
                             TileType.SMALL
                         )
                     } else {
-                        if (index == tiles.count() - 1) {
+                        if (idx == theseTiles.count() - 1) {
                             Tile(
                                 tileModel,
                                 bigTileStyle,

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
@@ -147,6 +147,6 @@ open class Network(val context: Context) {
         } finally {
             connection.disconnect()
         }
-        return@withContext response // unreachable code needed for return type inference
+        return@withContext response
     }
 }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
@@ -146,9 +146,7 @@ open class Network(val context: Context) {
                 connection.inputStream.bufferedReader().use { it.readText() }
         } finally {
             connection.disconnect()
-            return@withContext response
         }
-        @Suppress("UNREACHABLE_CODE")
         return@withContext response // unreachable code needed for return type inference
     }
 }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
@@ -124,7 +124,6 @@ open class Network(val context: Context) {
             connection.disconnect()
             return@withContext response
         }
-        return@withContext response
     }
 
     open suspend fun httpGet(
@@ -149,6 +148,5 @@ open class Network(val context: Context) {
             connection.disconnect()
             return@withContext response
         }
-        return@withContext response
     }
 }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
@@ -124,6 +124,8 @@ open class Network(val context: Context) {
             connection.disconnect()
             return@withContext response
         }
+        @Suppress("UNREACHABLE_CODE")
+        return@withContext response // unreachable code needed for return type inference
     }
 
     open suspend fun httpGet(
@@ -148,5 +150,7 @@ open class Network(val context: Context) {
             connection.disconnect()
             return@withContext response
         }
+        @Suppress("UNREACHABLE_CODE")
+        return@withContext response // unreachable code needed for return type inference
     }
 }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/network/Network.kt
@@ -122,10 +122,8 @@ open class Network(val context: Context) {
                 connection.inputStream.bufferedReader().use { it.readText() }
         } finally {
             connection.disconnect()
-            return@withContext response
         }
-        @Suppress("UNREACHABLE_CODE")
-        return@withContext response // unreachable code needed for return type inference
+        return@withContext response
     }
 
     open suspend fun httpGet(


### PR DESCRIPTION
In tests or builds such as [this one](https://github.com/polypoly-eu/polyPod/actions/runs/3088056402/jobs/4994093066) there are a number of warnings (which also show up in Android Studio) that are not caught by the linter

![Captura de pantalla de 2022-09-20 10-41-10](https://user-images.githubusercontent.com/500/191211090-d645fe6c-ce8a-43f7-a3a3-4219135e0875.png)



# ✍️ Description

Address warnings as well as possible

* Rename shadowed variables
* Eliminate unreachable code

> Refactoring deprecated code might be in scope, but needs a bit of research


 ♥️ Thank you!
