### PR TITLE
Fix bug when clicking details by changing way story is transferred via state

### DIFF
--- a/features/facebookImport/src/views/explore/details.jsx
+++ b/features/facebookImport/src/views/explore/details.jsx
@@ -1,5 +1,5 @@
-import { PolyImportContext, Screen } from "@polypoly-eu/poly-look";
-import React, { useContext } from "react";
+import { Screen } from "@polypoly-eu/poly-look";
+import React from "react";
 import { useHistory } from "react-router-dom";
 import Story from "../../views/ministories/story.jsx";
 
@@ -7,13 +7,9 @@ import "./details.css";
 
 const ExploreDetails = () => {
     const history = useHistory();
-    const { account } = useContext(PolyImportContext);
 
-    const { ActiveStoryClass } = history.location.state;
-    const activeStory = new ActiveStoryClass({
-        account,
-        mode: Story.MODES.DETAILS,
-    });
+    const { activeStory } = history.location.state;
+    activeStory.mode = Story.MODES.DETAILS;
     return (
         <Screen className="details-view" layout="poly-standard-layout">
             <h1>{activeStory.title}</h1>

--- a/features/facebookImport/src/views/explore/explore.jsx
+++ b/features/facebookImport/src/views/explore/explore.jsx
@@ -95,13 +95,14 @@ const ExploreView = () => {
                     {ministory.render()}
                 </>
             );
+
             return ministory.hasDetails() ? (
                 <RoutingWrapper
                     key={index}
                     history={history}
                     route="/explore/details"
                     stateChange={{
-                        ActiveStoryClass: ministory.constructor.name,
+                        activeStory: ministory,
                     }}
                 >
                     <ClickableCard


### PR DESCRIPTION
Bug introduced here https://github.com/polypoly-eu/polyPod/commit/e83ebe6f5fce4580deddd0e4fba16ddac25d59a4

`ministory.constructor.name` is a string while it expects a `storyClass`

Now it gets the actual story so it doesn't need to be generated twice anymore