### PR TITLE
Add update_notification library

### DIFF
--- a/platform/core/Cargo.lock
+++ b/platform/core/Cargo.lock
@@ -1564,6 +1564,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "update_notification"
+version = "0.1.0"
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/platform/core/crates/update_notification/Cargo.toml
+++ b/platform/core/crates/update_notification/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "update_notification"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/platform/core/crates/update_notification/src/lib.rs
+++ b/platform/core/crates/update_notification/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod update_notification;

--- a/platform/core/crates/update_notification/src/update_notification.rs
+++ b/platform/core/crates/update_notification/src/update_notification.rs
@@ -1,0 +1,87 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(PartialEq, Copy, Clone)]
+#[repr(C)]
+pub enum Seen {
+    NOT,
+    PUSH,
+    ALL,
+}
+
+pub trait UpdateNotificationStorage {
+    fn read_id(&self) -> u32;
+    fn read_last_id(&self) -> Option<u32>;
+    fn read_last_state(&self) -> Option<Seen>;
+    fn write_last(&mut self, id: u32, state: Seen);
+}
+
+#[repr(C)]
+pub struct UpdateNotification {
+    storage: Rc<RefCell<dyn UpdateNotificationStorage>>,
+    id: u32,
+    last_id: u32,
+    last_state: Seen,
+}
+
+impl UpdateNotification {
+    // Would be ideal if the storage instance could just be passed in as a
+    // reference, or anything simpler than Rc<RefCell<>>.
+    pub fn new(storage: Rc<RefCell<dyn UpdateNotificationStorage>>) -> Self {
+        Self {
+            storage: storage.clone(),
+            id: storage.borrow().read_id(),
+            last_id: storage.borrow().read_last_id().unwrap_or(0),
+            last_state: storage.borrow().read_last_state().unwrap_or(Seen::NOT),
+        }
+    }
+
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    fn show<F: Fn(Seen) -> bool>(&self, show_for_last_state: F) -> bool {
+        if self.id == 0 || self.id < self.last_id {
+            return false;
+        }
+        if self.id > self.last_id {
+            return true;
+        }
+        show_for_last_state(self.last_state)
+    }
+
+    pub fn handle_first_run(&mut self) {
+        self.handle_in_app_seen();
+    }
+
+    pub fn handle_startup(&mut self) {
+        self.handle_push_seen();
+    }
+
+    pub fn show_in_app(&self) -> bool {
+        self.show(|state| state != Seen::ALL)
+    }
+
+    pub fn show_push(&self) -> bool {
+        self.show(|state| state == Seen::NOT)
+    }
+
+    fn update_last(&mut self, state: Seen) {
+        self.last_id = self.id;
+        self.last_state = state;
+        self.storage
+            .borrow_mut()
+            .write_last(self.last_id, self.last_state);
+    }
+
+    pub fn handle_in_app_seen(&mut self) {
+        self.update_last(Seen::ALL);
+    }
+
+    pub fn handle_push_seen(&mut self) {
+        if self.last_state != Seen::NOT {
+            return;
+        }
+        self.update_last(Seen::PUSH);
+    }
+}

--- a/platform/core/crates/update_notification/tests/update_notification.rs
+++ b/platform/core/crates/update_notification/tests/update_notification.rs
@@ -1,0 +1,172 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use update_notification::update_notification::*;
+
+struct MockUpdateNotificationStorage {
+    mock_id: Option<u32>,
+    last_id: Option<u32>,
+    last_state: Option<Seen>,
+}
+
+impl MockUpdateNotificationStorage {
+    fn new() -> MockUpdateNotificationStorage {
+        MockUpdateNotificationStorage {
+            mock_id: None,
+            last_id: None,
+            last_state: None,
+        }
+    }
+}
+
+impl UpdateNotificationStorage for MockUpdateNotificationStorage {
+    fn read_id(&self) -> u32 {
+        self.mock_id.unwrap()
+    }
+
+    fn read_last_id(&self) -> Option<u32> {
+        self.last_id
+    }
+
+    fn read_last_state(&self) -> Option<Seen> {
+        self.last_state.clone()
+    }
+
+    fn write_last(&mut self, id: u32, state: Seen) {
+        self.last_id = Some(id);
+        self.last_state = Some(state);
+    }
+}
+
+macro_rules! assert_in_app_showing {
+    ($notification: expr) => {
+        assert!(
+            $notification.show_in_app(),
+            "Expected in app notification with id '{}' to show",
+            $notification.id()
+        );
+    };
+}
+
+macro_rules! assert_in_app_not_showing {
+    ($notification: expr) => {
+        assert!(
+            !$notification.show_in_app(),
+            "Expected in app notification with id '{}' to not show",
+            $notification.id()
+        );
+    };
+}
+
+macro_rules! assert_push_showing {
+    ($notification: expr) => {
+        assert!(
+            $notification.show_push(),
+            "Expected push notification with id '{}' to show",
+            $notification.id()
+        );
+    };
+}
+
+macro_rules! assert_push_not_showing {
+    ($notification: expr) => {
+        assert!(
+            !$notification.show_push(),
+            "Expected push notification with id '{}' to not show",
+            $notification.id()
+        );
+    };
+}
+
+macro_rules! assert_none_showing {
+    ($notification: expr) => {
+        assert_in_app_not_showing!($notification);
+        assert_push_not_showing!($notification);
+    };
+}
+
+macro_rules! assert_all_showing {
+    ($notification: expr) => {
+        assert_in_app_showing!($notification);
+        assert_push_showing!($notification);
+    };
+}
+
+fn create_storage() -> Rc<RefCell<MockUpdateNotificationStorage>> {
+    Rc::new(RefCell::new(MockUpdateNotificationStorage::new()))
+}
+
+fn create_notification(
+    storage: &Rc<RefCell<MockUpdateNotificationStorage>>,
+    mock_id: u32,
+) -> UpdateNotification {
+    storage.borrow_mut().mock_id = Some(mock_id);
+    UpdateNotification::new(storage.clone())
+}
+
+#[test]
+fn notification_with_id_0_seen() {
+    let storage = create_storage();
+    let notification = create_notification(&storage, 0);
+    assert_none_showing!(notification);
+}
+
+#[test]
+fn first_notification_not_seen() {
+    let storage = create_storage();
+    let notification = create_notification(&storage, 1);
+    assert_all_showing!(notification);
+}
+
+#[test]
+fn previously_seen_notification_seen() {
+    let storage = create_storage();
+    let mut notification = create_notification(&storage, 1);
+    notification.handle_in_app_seen();
+    assert_none_showing!(notification);
+}
+
+#[test]
+fn additional_notification_not_seen() {
+    let storage = create_storage();
+    let mut notification = create_notification(&storage, 1);
+    notification.handle_in_app_seen();
+
+    let second_notification = create_notification(&storage, 2);
+    assert_all_showing!(second_notification);
+}
+
+#[test]
+fn additonal_notification_with_lower_id_seen() {
+    let storage = create_storage();
+    let mut notification = create_notification(&storage, 2);
+    notification.handle_in_app_seen();
+
+    let second_notification = create_notification(&storage, 1);
+    assert_none_showing!(second_notification);
+}
+
+#[test]
+fn push_notification_seen_after_startup() {
+    let storage = create_storage();
+    let mut notification = create_notification(&storage, 1);
+    notification.handle_startup();
+    assert_in_app_showing!(notification);
+    assert_push_not_showing!(notification);
+}
+
+#[test]
+fn in_app_not_seen_after_push_seen() {
+    let storage = create_storage();
+    let mut notification = create_notification(&storage, 1);
+    notification.handle_push_seen();
+    assert_in_app_showing!(notification);
+    assert_push_not_showing!(notification);
+}
+
+#[test]
+fn all_seen_after_first_run() {
+    let storage = create_storage();
+    let mut notification = create_notification(&storage, 1);
+    notification.handle_first_run();
+    assert_none_showing!(notification);
+}


### PR DESCRIPTION
# ✍️ Description

The UpdateNotification logic is duplicated between Android and iOS right now. This moves it to platform/core.

### 🏗️ Fixes PROD4POD-1921