### PR TITLE
[Fix] d3 color security vulnerabilities

### DIFF
--- a/feature-utils/poly-look/package-lock.json
+++ b/feature-utils/poly-look/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@polypoly-eu/silly-i18n": "file:../silly-i18n",
-        "d3": "^7.6.1",
         "d3-sankey": "^0.12.3",
         "lit-element": "^2.5.1",
         "lit-html": "^1.4.1",
@@ -28,6 +27,7 @@
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
         "babel-jest": "^27.5.1",
+        "d3": "^7.6.1",
         "identity-obj-proxy": "^3.0.0",
         "svg-jest": "^1.0.1"
       }
@@ -4001,6 +4001,7 @@
     },
     "node_modules/commander": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -4130,6 +4131,7 @@
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
       "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
+      "dev": true,
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -4170,6 +4172,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
       "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
+      "dev": true,
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -4179,6 +4182,7 @@
     },
     "node_modules/d3-axis": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4186,6 +4190,7 @@
     },
     "node_modules/d3-brush": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -4200,6 +4205,7 @@
     },
     "node_modules/d3-chord": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "1 - 3"
@@ -4212,6 +4218,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -4220,6 +4227,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
       "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
+      "dev": true,
       "dependencies": {
         "d3-array": "^3.2.0"
       },
@@ -4229,6 +4237,7 @@
     },
     "node_modules/d3-delaunay": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "delaunator": "5"
@@ -4239,6 +4248,7 @@
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4246,6 +4256,7 @@
     },
     "node_modules/d3-drag": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -4257,6 +4268,7 @@
     },
     "node_modules/d3-dsv": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "commander": "7",
@@ -4280,6 +4292,7 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
@@ -4287,6 +4300,7 @@
     },
     "node_modules/d3-fetch": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dsv": "1 - 3"
@@ -4297,6 +4311,7 @@
     },
     "node_modules/d3-force": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -4309,6 +4324,7 @@
     },
     "node_modules/d3-format": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4316,6 +4332,7 @@
     },
     "node_modules/d3-geo": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.5.0 - 3"
@@ -4326,6 +4343,7 @@
     },
     "node_modules/d3-hierarchy": {
       "version": "3.1.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4333,6 +4351,7 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3"
@@ -4343,6 +4362,7 @@
     },
     "node_modules/d3-path": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4350,6 +4370,7 @@
     },
     "node_modules/d3-polygon": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4357,6 +4378,7 @@
     },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4364,6 +4386,7 @@
     },
     "node_modules/d3-random": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4401,6 +4424,7 @@
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.10.0 - 3",
@@ -4415,6 +4439,7 @@
     },
     "node_modules/d3-scale-chromatic": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -4426,6 +4451,7 @@
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4433,6 +4459,7 @@
     },
     "node_modules/d3-shape": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "1 - 3"
@@ -4443,6 +4470,7 @@
     },
     "node_modules/d3-time": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2 - 3"
@@ -4453,6 +4481,7 @@
     },
     "node_modules/d3-time-format": {
       "version": "4.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-time": "1 - 3"
@@ -4463,6 +4492,7 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4470,6 +4500,7 @@
     },
     "node_modules/d3-transition": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -4487,6 +4518,7 @@
     },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -4570,6 +4602,7 @@
     },
     "node_modules/delaunator": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.0"
@@ -5079,6 +5112,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -5165,6 +5199,7 @@
     },
     "node_modules/internmap": {
       "version": "2.0.3",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -6835,6 +6870,7 @@
     },
     "node_modules/robust-predicates": {
       "version": "3.0.1",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/rollup": {
@@ -6875,6 +6911,7 @@
     },
     "node_modules/rw": {
       "version": "1.3.3",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/safe-buffer": {
@@ -6884,6 +6921,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
@@ -10135,7 +10173,8 @@
       }
     },
     "commander": {
-      "version": "7.2.0"
+      "version": "7.2.0",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -10221,6 +10260,7 @@
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
       "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
+      "dev": true,
       "requires": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -10258,15 +10298,18 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
       "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
+      "dev": true,
       "requires": {
         "internmap": "1 - 2"
       }
     },
     "d3-axis": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "d3-brush": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -10277,6 +10320,7 @@
     },
     "d3-chord": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-path": "1 - 3"
       }
@@ -10284,27 +10328,32 @@
     "d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true
     },
     "d3-contour": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
       "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
+      "dev": true,
       "requires": {
         "d3-array": "^3.2.0"
       }
     },
     "d3-delaunay": {
       "version": "6.0.2",
+      "dev": true,
       "requires": {
         "delaunator": "5"
       }
     },
     "d3-dispatch": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-drag": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -10312,6 +10361,7 @@
     },
     "d3-dsv": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "commander": "7",
         "iconv-lite": "0.6",
@@ -10319,16 +10369,19 @@
       }
     },
     "d3-ease": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-fetch": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-dsv": "1 - 3"
       }
     },
     "d3-force": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-quadtree": "1 - 3",
@@ -10336,34 +10389,42 @@
       }
     },
     "d3-format": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "dev": true
     },
     "d3-geo": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-array": "2.5.0 - 3"
       }
     },
     "d3-hierarchy": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "d3-interpolate": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-color": "1 - 3"
       }
     },
     "d3-path": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-polygon": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-quadtree": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-random": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-sankey": {
       "version": "0.12.3",
@@ -10394,6 +10455,7 @@
     },
     "d3-scale": {
       "version": "4.0.2",
+      "dev": true,
       "requires": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -10404,37 +10466,44 @@
     },
     "d3-scale-chromatic": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
       }
     },
     "d3-selection": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "d3-shape": {
       "version": "3.1.0",
+      "dev": true,
       "requires": {
         "d3-path": "1 - 3"
       }
     },
     "d3-time": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-array": "2 - 3"
       }
     },
     "d3-time-format": {
       "version": "4.1.0",
+      "dev": true,
       "requires": {
         "d3-time": "1 - 3"
       }
     },
     "d3-timer": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-transition": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -10445,6 +10514,7 @@
     },
     "d3-zoom": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -10493,6 +10563,7 @@
     },
     "delaunator": {
       "version": "5.0.0",
+      "dev": true,
       "requires": {
         "robust-predicates": "^3.0.0"
       }
@@ -10819,6 +10890,7 @@
     },
     "iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -10863,7 +10935,8 @@
       "dev": true
     },
     "internmap": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "dev": true
     },
     "ip": {
       "version": "1.1.5",
@@ -11930,7 +12003,8 @@
       }
     },
     "robust-predicates": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "rollup": {
       "version": "2.63.0",
@@ -11947,14 +12021,16 @@
       }
     },
     "rw": {
-      "version": "1.3.3"
+      "version": "1.3.3",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
       "dev": true
     },
     "safer-buffer": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "dev": true
     },
     "scheduler": {
       "version": "0.20.2",

--- a/feature-utils/poly-look/package.json
+++ b/feature-utils/poly-look/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@polypoly-eu/silly-i18n": "file:../silly-i18n",
-    "d3": "^7.6.1",
     "d3-sankey": "^0.12.3",
     "lit-element": "^2.5.1",
     "lit-html": "^1.4.1",
@@ -35,6 +34,7 @@
     "@testing-library/react": "^12.1.3",
     "@web/test-runner": "^0.13.22",
     "babel-jest": "^27.5.1",
+    "d3": "^7.6.1",
     "identity-obj-proxy": "^3.0.0",
     "svg-jest": "^1.0.1"
   },

--- a/features/google/package-lock.json
+++ b/features/google/package-lock.json
@@ -10,7 +10,6 @@
         "@polypoly-eu/poly-analysis": "file:../../feature-utils/poly-analysis",
         "@polypoly-eu/poly-import": "file:../../feature-utils/poly-import",
         "@polypoly-eu/silly-i18n": "file:../../feature-utils/silly-i18n",
-        "d3": "^7.6.1",
         "dayjs": "^1.11.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -21,6 +20,7 @@
         "@polypoly-eu/poly-look": "file:../../feature-utils/poly-look",
         "@polypoly-eu/rollup-plugin-copy-watch": "file:../../dev-utils/rollup-plugin-copy-watch",
         "@rollup/plugin-json": "*",
+        "d3": "^7.6.1",
         "rollup-plugin-serve": "^1.1.0"
       }
     },
@@ -521,7 +521,6 @@
       "license": "MIT",
       "dependencies": {
         "@polypoly-eu/silly-i18n": "file:../silly-i18n",
-        "d3": "^7.6.1",
         "d3-sankey": "^0.12.3",
         "lit-element": "^2.5.1",
         "lit-html": "^1.4.1",
@@ -539,6 +538,7 @@
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
         "babel-jest": "^27.5.1",
+        "d3": "^7.6.1",
         "identity-obj-proxy": "^3.0.0",
         "svg-jest": "^1.0.1"
       }
@@ -6909,11 +6909,12 @@
       "name": "@polypoly-eu/podjs",
       "dependencies": {
         "@polypoly-eu/api": "file:../feature-api/api",
+        "@rollup/plugin-wasm": "^5.2.0",
         "@zip.js/zip.js": "2.3.7",
         "fp-ts": "^2.8.2",
         "io-ts": "^2.2.16",
-        "rdf-js": "^4.0.2",
-        "rdf-string": "^1.6.0"
+        "oxigraph": "^0.3.5",
+        "rdf-js": "^4.0.2"
       },
       "devDependencies": {
         "body-parser": "^1.19.0",
@@ -7769,6 +7770,7 @@
     },
     "node_modules/commander": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -7787,6 +7789,7 @@
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
       "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
+      "dev": true,
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -7827,6 +7830,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
       "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
+      "dev": true,
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -7836,6 +7840,7 @@
     },
     "node_modules/d3-axis": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7843,6 +7848,7 @@
     },
     "node_modules/d3-brush": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -7857,6 +7863,7 @@
     },
     "node_modules/d3-chord": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "1 - 3"
@@ -7869,6 +7876,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -7877,6 +7885,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
       "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
+      "dev": true,
       "dependencies": {
         "d3-array": "^3.2.0"
       },
@@ -7886,6 +7895,7 @@
     },
     "node_modules/d3-delaunay": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "delaunator": "5"
@@ -7896,6 +7906,7 @@
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7903,6 +7914,7 @@
     },
     "node_modules/d3-drag": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -7914,6 +7926,7 @@
     },
     "node_modules/d3-dsv": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "commander": "7",
@@ -7937,6 +7950,7 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
@@ -7944,6 +7958,7 @@
     },
     "node_modules/d3-fetch": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dsv": "1 - 3"
@@ -7954,6 +7969,7 @@
     },
     "node_modules/d3-force": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -7966,6 +7982,7 @@
     },
     "node_modules/d3-format": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7973,6 +7990,7 @@
     },
     "node_modules/d3-geo": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.5.0 - 3"
@@ -7983,6 +8001,7 @@
     },
     "node_modules/d3-hierarchy": {
       "version": "3.1.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7990,6 +8009,7 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3"
@@ -8000,6 +8020,7 @@
     },
     "node_modules/d3-path": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -8007,6 +8028,7 @@
     },
     "node_modules/d3-polygon": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -8014,6 +8036,7 @@
     },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -8021,6 +8044,7 @@
     },
     "node_modules/d3-random": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -8028,6 +8052,7 @@
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.10.0 - 3",
@@ -8042,6 +8067,7 @@
     },
     "node_modules/d3-scale-chromatic": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -8053,6 +8079,7 @@
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -8060,6 +8087,7 @@
     },
     "node_modules/d3-shape": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "1 - 3"
@@ -8070,6 +8098,7 @@
     },
     "node_modules/d3-time": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2 - 3"
@@ -8080,6 +8109,7 @@
     },
     "node_modules/d3-time-format": {
       "version": "4.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-time": "1 - 3"
@@ -8090,6 +8120,7 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -8097,6 +8128,7 @@
     },
     "node_modules/d3-transition": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -8114,6 +8146,7 @@
     },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -8150,6 +8183,7 @@
     },
     "node_modules/delaunator": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.0"
@@ -8248,6 +8282,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8258,6 +8293,7 @@
     },
     "node_modules/internmap": {
       "version": "2.0.3",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -8471,6 +8507,7 @@
     },
     "node_modules/robust-predicates": {
       "version": "3.0.1",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/rollup": {
@@ -8500,6 +8537,7 @@
     },
     "node_modules/rw": {
       "version": "1.3.3",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/safe-buffer": {
@@ -8510,6 +8548,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
@@ -8868,13 +8907,14 @@
       "version": "file:../../platform/podjs",
       "requires": {
         "@polypoly-eu/api": "file:../feature-api/api",
+        "@rollup/plugin-wasm": "^5.2.0",
         "@zip.js/zip.js": "2.3.7",
         "body-parser": "^1.19.0",
         "fast-check": "^2.11.0",
         "fp-ts": "^2.8.2",
         "io-ts": "^2.2.16",
-        "rdf-js": "^4.0.2",
-        "rdf-string": "^1.6.0"
+        "oxigraph": "^0.3.5",
+        "rdf-js": "^4.0.2"
       },
       "dependencies": {
         "@rdfjs/types": {
@@ -13784,7 +13824,8 @@
       "peer": true
     },
     "commander": {
-      "version": "7.2.0"
+      "version": "7.2.0",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.8.0",
@@ -13798,6 +13839,7 @@
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
       "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
+      "dev": true,
       "requires": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -13835,15 +13877,18 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
       "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
+      "dev": true,
       "requires": {
         "internmap": "1 - 2"
       }
     },
     "d3-axis": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "d3-brush": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -13854,6 +13899,7 @@
     },
     "d3-chord": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-path": "1 - 3"
       }
@@ -13861,27 +13907,32 @@
     "d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true
     },
     "d3-contour": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
       "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
+      "dev": true,
       "requires": {
         "d3-array": "^3.2.0"
       }
     },
     "d3-delaunay": {
       "version": "6.0.2",
+      "dev": true,
       "requires": {
         "delaunator": "5"
       }
     },
     "d3-dispatch": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-drag": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -13889,6 +13940,7 @@
     },
     "d3-dsv": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "commander": "7",
         "iconv-lite": "0.6",
@@ -13896,16 +13948,19 @@
       }
     },
     "d3-ease": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-fetch": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-dsv": "1 - 3"
       }
     },
     "d3-force": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-quadtree": "1 - 3",
@@ -13913,37 +13968,46 @@
       }
     },
     "d3-format": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "dev": true
     },
     "d3-geo": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-array": "2.5.0 - 3"
       }
     },
     "d3-hierarchy": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "d3-interpolate": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-color": "1 - 3"
       }
     },
     "d3-path": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-polygon": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-quadtree": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-random": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-scale": {
       "version": "4.0.2",
+      "dev": true,
       "requires": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -13954,37 +14018,44 @@
     },
     "d3-scale-chromatic": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
       }
     },
     "d3-selection": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "d3-shape": {
       "version": "3.1.0",
+      "dev": true,
       "requires": {
         "d3-path": "1 - 3"
       }
     },
     "d3-time": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-array": "2 - 3"
       }
     },
     "d3-time-format": {
       "version": "4.1.0",
+      "dev": true,
       "requires": {
         "d3-time": "1 - 3"
       }
     },
     "d3-timer": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-transition": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -13995,6 +14066,7 @@
     },
     "d3-zoom": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -14018,6 +14090,7 @@
     },
     "delaunator": {
       "version": "5.0.0",
+      "dev": true,
       "requires": {
         "robust-predicates": "^3.0.0"
       }
@@ -14085,12 +14158,14 @@
     },
     "iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "internmap": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "dev": true
     },
     "isarray": {
       "version": "0.0.1"
@@ -14229,7 +14304,8 @@
       "version": "3.0.0"
     },
     "robust-predicates": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "rollup": {
       "version": "2.79.0",
@@ -14250,7 +14326,8 @@
       }
     },
     "rw": {
-      "version": "1.3.3"
+      "version": "1.3.3",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -14258,7 +14335,8 @@
       "peer": true
     },
     "safer-buffer": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "dev": true
     },
     "scheduler": {
       "version": "0.20.2",

--- a/features/google/package.json
+++ b/features/google/package.json
@@ -14,8 +14,9 @@
     "@babel/preset-react": "^7.14.5",
     "@polypoly-eu/poly-look": "file:../../feature-utils/poly-look",
     "@polypoly-eu/rollup-plugin-copy-watch": "file:../../dev-utils/rollup-plugin-copy-watch",
-    "rollup-plugin-serve": "^1.1.0",
-    "@rollup/plugin-json": "*"
+    "@rollup/plugin-json": "*",
+    "d3": "^7.6.1",
+    "rollup-plugin-serve": "^1.1.0"
   },
   "private": true,
   "dependencies": {
@@ -23,7 +24,6 @@
     "@polypoly-eu/poly-analysis": "file:../../feature-utils/poly-analysis",
     "@polypoly-eu/poly-import": "file:../../feature-utils/poly-import",
     "@polypoly-eu/silly-i18n": "file:../../feature-utils/silly-i18n",
-    "d3": "^7.6.1",
     "dayjs": "^1.11.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/features/polyExplorer/package-lock.json
+++ b/features/polyExplorer/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@polypoly-eu/poly-look": "file:../../feature-utils/poly-look",
         "@polypoly-eu/silly-i18n": "file:../../feature-utils/silly-i18n",
-        "d3": "^7.3.0",
         "react-infinite-scroll-component": "^6.0.0",
         "react-router-dom": "^5.2.0",
         "swiper": "^6.4.11"
@@ -18,6 +17,7 @@
       "devDependencies": {
         "@polypoly-eu/podjs": "file:../../platform/podjs",
         "@polypoly-eu/rollup-plugin-copy-watch": "file:../../dev-utils/rollup-plugin-copy-watch",
+        "d3": "^7.6.1",
         "react": "^16.13.1",
         "react-dom": "^16.13.1"
       }
@@ -498,7 +498,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "d3": "^7.0.4",
+        "@polypoly-eu/silly-i18n": "file:../silly-i18n",
         "d3-sankey": "^0.12.3",
         "lit-element": "^2.5.1",
         "lit-html": "^1.4.1",
@@ -516,6 +516,7 @@
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
         "babel-jest": "^27.5.1",
+        "d3": "^7.6.1",
         "identity-obj-proxy": "^3.0.0",
         "svg-jest": "^1.0.1"
       }
@@ -3568,6 +3569,7 @@
     },
     "../../feature-utils/poly-look/node_modules/commander": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -3695,6 +3697,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3": {
       "version": "7.3.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "3",
@@ -3734,6 +3737,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-array": {
       "version": "3.1.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
@@ -3744,6 +3748,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-axis": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3751,6 +3756,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-brush": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -3765,6 +3771,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-chord": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "1 - 3"
@@ -3774,14 +3781,17 @@
       }
     },
     "../../feature-utils/poly-look/node_modules/d3-color": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
     },
     "../../feature-utils/poly-look/node_modules/d3-contour": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2 - 3"
@@ -3792,6 +3802,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-delaunay": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "delaunator": "5"
@@ -3802,6 +3813,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-dispatch": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3809,6 +3821,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-drag": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -3820,6 +3833,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-dsv": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "commander": "7",
@@ -3843,6 +3857,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-ease": {
       "version": "3.0.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
@@ -3850,6 +3865,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-fetch": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dsv": "1 - 3"
@@ -3860,6 +3876,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-force": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -3872,6 +3889,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-format": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3879,6 +3897,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-geo": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.5.0 - 3"
@@ -3889,6 +3908,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-hierarchy": {
       "version": "3.1.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3896,6 +3916,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-interpolate": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3"
@@ -3906,6 +3927,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-path": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3913,6 +3935,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-polygon": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3920,6 +3943,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-quadtree": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3927,6 +3951,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-random": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3964,6 +3989,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-scale": {
       "version": "4.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.10.0 - 3",
@@ -3978,6 +4004,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-scale-chromatic": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -3989,6 +4016,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-selection": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3996,6 +4024,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-shape": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "1 - 3"
@@ -4006,6 +4035,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-time": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2 - 3"
@@ -4016,6 +4046,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-time-format": {
       "version": "4.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-time": "1 - 3"
@@ -4026,6 +4057,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-timer": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4033,6 +4065,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-transition": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -4050,6 +4083,7 @@
     },
     "../../feature-utils/poly-look/node_modules/d3-zoom": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -4133,6 +4167,7 @@
     },
     "../../feature-utils/poly-look/node_modules/delaunator": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.0"
@@ -4605,6 +4640,7 @@
     },
     "../../feature-utils/poly-look/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4683,6 +4719,7 @@
     },
     "../../feature-utils/poly-look/node_modules/internmap": {
       "version": "2.0.3",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -6123,6 +6160,7 @@
     },
     "../../feature-utils/poly-look/node_modules/robust-predicates": {
       "version": "3.0.1",
+      "dev": true,
       "license": "Unlicense"
     },
     "../../feature-utils/poly-look/node_modules/rollup": {
@@ -6163,6 +6201,7 @@
     },
     "../../feature-utils/poly-look/node_modules/rw": {
       "version": "1.3.3",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "../../feature-utils/poly-look/node_modules/safe-buffer": {
@@ -6172,6 +6211,7 @@
     },
     "../../feature-utils/poly-look/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "../../feature-utils/poly-look/node_modules/scheduler": {
@@ -6771,7 +6811,7 @@
     "../../platform/feature-api/api/pod-api": {
       "name": "@polypoly-eu/pod-api",
       "version": "0.8.0",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "@polypoly-eu/rdf": "file:../rdf"
       },
@@ -6787,199 +6827,10 @@
         "memfs": "^3.2.0"
       }
     },
-    "../../platform/feature-api/api/pod-api/node_modules/@polypoly-eu/rdf": {
-      "resolved": "../../platform/feature-api/api/rdf",
-      "link": true
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/@polypoly-eu/rdf-spec": {
-      "resolved": "../../platform/feature-api/api/rdf-spec",
-      "link": true
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/@rdfjs/data-model": {
-      "version": "1.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": ">=1.0.1"
-      },
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/@rdfjs/dataset": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.2.0"
-      },
-      "bin": {
-        "rdfjs-dataset-test": "bin/test.js"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/@rdfjs/types": {
-      "version": "1.0.1",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/@types/chai": {
-      "version": "4.2.22",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/@types/chai-as-promised": {
-      "version": "7.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "*"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/@types/node": {
-      "version": "14.17.33",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/@types/rdfjs__dataset": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdf-js": "^4.0.2"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/assertion-error": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/chai": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/chai-as-promised": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "WTFPL",
-      "dependencies": {
-        "check-error": "^1.0.2"
-      },
-      "peerDependencies": {
-        "chai": ">= 2.1.2 < 5"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/check-error": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/deep-eql": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/fast-check": {
-      "version": "2.19.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pure-rand": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/fast-check"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/fs-monkey": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "Unlicense"
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/get-func-name": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/memfs": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "Unlicense",
-      "dependencies": {
-        "fs-monkey": "1.0.3"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/pathval": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/pure-rand": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/fast-check"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/rdf-js": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "../../platform/feature-api/api/pod-api/node_modules/type-detect": {
-      "version": "4.0.8",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "../../platform/feature-api/api/rdf": {
       "name": "@polypoly-eu/rdf",
       "version": "0.2.0",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "@types/rdf-js": "^4.0.0"
       },
@@ -6991,7 +6842,7 @@
     "../../platform/feature-api/api/rdf-spec": {
       "name": "@polypoly-eu/rdf-spec",
       "version": "0.3.1",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "chai": "^4.2.0",
         "fast-check": "^2.2.1"
@@ -7009,331 +6860,6 @@
         "rdf-data-factory": "^1.0.4"
       }
     },
-    "../../platform/feature-api/api/rdf-spec/node_modules/@graphy/core.data.factory": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "uri-js": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=8.4.0"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/@graphy/core.iso.stream": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8.4.0"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/@graphy/memory.dataset.fast": {
-      "version": "4.3.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@graphy/core.data.factory": "^4.3.3",
-        "@graphy/core.iso.stream": "^4.3.3"
-      },
-      "engines": {
-        "node": ">=8.4.0"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/@rdfjs/data-model": {
-      "version": "1.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": ">=1.0.1"
-      },
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/@rdfjs/dataset": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.2.0"
-      },
-      "bin": {
-        "rdfjs-dataset-test": "bin/test.js"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/@rdfjs/types": {
-      "version": "1.0.1",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/@types/chai": {
-      "version": "4.2.22",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/@types/n3": {
-      "version": "1.10.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "rdf-js": "^4.0.2"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/@types/node": {
-      "version": "14.17.32",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/@types/rdfjs__dataset": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdf-js": "^4.0.2"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/assertion-error": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/chai": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/check-error": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/deep-eql": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/fast-check": {
-      "version": "2.19.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pure-rand": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/fast-check"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/get-func-name": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "ISC"
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/n3": {
-      "version": "1.11.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.1.2",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/pathval": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/punycode": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/pure-rand": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/fast-check"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/rdf-data-factory": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/rdf-js": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/type-detect": {
-      "version": "4.0.8",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/uri-js": {
-      "version": "4.4.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "../../platform/feature-api/api/rdf-spec/node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/rdf/node_modules/@polypoly-eu/rdf-spec": {
-      "resolved": "../../platform/feature-api/api/rdf-spec",
-      "link": true
-    },
-    "../../platform/feature-api/api/rdf/node_modules/@rdfjs/data-model": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/rdf-js": "*"
-      },
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "../../platform/feature-api/api/rdf/node_modules/@types/node": {
-      "version": "14.14.22",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../platform/feature-api/api/rdf/node_modules/@types/rdf-js": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "../../platform/feature-api/utils": {
       "name": "@polypoly-eu/test-utils",
       "version": "0.0.1",
@@ -7343,35 +6869,21 @@
       "name": "@polypoly-eu/podjs",
       "dev": true,
       "dependencies": {
-        "@polypoly-eu/pod-api": "file:../feature-api/api/pod-api",
-        "@polypoly-eu/rdf": "file:../feature-api/api/rdf",
+        "@polypoly-eu/api": "file:../feature-api/api",
+        "@rollup/plugin-wasm": "^5.2.0",
         "@zip.js/zip.js": "2.3.7",
         "fp-ts": "^2.8.2",
         "io-ts": "^2.2.16",
-        "rdf-js": "^4.0.2",
-        "rdf-string": "^1.6.0"
+        "oxigraph": "^0.3.5",
+        "rdf-js": "^4.0.2"
       },
       "devDependencies": {
-        "@polypoly-eu/rdf-spec": "file:../feature-api/api/rdf-spec",
-        "@types/node": "^14.14.21",
         "body-parser": "^1.19.0",
         "fast-check": "^2.11.0"
       },
       "peerDependencies": {
         "body-parser": "^1.19.0"
       }
-    },
-    "../../platform/podjs/node_modules/@polypoly-eu/pod-api": {
-      "resolved": "../../platform/feature-api/api/pod-api",
-      "link": true
-    },
-    "../../platform/podjs/node_modules/@polypoly-eu/rdf": {
-      "resolved": "../../platform/feature-api/api/rdf",
-      "link": true
-    },
-    "../../platform/podjs/node_modules/@polypoly-eu/rdf-spec": {
-      "resolved": "../../platform/feature-api/api/rdf-spec",
-      "link": true
     },
     "../../platform/podjs/node_modules/@rdfjs/types": {
       "version": "1.0.1",
@@ -7661,15 +7173,17 @@
       "link": true
     },
     "node_modules/d3": {
-      "version": "7.3.0",
-      "license": "ISC",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
+      "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
+      "dev": true,
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
         "d3-brush": "3",
         "d3-chord": "3",
         "d3-color": "3",
-        "d3-contour": "3",
+        "d3-contour": "4",
         "d3-delaunay": "6",
         "d3-dispatch": "3",
         "d3-drag": "3",
@@ -7700,8 +7214,10 @@
       }
     },
     "node_modules/d3-array": {
-      "version": "3.1.1",
-      "license": "ISC",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
+      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
+      "dev": true,
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -7711,6 +7227,7 @@
     },
     "node_modules/d3-axis": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7718,6 +7235,7 @@
     },
     "node_modules/d3-brush": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -7732,6 +7250,7 @@
     },
     "node_modules/d3-chord": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "1 - 3"
@@ -7741,17 +7260,21 @@
       }
     },
     "node_modules/d3-color": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-contour": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
+      "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
+      "dev": true,
       "dependencies": {
-        "d3-array": "2 - 3"
+        "d3-array": "^3.2.0"
       },
       "engines": {
         "node": ">=12"
@@ -7759,6 +7282,7 @@
     },
     "node_modules/d3-delaunay": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "delaunator": "5"
@@ -7769,6 +7293,7 @@
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7776,6 +7301,7 @@
     },
     "node_modules/d3-drag": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -7787,6 +7313,7 @@
     },
     "node_modules/d3-dsv": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "commander": "7",
@@ -7810,6 +7337,7 @@
     },
     "node_modules/d3-dsv/node_modules/commander": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -7817,6 +7345,7 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
@@ -7824,6 +7353,7 @@
     },
     "node_modules/d3-fetch": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dsv": "1 - 3"
@@ -7834,6 +7364,7 @@
     },
     "node_modules/d3-force": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -7846,6 +7377,7 @@
     },
     "node_modules/d3-format": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7853,6 +7385,7 @@
     },
     "node_modules/d3-geo": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.5.0 - 3"
@@ -7863,6 +7396,7 @@
     },
     "node_modules/d3-hierarchy": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7870,6 +7404,7 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3"
@@ -7880,6 +7415,7 @@
     },
     "node_modules/d3-path": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7887,6 +7423,7 @@
     },
     "node_modules/d3-polygon": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7894,6 +7431,7 @@
     },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7901,6 +7439,7 @@
     },
     "node_modules/d3-random": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7908,6 +7447,7 @@
     },
     "node_modules/d3-scale": {
       "version": "4.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.10.0 - 3",
@@ -7922,6 +7462,7 @@
     },
     "node_modules/d3-scale-chromatic": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -7933,6 +7474,7 @@
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7940,6 +7482,7 @@
     },
     "node_modules/d3-shape": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "1 - 3"
@@ -7950,6 +7493,7 @@
     },
     "node_modules/d3-time": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2 - 3"
@@ -7960,6 +7504,7 @@
     },
     "node_modules/d3-time-format": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-time": "1 - 3"
@@ -7970,6 +7515,7 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7977,6 +7523,7 @@
     },
     "node_modules/d3-transition": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -7994,6 +7541,7 @@
     },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -8008,6 +7556,7 @@
     },
     "node_modules/delaunator": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.0"
@@ -8045,6 +7594,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8055,6 +7605,7 @@
     },
     "node_modules/internmap": {
       "version": "2.0.3",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -8202,14 +7753,17 @@
     },
     "node_modules/robust-predicates": {
       "version": "3.0.1",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/rw": {
       "version": "1.3.3",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
@@ -8277,1018 +7831,17 @@
     "@polypoly-eu/podjs": {
       "version": "file:../../platform/podjs",
       "requires": {
-        "@polypoly-eu/pod-api": "file:../feature-api/api/pod-api",
-        "@polypoly-eu/rdf": "file:../feature-api/api/rdf",
-        "@polypoly-eu/rdf-spec": "file:../feature-api/api/rdf-spec",
-        "@types/node": "^14.14.21",
+        "@polypoly-eu/api": "file:../feature-api/api",
+        "@rollup/plugin-wasm": "^5.2.0",
         "@zip.js/zip.js": "2.3.7",
         "body-parser": "^1.19.0",
         "fast-check": "^2.11.0",
         "fp-ts": "^2.8.2",
         "io-ts": "^2.2.16",
-        "rdf-js": "^4.0.2",
-        "rdf-string": "^1.6.0"
+        "oxigraph": "^0.3.5",
+        "rdf-js": "^4.0.2"
       },
       "dependencies": {
-        "@polypoly-eu/pod-api": {
-          "version": "file:../../platform/feature-api/api/pod-api",
-          "requires": {
-            "@polypoly-eu/rdf": "file:../rdf",
-            "@polypoly-eu/rdf-spec": "file:../rdf-spec",
-            "@rdfjs/dataset": "^1.0.1",
-            "@types/chai": "^4.2.14",
-            "@types/chai-as-promised": "^7.1.3",
-            "@types/rdfjs__dataset": "^1.0.4",
-            "chai": "^4.2.0",
-            "chai-as-promised": "^7.1.1",
-            "fast-check": "^2.11.0",
-            "memfs": "^3.2.0"
-          },
-          "dependencies": {
-            "@polypoly-eu/rdf": {
-              "version": "file:../../platform/feature-api/api/rdf",
-              "requires": {
-                "@polypoly-eu/rdf-spec": "file:../rdf-spec",
-                "@rdfjs/data-model": "^1.2.0",
-                "@types/rdf-js": "^4.0.0"
-              },
-              "dependencies": {
-                "@polypoly-eu/rdf-spec": {
-                  "version": "file:../../platform/feature-api/api/rdf-spec",
-                  "requires": {
-                    "@graphy/core.data.factory": "^4.3.4",
-                    "@graphy/memory.dataset.fast": "^4.3.3",
-                    "@rdfjs/data-model": "^1.1.3",
-                    "@rdfjs/dataset": "^1.0.1",
-                    "@types/chai": "^4.2.14",
-                    "@types/n3": "^1.10.3",
-                    "@types/node": "^14.17.9",
-                    "@types/rdfjs__dataset": "^1.0.4",
-                    "chai": "^4.2.0",
-                    "fast-check": "^2.2.1",
-                    "n3": "^1.8.0",
-                    "rdf-data-factory": "^1.0.4"
-                  },
-                  "dependencies": {
-                    "@graphy/core.data.factory": {
-                      "version": "4.3.4",
-                      "dev": true,
-                      "requires": {
-                        "uri-js": "^4.4.0"
-                      }
-                    },
-                    "@graphy/core.iso.stream": {
-                      "version": "4.3.4",
-                      "dev": true,
-                      "requires": {
-                        "readable-stream": "^3.6.0"
-                      }
-                    },
-                    "@graphy/memory.dataset.fast": {
-                      "version": "4.3.3",
-                      "dev": true,
-                      "requires": {
-                        "@graphy/core.data.factory": "^4.3.3",
-                        "@graphy/core.iso.stream": "^4.3.3"
-                      }
-                    },
-                    "@rdfjs/data-model": {
-                      "version": "1.3.4",
-                      "dev": true,
-                      "requires": {
-                        "@rdfjs/types": ">=1.0.1"
-                      }
-                    },
-                    "@rdfjs/dataset": {
-                      "version": "1.1.1",
-                      "dev": true,
-                      "requires": {
-                        "@rdfjs/data-model": "^1.2.0"
-                      }
-                    },
-                    "@rdfjs/types": {
-                      "version": "1.0.1",
-                      "dev": true,
-                      "requires": {
-                        "@types/node": "*"
-                      }
-                    },
-                    "@types/chai": {
-                      "version": "4.2.22",
-                      "dev": true
-                    },
-                    "@types/n3": {
-                      "version": "1.10.3",
-                      "dev": true,
-                      "requires": {
-                        "@types/node": "*",
-                        "rdf-js": "^4.0.2"
-                      }
-                    },
-                    "@types/node": {
-                      "version": "14.17.32",
-                      "dev": true
-                    },
-                    "@types/rdfjs__dataset": {
-                      "version": "1.0.5",
-                      "dev": true,
-                      "requires": {
-                        "rdf-js": "^4.0.2"
-                      }
-                    },
-                    "assertion-error": {
-                      "version": "1.1.0",
-                      "dev": true
-                    },
-                    "chai": {
-                      "version": "4.3.4",
-                      "dev": true,
-                      "requires": {
-                        "assertion-error": "^1.1.0",
-                        "check-error": "^1.0.2",
-                        "deep-eql": "^3.0.1",
-                        "get-func-name": "^2.0.0",
-                        "pathval": "^1.1.1",
-                        "type-detect": "^4.0.5"
-                      }
-                    },
-                    "check-error": {
-                      "version": "1.0.2",
-                      "dev": true
-                    },
-                    "deep-eql": {
-                      "version": "3.0.1",
-                      "dev": true,
-                      "requires": {
-                        "type-detect": "^4.0.0"
-                      }
-                    },
-                    "fast-check": {
-                      "version": "2.19.0",
-                      "dev": true,
-                      "requires": {
-                        "pure-rand": "^5.0.0"
-                      }
-                    },
-                    "get-func-name": {
-                      "version": "2.0.0",
-                      "dev": true
-                    },
-                    "inherits": {
-                      "version": "2.0.4",
-                      "dev": true
-                    },
-                    "n3": {
-                      "version": "1.11.1",
-                      "dev": true,
-                      "requires": {
-                        "queue-microtask": "^1.1.2",
-                        "readable-stream": "^3.6.0"
-                      }
-                    },
-                    "pathval": {
-                      "version": "1.1.1",
-                      "dev": true
-                    },
-                    "punycode": {
-                      "version": "2.1.1",
-                      "dev": true
-                    },
-                    "pure-rand": {
-                      "version": "5.0.0",
-                      "dev": true
-                    },
-                    "queue-microtask": {
-                      "version": "1.2.3",
-                      "dev": true
-                    },
-                    "rdf-data-factory": {
-                      "version": "1.1.0",
-                      "dev": true,
-                      "requires": {
-                        "@rdfjs/types": "*"
-                      }
-                    },
-                    "rdf-js": {
-                      "version": "4.0.2",
-                      "dev": true,
-                      "requires": {
-                        "@rdfjs/types": "*"
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "3.6.0",
-                      "dev": true,
-                      "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
-                      }
-                    },
-                    "string_decoder": {
-                      "version": "1.3.0",
-                      "dev": true,
-                      "requires": {
-                        "safe-buffer": "~5.2.0"
-                      },
-                      "dependencies": {
-                        "safe-buffer": {
-                          "version": "5.2.1",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "type-detect": {
-                      "version": "4.0.8",
-                      "dev": true
-                    },
-                    "uri-js": {
-                      "version": "4.4.1",
-                      "dev": true,
-                      "requires": {
-                        "punycode": "^2.1.0"
-                      }
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "dev": true
-                    }
-                  }
-                },
-                "@rdfjs/data-model": {
-                  "version": "1.2.0",
-                  "dev": true,
-                  "requires": {
-                    "@types/rdf-js": "*"
-                  }
-                },
-                "@types/node": {
-                  "version": "14.14.22",
-                  "dev": true
-                },
-                "@types/rdf-js": {
-                  "version": "4.0.1",
-                  "dev": true,
-                  "requires": {
-                    "@types/node": "*"
-                  }
-                }
-              }
-            },
-            "@polypoly-eu/rdf-spec": {
-              "version": "file:../../platform/feature-api/api/rdf-spec",
-              "requires": {
-                "@graphy/core.data.factory": "^4.3.4",
-                "@graphy/memory.dataset.fast": "^4.3.3",
-                "@rdfjs/data-model": "^1.1.3",
-                "@rdfjs/dataset": "^1.0.1",
-                "@types/chai": "^4.2.14",
-                "@types/n3": "^1.10.3",
-                "@types/node": "^14.17.9",
-                "@types/rdfjs__dataset": "^1.0.4",
-                "chai": "^4.2.0",
-                "fast-check": "^2.2.1",
-                "n3": "^1.8.0",
-                "rdf-data-factory": "^1.0.4"
-              },
-              "dependencies": {
-                "@graphy/core.data.factory": {
-                  "version": "4.3.4",
-                  "dev": true,
-                  "requires": {
-                    "uri-js": "^4.4.0"
-                  }
-                },
-                "@graphy/core.iso.stream": {
-                  "version": "4.3.4",
-                  "dev": true,
-                  "requires": {
-                    "readable-stream": "^3.6.0"
-                  }
-                },
-                "@graphy/memory.dataset.fast": {
-                  "version": "4.3.3",
-                  "dev": true,
-                  "requires": {
-                    "@graphy/core.data.factory": "^4.3.3",
-                    "@graphy/core.iso.stream": "^4.3.3"
-                  }
-                },
-                "@rdfjs/data-model": {
-                  "version": "1.3.4",
-                  "dev": true,
-                  "requires": {
-                    "@rdfjs/types": ">=1.0.1"
-                  }
-                },
-                "@rdfjs/dataset": {
-                  "version": "1.1.1",
-                  "dev": true,
-                  "requires": {
-                    "@rdfjs/data-model": "^1.2.0"
-                  }
-                },
-                "@rdfjs/types": {
-                  "version": "1.0.1",
-                  "dev": true,
-                  "requires": {
-                    "@types/node": "*"
-                  }
-                },
-                "@types/chai": {
-                  "version": "4.2.22",
-                  "dev": true
-                },
-                "@types/n3": {
-                  "version": "1.10.3",
-                  "dev": true,
-                  "requires": {
-                    "@types/node": "*",
-                    "rdf-js": "^4.0.2"
-                  }
-                },
-                "@types/node": {
-                  "version": "14.17.32",
-                  "dev": true
-                },
-                "@types/rdfjs__dataset": {
-                  "version": "1.0.5",
-                  "dev": true,
-                  "requires": {
-                    "rdf-js": "^4.0.2"
-                  }
-                },
-                "assertion-error": {
-                  "version": "1.1.0",
-                  "dev": true
-                },
-                "chai": {
-                  "version": "4.3.4",
-                  "dev": true,
-                  "requires": {
-                    "assertion-error": "^1.1.0",
-                    "check-error": "^1.0.2",
-                    "deep-eql": "^3.0.1",
-                    "get-func-name": "^2.0.0",
-                    "pathval": "^1.1.1",
-                    "type-detect": "^4.0.5"
-                  }
-                },
-                "check-error": {
-                  "version": "1.0.2",
-                  "dev": true
-                },
-                "deep-eql": {
-                  "version": "3.0.1",
-                  "dev": true,
-                  "requires": {
-                    "type-detect": "^4.0.0"
-                  }
-                },
-                "fast-check": {
-                  "version": "2.19.0",
-                  "dev": true,
-                  "requires": {
-                    "pure-rand": "^5.0.0"
-                  }
-                },
-                "get-func-name": {
-                  "version": "2.0.0",
-                  "dev": true
-                },
-                "inherits": {
-                  "version": "2.0.4",
-                  "dev": true
-                },
-                "n3": {
-                  "version": "1.11.1",
-                  "dev": true,
-                  "requires": {
-                    "queue-microtask": "^1.1.2",
-                    "readable-stream": "^3.6.0"
-                  }
-                },
-                "pathval": {
-                  "version": "1.1.1",
-                  "dev": true
-                },
-                "punycode": {
-                  "version": "2.1.1",
-                  "dev": true
-                },
-                "pure-rand": {
-                  "version": "5.0.0",
-                  "dev": true
-                },
-                "queue-microtask": {
-                  "version": "1.2.3",
-                  "dev": true
-                },
-                "rdf-data-factory": {
-                  "version": "1.1.0",
-                  "dev": true,
-                  "requires": {
-                    "@rdfjs/types": "*"
-                  }
-                },
-                "rdf-js": {
-                  "version": "4.0.2",
-                  "dev": true,
-                  "requires": {
-                    "@rdfjs/types": "*"
-                  }
-                },
-                "readable-stream": {
-                  "version": "3.6.0",
-                  "dev": true,
-                  "requires": {
-                    "inherits": "^2.0.3",
-                    "string_decoder": "^1.1.1",
-                    "util-deprecate": "^1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.3.0",
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.2.0"
-                  },
-                  "dependencies": {
-                    "safe-buffer": {
-                      "version": "5.2.1",
-                      "dev": true
-                    }
-                  }
-                },
-                "type-detect": {
-                  "version": "4.0.8",
-                  "dev": true
-                },
-                "uri-js": {
-                  "version": "4.4.1",
-                  "dev": true,
-                  "requires": {
-                    "punycode": "^2.1.0"
-                  }
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "dev": true
-                }
-              }
-            },
-            "@rdfjs/data-model": {
-              "version": "1.3.4",
-              "dev": true,
-              "requires": {
-                "@rdfjs/types": ">=1.0.1"
-              }
-            },
-            "@rdfjs/dataset": {
-              "version": "1.1.1",
-              "dev": true,
-              "requires": {
-                "@rdfjs/data-model": "^1.2.0"
-              }
-            },
-            "@rdfjs/types": {
-              "version": "1.0.1",
-              "dev": true,
-              "requires": {
-                "@types/node": "*"
-              }
-            },
-            "@types/chai": {
-              "version": "4.2.22",
-              "dev": true
-            },
-            "@types/chai-as-promised": {
-              "version": "7.1.4",
-              "dev": true,
-              "requires": {
-                "@types/chai": "*"
-              }
-            },
-            "@types/node": {
-              "version": "14.17.33",
-              "dev": true
-            },
-            "@types/rdfjs__dataset": {
-              "version": "1.0.5",
-              "dev": true,
-              "requires": {
-                "rdf-js": "^4.0.2"
-              }
-            },
-            "assertion-error": {
-              "version": "1.1.0",
-              "dev": true
-            },
-            "chai": {
-              "version": "4.3.4",
-              "dev": true,
-              "requires": {
-                "assertion-error": "^1.1.0",
-                "check-error": "^1.0.2",
-                "deep-eql": "^3.0.1",
-                "get-func-name": "^2.0.0",
-                "pathval": "^1.1.1",
-                "type-detect": "^4.0.5"
-              }
-            },
-            "chai-as-promised": {
-              "version": "7.1.1",
-              "dev": true,
-              "requires": {
-                "check-error": "^1.0.2"
-              }
-            },
-            "check-error": {
-              "version": "1.0.2",
-              "dev": true
-            },
-            "deep-eql": {
-              "version": "3.0.1",
-              "dev": true,
-              "requires": {
-                "type-detect": "^4.0.0"
-              }
-            },
-            "fast-check": {
-              "version": "2.19.0",
-              "dev": true,
-              "requires": {
-                "pure-rand": "^5.0.0"
-              }
-            },
-            "fs-monkey": {
-              "version": "1.0.3",
-              "dev": true
-            },
-            "get-func-name": {
-              "version": "2.0.0",
-              "dev": true
-            },
-            "memfs": {
-              "version": "3.3.0",
-              "dev": true,
-              "requires": {
-                "fs-monkey": "1.0.3"
-              }
-            },
-            "pathval": {
-              "version": "1.1.1",
-              "dev": true
-            },
-            "pure-rand": {
-              "version": "5.0.0",
-              "dev": true
-            },
-            "rdf-js": {
-              "version": "4.0.2",
-              "dev": true,
-              "requires": {
-                "@rdfjs/types": "*"
-              }
-            },
-            "type-detect": {
-              "version": "4.0.8",
-              "dev": true
-            }
-          }
-        },
-        "@polypoly-eu/rdf": {
-          "version": "file:../../platform/feature-api/api/rdf",
-          "requires": {
-            "@polypoly-eu/rdf-spec": "file:../rdf-spec",
-            "@rdfjs/data-model": "^1.2.0",
-            "@types/rdf-js": "^4.0.0"
-          },
-          "dependencies": {
-            "@polypoly-eu/rdf-spec": {
-              "version": "file:../../platform/feature-api/api/rdf-spec",
-              "requires": {
-                "@graphy/core.data.factory": "^4.3.4",
-                "@graphy/memory.dataset.fast": "^4.3.3",
-                "@rdfjs/data-model": "^1.1.3",
-                "@rdfjs/dataset": "^1.0.1",
-                "@types/chai": "^4.2.14",
-                "@types/n3": "^1.10.3",
-                "@types/node": "^14.17.9",
-                "@types/rdfjs__dataset": "^1.0.4",
-                "chai": "^4.2.0",
-                "fast-check": "^2.2.1",
-                "n3": "^1.8.0",
-                "rdf-data-factory": "^1.0.4"
-              },
-              "dependencies": {
-                "@graphy/core.data.factory": {
-                  "version": "4.3.4",
-                  "dev": true,
-                  "requires": {
-                    "uri-js": "^4.4.0"
-                  }
-                },
-                "@graphy/core.iso.stream": {
-                  "version": "4.3.4",
-                  "dev": true,
-                  "requires": {
-                    "readable-stream": "^3.6.0"
-                  }
-                },
-                "@graphy/memory.dataset.fast": {
-                  "version": "4.3.3",
-                  "dev": true,
-                  "requires": {
-                    "@graphy/core.data.factory": "^4.3.3",
-                    "@graphy/core.iso.stream": "^4.3.3"
-                  }
-                },
-                "@rdfjs/data-model": {
-                  "version": "1.3.4",
-                  "dev": true,
-                  "requires": {
-                    "@rdfjs/types": ">=1.0.1"
-                  }
-                },
-                "@rdfjs/dataset": {
-                  "version": "1.1.1",
-                  "dev": true,
-                  "requires": {
-                    "@rdfjs/data-model": "^1.2.0"
-                  }
-                },
-                "@rdfjs/types": {
-                  "version": "1.0.1",
-                  "dev": true,
-                  "requires": {
-                    "@types/node": "*"
-                  }
-                },
-                "@types/chai": {
-                  "version": "4.2.22",
-                  "dev": true
-                },
-                "@types/n3": {
-                  "version": "1.10.3",
-                  "dev": true,
-                  "requires": {
-                    "@types/node": "*",
-                    "rdf-js": "^4.0.2"
-                  }
-                },
-                "@types/node": {
-                  "version": "14.17.32",
-                  "dev": true
-                },
-                "@types/rdfjs__dataset": {
-                  "version": "1.0.5",
-                  "dev": true,
-                  "requires": {
-                    "rdf-js": "^4.0.2"
-                  }
-                },
-                "assertion-error": {
-                  "version": "1.1.0",
-                  "dev": true
-                },
-                "chai": {
-                  "version": "4.3.4",
-                  "dev": true,
-                  "requires": {
-                    "assertion-error": "^1.1.0",
-                    "check-error": "^1.0.2",
-                    "deep-eql": "^3.0.1",
-                    "get-func-name": "^2.0.0",
-                    "pathval": "^1.1.1",
-                    "type-detect": "^4.0.5"
-                  }
-                },
-                "check-error": {
-                  "version": "1.0.2",
-                  "dev": true
-                },
-                "deep-eql": {
-                  "version": "3.0.1",
-                  "dev": true,
-                  "requires": {
-                    "type-detect": "^4.0.0"
-                  }
-                },
-                "fast-check": {
-                  "version": "2.19.0",
-                  "dev": true,
-                  "requires": {
-                    "pure-rand": "^5.0.0"
-                  }
-                },
-                "get-func-name": {
-                  "version": "2.0.0",
-                  "dev": true
-                },
-                "inherits": {
-                  "version": "2.0.4",
-                  "dev": true
-                },
-                "n3": {
-                  "version": "1.11.1",
-                  "dev": true,
-                  "requires": {
-                    "queue-microtask": "^1.1.2",
-                    "readable-stream": "^3.6.0"
-                  }
-                },
-                "pathval": {
-                  "version": "1.1.1",
-                  "dev": true
-                },
-                "punycode": {
-                  "version": "2.1.1",
-                  "dev": true
-                },
-                "pure-rand": {
-                  "version": "5.0.0",
-                  "dev": true
-                },
-                "queue-microtask": {
-                  "version": "1.2.3",
-                  "dev": true
-                },
-                "rdf-data-factory": {
-                  "version": "1.1.0",
-                  "dev": true,
-                  "requires": {
-                    "@rdfjs/types": "*"
-                  }
-                },
-                "rdf-js": {
-                  "version": "4.0.2",
-                  "dev": true,
-                  "requires": {
-                    "@rdfjs/types": "*"
-                  }
-                },
-                "readable-stream": {
-                  "version": "3.6.0",
-                  "dev": true,
-                  "requires": {
-                    "inherits": "^2.0.3",
-                    "string_decoder": "^1.1.1",
-                    "util-deprecate": "^1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.3.0",
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.2.0"
-                  },
-                  "dependencies": {
-                    "safe-buffer": {
-                      "version": "5.2.1",
-                      "dev": true
-                    }
-                  }
-                },
-                "type-detect": {
-                  "version": "4.0.8",
-                  "dev": true
-                },
-                "uri-js": {
-                  "version": "4.4.1",
-                  "dev": true,
-                  "requires": {
-                    "punycode": "^2.1.0"
-                  }
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "dev": true
-                }
-              }
-            },
-            "@rdfjs/data-model": {
-              "version": "1.2.0",
-              "dev": true,
-              "requires": {
-                "@types/rdf-js": "*"
-              }
-            },
-            "@types/node": {
-              "version": "14.14.22",
-              "dev": true
-            },
-            "@types/rdf-js": {
-              "version": "4.0.1",
-              "dev": true,
-              "requires": {
-                "@types/node": "*"
-              }
-            }
-          }
-        },
-        "@polypoly-eu/rdf-spec": {
-          "version": "file:../../platform/feature-api/api/rdf-spec",
-          "requires": {
-            "@graphy/core.data.factory": "^4.3.4",
-            "@graphy/memory.dataset.fast": "^4.3.3",
-            "@rdfjs/data-model": "^1.1.3",
-            "@rdfjs/dataset": "^1.0.1",
-            "@types/chai": "^4.2.14",
-            "@types/n3": "^1.10.3",
-            "@types/node": "^14.17.9",
-            "@types/rdfjs__dataset": "^1.0.4",
-            "chai": "^4.2.0",
-            "fast-check": "^2.2.1",
-            "n3": "^1.8.0",
-            "rdf-data-factory": "^1.0.4"
-          },
-          "dependencies": {
-            "@graphy/core.data.factory": {
-              "version": "4.3.4",
-              "dev": true,
-              "requires": {
-                "uri-js": "^4.4.0"
-              }
-            },
-            "@graphy/core.iso.stream": {
-              "version": "4.3.4",
-              "dev": true,
-              "requires": {
-                "readable-stream": "^3.6.0"
-              }
-            },
-            "@graphy/memory.dataset.fast": {
-              "version": "4.3.3",
-              "dev": true,
-              "requires": {
-                "@graphy/core.data.factory": "^4.3.3",
-                "@graphy/core.iso.stream": "^4.3.3"
-              }
-            },
-            "@rdfjs/data-model": {
-              "version": "1.3.4",
-              "dev": true,
-              "requires": {
-                "@rdfjs/types": ">=1.0.1"
-              }
-            },
-            "@rdfjs/dataset": {
-              "version": "1.1.1",
-              "dev": true,
-              "requires": {
-                "@rdfjs/data-model": "^1.2.0"
-              }
-            },
-            "@rdfjs/types": {
-              "version": "1.0.1",
-              "dev": true,
-              "requires": {
-                "@types/node": "*"
-              }
-            },
-            "@types/chai": {
-              "version": "4.2.22",
-              "dev": true
-            },
-            "@types/n3": {
-              "version": "1.10.3",
-              "dev": true,
-              "requires": {
-                "@types/node": "*",
-                "rdf-js": "^4.0.2"
-              }
-            },
-            "@types/node": {
-              "version": "14.17.32",
-              "dev": true
-            },
-            "@types/rdfjs__dataset": {
-              "version": "1.0.5",
-              "dev": true,
-              "requires": {
-                "rdf-js": "^4.0.2"
-              }
-            },
-            "assertion-error": {
-              "version": "1.1.0",
-              "dev": true
-            },
-            "chai": {
-              "version": "4.3.4",
-              "dev": true,
-              "requires": {
-                "assertion-error": "^1.1.0",
-                "check-error": "^1.0.2",
-                "deep-eql": "^3.0.1",
-                "get-func-name": "^2.0.0",
-                "pathval": "^1.1.1",
-                "type-detect": "^4.0.5"
-              }
-            },
-            "check-error": {
-              "version": "1.0.2",
-              "dev": true
-            },
-            "deep-eql": {
-              "version": "3.0.1",
-              "dev": true,
-              "requires": {
-                "type-detect": "^4.0.0"
-              }
-            },
-            "fast-check": {
-              "version": "2.19.0",
-              "dev": true,
-              "requires": {
-                "pure-rand": "^5.0.0"
-              }
-            },
-            "get-func-name": {
-              "version": "2.0.0",
-              "dev": true
-            },
-            "inherits": {
-              "version": "2.0.4",
-              "dev": true
-            },
-            "n3": {
-              "version": "1.11.1",
-              "dev": true,
-              "requires": {
-                "queue-microtask": "^1.1.2",
-                "readable-stream": "^3.6.0"
-              }
-            },
-            "pathval": {
-              "version": "1.1.1",
-              "dev": true
-            },
-            "punycode": {
-              "version": "2.1.1",
-              "dev": true
-            },
-            "pure-rand": {
-              "version": "5.0.0",
-              "dev": true
-            },
-            "queue-microtask": {
-              "version": "1.2.3",
-              "dev": true
-            },
-            "rdf-data-factory": {
-              "version": "1.1.0",
-              "dev": true,
-              "requires": {
-                "@rdfjs/types": "*"
-              }
-            },
-            "rdf-js": {
-              "version": "4.0.2",
-              "dev": true,
-              "requires": {
-                "@rdfjs/types": "*"
-              }
-            },
-            "readable-stream": {
-              "version": "3.6.0",
-              "dev": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.3.0",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.2.0"
-              },
-              "dependencies": {
-                "safe-buffer": {
-                  "version": "5.2.1",
-                  "dev": true
-                }
-              }
-            },
-            "type-detect": {
-              "version": "4.0.8",
-              "dev": true
-            },
-            "uri-js": {
-              "version": "4.4.1",
-              "dev": true,
-              "requires": {
-                "punycode": "^2.1.0"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "dev": true
-            }
-          }
-        },
         "@rdfjs/types": {
           "version": "1.0.1",
           "dev": true,
@@ -9475,11 +8028,12 @@
         "@polypoly-eu/poly-analysis": "file:../poly-analysis",
         "@polypoly-eu/poly-import": "file:../poly-import",
         "@polypoly-eu/rollup-plugin-copy-watch": "file:../../dev-utils/rollup-plugin-copy-watch",
+        "@polypoly-eu/silly-i18n": "file:../silly-i18n",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@web/test-runner": "^0.13.22",
         "babel-jest": "^27.5.1",
-        "d3": "^7.0.4",
+        "d3": "^7.6.1",
         "d3-sankey": "^0.12.3",
         "identity-obj-proxy": "^3.0.0",
         "lit-element": "^2.5.1",
@@ -11772,7 +10326,8 @@
           }
         },
         "commander": {
-          "version": "7.2.0"
+          "version": "7.2.0",
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -11856,6 +10411,7 @@
         },
         "d3": {
           "version": "7.3.0",
+          "dev": true,
           "requires": {
             "d3-array": "3",
             "d3-axis": "3",
@@ -11891,15 +10447,18 @@
         },
         "d3-array": {
           "version": "3.1.1",
+          "dev": true,
           "requires": {
             "internmap": "1 - 2"
           }
         },
         "d3-axis": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "dev": true
         },
         "d3-brush": {
           "version": "3.0.0",
+          "dev": true,
           "requires": {
             "d3-dispatch": "1 - 3",
             "d3-drag": "2 - 3",
@@ -11910,30 +10469,38 @@
         },
         "d3-chord": {
           "version": "3.0.1",
+          "dev": true,
           "requires": {
             "d3-path": "1 - 3"
           }
         },
         "d3-color": {
-          "version": "3.0.1"
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+          "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+          "dev": true
         },
         "d3-contour": {
           "version": "3.0.1",
+          "dev": true,
           "requires": {
             "d3-array": "2 - 3"
           }
         },
         "d3-delaunay": {
           "version": "6.0.2",
+          "dev": true,
           "requires": {
             "delaunator": "5"
           }
         },
         "d3-dispatch": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "dev": true
         },
         "d3-drag": {
           "version": "3.0.0",
+          "dev": true,
           "requires": {
             "d3-dispatch": "1 - 3",
             "d3-selection": "3"
@@ -11941,6 +10508,7 @@
         },
         "d3-dsv": {
           "version": "3.0.1",
+          "dev": true,
           "requires": {
             "commander": "7",
             "iconv-lite": "0.6",
@@ -11948,16 +10516,19 @@
           }
         },
         "d3-ease": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "dev": true
         },
         "d3-fetch": {
           "version": "3.0.1",
+          "dev": true,
           "requires": {
             "d3-dsv": "1 - 3"
           }
         },
         "d3-force": {
           "version": "3.0.0",
+          "dev": true,
           "requires": {
             "d3-dispatch": "1 - 3",
             "d3-quadtree": "1 - 3",
@@ -11965,34 +10536,42 @@
           }
         },
         "d3-format": {
-          "version": "3.1.0"
+          "version": "3.1.0",
+          "dev": true
         },
         "d3-geo": {
           "version": "3.0.1",
+          "dev": true,
           "requires": {
             "d3-array": "2.5.0 - 3"
           }
         },
         "d3-hierarchy": {
-          "version": "3.1.1"
+          "version": "3.1.1",
+          "dev": true
         },
         "d3-interpolate": {
           "version": "3.0.1",
+          "dev": true,
           "requires": {
             "d3-color": "1 - 3"
           }
         },
         "d3-path": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "dev": true
         },
         "d3-polygon": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "dev": true
         },
         "d3-quadtree": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "dev": true
         },
         "d3-random": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "dev": true
         },
         "d3-sankey": {
           "version": "0.12.3",
@@ -12023,6 +10602,7 @@
         },
         "d3-scale": {
           "version": "4.0.2",
+          "dev": true,
           "requires": {
             "d3-array": "2.10.0 - 3",
             "d3-format": "1 - 3",
@@ -12033,37 +10613,44 @@
         },
         "d3-scale-chromatic": {
           "version": "3.0.0",
+          "dev": true,
           "requires": {
             "d3-color": "1 - 3",
             "d3-interpolate": "1 - 3"
           }
         },
         "d3-selection": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "dev": true
         },
         "d3-shape": {
           "version": "3.1.0",
+          "dev": true,
           "requires": {
             "d3-path": "1 - 3"
           }
         },
         "d3-time": {
           "version": "3.0.0",
+          "dev": true,
           "requires": {
             "d3-array": "2 - 3"
           }
         },
         "d3-time-format": {
           "version": "4.1.0",
+          "dev": true,
           "requires": {
             "d3-time": "1 - 3"
           }
         },
         "d3-timer": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "dev": true
         },
         "d3-transition": {
           "version": "3.0.1",
+          "dev": true,
           "requires": {
             "d3-color": "1 - 3",
             "d3-dispatch": "1 - 3",
@@ -12074,6 +10661,7 @@
         },
         "d3-zoom": {
           "version": "3.0.0",
+          "dev": true,
           "requires": {
             "d3-dispatch": "1 - 3",
             "d3-drag": "2 - 3",
@@ -12122,6 +10710,7 @@
         },
         "delaunator": {
           "version": "5.0.0",
+          "dev": true,
           "requires": {
             "robust-predicates": "^3.0.0"
           }
@@ -12426,6 +11015,7 @@
         },
         "iconv-lite": {
           "version": "0.6.3",
+          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -12466,7 +11056,8 @@
           "dev": true
         },
         "internmap": {
-          "version": "2.0.3"
+          "version": "2.0.3",
+          "dev": true
         },
         "ip": {
           "version": "1.1.5",
@@ -13381,7 +11972,8 @@
           }
         },
         "robust-predicates": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "dev": true
         },
         "rollup": {
           "version": "2.63.0",
@@ -13398,14 +11990,16 @@
           }
         },
         "rw": {
-          "version": "1.3.3"
+          "version": "1.3.3",
+          "dev": true
         },
         "safe-buffer": {
           "version": "5.1.2",
           "dev": true
         },
         "safer-buffer": {
-          "version": "2.1.2"
+          "version": "2.1.2",
+          "dev": true
         },
         "scheduler": {
           "version": "0.20.2",
@@ -14061,14 +12655,17 @@
       "version": "file:../../feature-utils/silly-i18n"
     },
     "d3": {
-      "version": "7.3.0",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
+      "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
+      "dev": true,
       "requires": {
         "d3-array": "3",
         "d3-axis": "3",
         "d3-brush": "3",
         "d3-chord": "3",
         "d3-color": "3",
-        "d3-contour": "3",
+        "d3-contour": "4",
         "d3-delaunay": "6",
         "d3-dispatch": "3",
         "d3-drag": "3",
@@ -14096,16 +12693,21 @@
       }
     },
     "d3-array": {
-      "version": "3.1.1",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
+      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
+      "dev": true,
       "requires": {
         "internmap": "1 - 2"
       }
     },
     "d3-axis": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "d3-brush": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -14116,30 +12718,40 @@
     },
     "d3-chord": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-path": "1 - 3"
       }
     },
     "d3-color": {
-      "version": "3.0.1"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true
     },
     "d3-contour": {
-      "version": "3.0.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
+      "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
+      "dev": true,
       "requires": {
-        "d3-array": "2 - 3"
+        "d3-array": "^3.2.0"
       }
     },
     "d3-delaunay": {
       "version": "6.0.2",
+      "dev": true,
       "requires": {
         "delaunator": "5"
       }
     },
     "d3-dispatch": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-drag": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -14147,6 +12759,7 @@
     },
     "d3-dsv": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "commander": "7",
         "iconv-lite": "0.6",
@@ -14154,21 +12767,25 @@
       },
       "dependencies": {
         "commander": {
-          "version": "7.2.0"
+          "version": "7.2.0",
+          "dev": true
         }
       }
     },
     "d3-ease": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-fetch": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-dsv": "1 - 3"
       }
     },
     "d3-force": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-quadtree": "1 - 3",
@@ -14176,37 +12793,46 @@
       }
     },
     "d3-format": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-geo": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-array": "2.5.0 - 3"
       }
     },
     "d3-hierarchy": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-interpolate": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-color": "1 - 3"
       }
     },
     "d3-path": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-polygon": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-quadtree": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-random": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-scale": {
       "version": "4.0.1",
+      "dev": true,
       "requires": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -14217,37 +12843,44 @@
     },
     "d3-scale-chromatic": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
       }
     },
     "d3-selection": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "d3-shape": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-path": "1 - 3"
       }
     },
     "d3-time": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-array": "2 - 3"
       }
     },
     "d3-time-format": {
       "version": "4.0.0",
+      "dev": true,
       "requires": {
         "d3-time": "1 - 3"
       }
     },
     "d3-timer": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "d3-transition": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -14258,6 +12891,7 @@
     },
     "d3-zoom": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -14268,6 +12902,7 @@
     },
     "delaunator": {
       "version": "5.0.0",
+      "dev": true,
       "requires": {
         "robust-predicates": "^3.0.0"
       }
@@ -14302,12 +12937,14 @@
     },
     "iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "internmap": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "dev": true
     },
     "isarray": {
       "version": "0.0.1"
@@ -14413,13 +13050,16 @@
       "version": "3.0.0"
     },
     "robust-predicates": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "rw": {
-      "version": "1.3.3"
+      "version": "1.3.3",
+      "dev": true
     },
     "safer-buffer": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "dev": true
     },
     "scheduler": {
       "version": "0.19.1",

--- a/features/polyExplorer/package.json
+++ b/features/polyExplorer/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@polypoly-eu/podjs": "file:../../platform/podjs",
     "@polypoly-eu/rollup-plugin-copy-watch": "file:../../dev-utils/rollup-plugin-copy-watch",
+    "d3": "^7.6.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },
@@ -23,7 +24,6 @@
   "dependencies": {
     "@polypoly-eu/poly-look": "file:../../feature-utils/poly-look",
     "@polypoly-eu/silly-i18n": "file:../../feature-utils/silly-i18n",
-    "d3": "^7.3.0",
     "react-infinite-scroll-component": "^6.0.0",
     "react-router-dom": "^5.2.0",
     "swiper": "^6.4.11"


### PR DESCRIPTION
# ✍️ Description

Tries to quell [these vulnerabilities](https://github.com/polypoly-eu/polyPod/security/dependabot/136) by upgrading d3, which was a couple of minors behind anyway. As usual, not something that could affect us, since it's no user-facing code, but upgrading is good and eliminates annoying warnings.

♥️ Thank you! 
