### PR TITLE
{PROD4POD-1930} Add tests for poly-importer

### DIFF
--- a/feature-utils/poly-import/package.json
+++ b/feature-utils/poly-import/package.json
@@ -6,5 +6,12 @@
   "scripts": {
     "build": "rollup -c rollup.config.js",
     "test": "jest --coverage"
+  },
+  "jest": {
+    "verbose": true,
+    "transform": {
+      "\\.[jt]sx?$": "babel-jest"
+    },
+    "testEnvironment": "jsdom"
   }
 }

--- a/feature-utils/poly-import/test/telemetry.test.js
+++ b/feature-utils/poly-import/test/telemetry.test.js
@@ -1,0 +1,14 @@
+import { Telemetry } from "../src";
+
+describe("Telemetry measures performance ", () => {
+    let telemetry;
+    beforeAll(() => {
+        telemetry = new Telemetry();
+    });
+
+    it("Returns increasing elapsed time", () => {
+        const oldTime = telemetry.elapsedTime();
+        expect(oldTime).toBeGreaterThan(0);
+        expect(telemetry.elapsedTime()).toBeGreaterThan(oldTime);
+    });
+});

--- a/feature-utils/poly-import/utils/performance-telemetry.js
+++ b/feature-utils/poly-import/utils/performance-telemetry.js
@@ -3,6 +3,7 @@
  *
  * @class
  */
+
 export class Telemetry {
     constructor() {
         this._creationTime = performance.now();


### PR DESCRIPTION
# ✍️ Description

Increase coverage of core tests. `poly-importer` is used by all features, and coverage was rather dim

![Captura de pantalla de 2022-10-03 10-10-26](https://user-images.githubusercontent.com/500/193530212-53fe8ec9-1243-4ebd-999a-e239a0f620ff.png)

The scope of this PR will be defined on the run. For the time being, it's :construction: and tries to increase it beyond original 13.68%

### 🏗️ Fixes 1930


## ℹ️ Other information

Refactoring will be made as needed. For starters, it needed configuration of the jest jsdom environment.

♥️ Thank you!
