### PR TITLE
Eliminate need to build platform/core separately

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -23,6 +23,8 @@ jobs:
                   cache-dependency-path: "**/package-lock.json"
             - name: Build prerequisites
               run: ./build.js
+              env:
+                POLYPOD_BUILD_PLATFORMS: android
             - uses: actions/setup-java@v2
               with:
                   distribution: 'zulu'

--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -21,12 +21,8 @@ jobs:
                   node-version: 16
                   cache: "npm"
                   cache-dependency-path: "**/package-lock.json"
-            - name: Install and build API and features
+            - name: Build prerequisites
               run: ./build.js
-            - name: Build core
-              working-directory: platform/core
-              run: |
-                make android_bindings
             - uses: actions/setup-java@v2
               with:
                   distribution: 'zulu'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -59,6 +59,8 @@ jobs:
         ./build.js
         cd platform/android
         ./gradlew compileDebugJavaWithJavac
+      env:
+        POLYPOD_BUILD_PLATFORMS: android
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,7 +58,6 @@ jobs:
       run: |
         ./build.js
         cd platform/android
-        make -C ../core android_bindings
         ./gradlew compileDebugJavaWithJavac
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -30,11 +30,8 @@ jobs:
                   cache-dependency-path: "**/package-lock.json"
             - name: Lock xcode version
               run: cd platform/ios; make lockxcodeversion
-            - name: Install modules, build API and features
+            - name: Build prerequisites
               run: ./build.js
-            - name: Build core
-              working-directory: platform/core
-              run: make ios_bindings
             - name: Build and test iOS
               working-directory: platform/ios
               run: make test

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -32,6 +32,8 @@ jobs:
               run: cd platform/ios; make lockxcodeversion
             - name: Build prerequisites
               run: ./build.js
+              env:
+                POLYPOD_BUILD_PLATFORMS: ios
             - name: Build and test iOS
               working-directory: platform/ios
               run: make test

--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Build platform and features
         if: steps.changes.outputs.apiAndFeatures == 'true' || steps.changes.outputs.android == 'true'
         run: ./build.js build
+        env:
+          POLYPOD_BUILD_PLATFORMS: android
       - name: Test platform and features
         if: steps.changes.outputs.apiAndFeatures == 'true'
         run: xvfb-run --auto-servernum ./build.js test

--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -52,16 +52,16 @@ jobs:
             - 'platform/podjs/**'
             swift:
             - 'platform/ios/**'
-      - name: Lint core and features
+      - name: Lint platform and features
         if: steps.changes.outputs.js == 'true'
         run: ./build.js lint
       - name: Install JS packages
         if: steps.cache.outputs.cache-hit != 'true' && (steps.changes.outputs.apiAndFeatures == 'true' || steps.changes.outputs.js == 'true' || steps.changes.outputs.android == 'true')
         run: ./build.js offlineInstall
-      - name: Build core and features
+      - name: Build platform and features
         if: steps.changes.outputs.apiAndFeatures == 'true' || steps.changes.outputs.android == 'true'
         run: ./build.js build
-      - name: Test core and features
+      - name: Test platform and features
         if: steps.changes.outputs.apiAndFeatures == 'true'
         run: xvfb-run --auto-servernum ./build.js test
       - uses: actions/setup-java@v3
@@ -75,11 +75,6 @@ jobs:
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
-      - name: Build core with Android bindings
-        if: steps.changes.outputs.android == 'true'
-        working-directory: platform/core
-        run: |
-          make android_bindings
       - name: Test android
         if: steps.changes.outputs.android == 'true'
         working-directory: platform/android

--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ But it will be much more than that. For more information please read the
 
 Just [Node.js](https://nodejs.org/) version 16.x or newer.
 
+## Setting the target platform
+
+The polyPod runs on several platforms. You can control which platforms to build
+for using the `POLYPOD_BUILD_PLATFORMS` environment variable.
+
+Regardless of what you set it to, even if you don't set it, _podjs_ will always
+be built - which is sufficient to run and develop features.
+
+In order to build the polyPod for other platforms, set `POLYPOD_BUILD_PLATFORMS`
+to one of the following values:
+
+- `all`
+- `android`
+- `ios`
+
 ## Building
 
 If you're on Windows, please follow the steps in

--- a/build/packages.json
+++ b/build/packages.json
@@ -29,6 +29,7 @@
         "features/polypolyMembershipPreview",
         "features/gdprDataImporterPreview",
         "features/companyDataCleanerPreview",
+        "platform/core",
         "platform/feature-api/api",
         "platform/feature-api/communication",
         "platform/podjs"

--- a/platform/core/Makefile
+++ b/platform/core/Makefile
@@ -34,6 +34,15 @@ else
 	endif
 endif
 
+ifeq ($(POLYPOD_BUILD_PLATFORMS), all)
+	build_android := true
+	build_ios := $(if $(macos),true)
+else ifeq ($(POLYPOD_BUILD_PLATFORMS), android)
+	build_android := true
+else ifeq ($(POLYPOD_BUILD_PLATFORMS), ios)
+	build_ios := $(if $(macos),true)
+endif
+
 # ============  Rust core ============ #
 
 $(target): $(wildcard src/*.rs)
@@ -116,7 +125,7 @@ android_bindings: $(android_core_libraries)
 ios_bindings: $(swift_core_framework)
 
 .PHONY: all
-all: $(android_core_libraries) $(if $(macos),$(swift_core_framework),$(target))
+all: $(if $(build_android),$(android_core_libraries),) $(if $(build_ios),$(swift_core_framework),)
 
 .PHONY: clean
 clean:
@@ -124,6 +133,7 @@ clean:
 	$(RM) -r export
 	$(RM) -r $(swift_core_framework)
 	$(RM) -r $(android_core_libraries)
+	$(RM) -r $(jni_libs_copy_path)
 
 # ============  Utils ============ #
 

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@polypoly-eu/platform-core",
+  "scripts": {
+    "build": "make",
+    "clean": "make clean"
+  }
+}


### PR DESCRIPTION
# ✍️ Description

platform/core is now being built as a pseudo NPM package, so there's
less manual steps involved in building now, running build.js is
enough.

The new POLYPOD_BUILD_PLATFORMS environment variable controls for
which platforms to build. Since most people are probably not
interested in building for Android or iOS, the default behaviour is
just podjs - same as before this change.

### 🏗️ Fixes PROD4POD-1936