### PR TITLE
[:coffin:] Refactoring return values

### DIFF
--- a/feature-utils/poly-import/src/storage.js
+++ b/feature-utils/poly-import/src/storage.js
@@ -17,7 +17,6 @@ export class FeatureFileStorage {
             statResults[file.id] = await polyOut.stat(file.id);
         }
         this._files = statResults;
-        return files;
     }
 
     async readFile(path) {

--- a/feature-utils/poly-look/src/react-components/contexts/poly-import.jsx
+++ b/feature-utils/poly-look/src/react-components/contexts/poly-import.jsx
@@ -48,7 +48,7 @@ export const PolyImportProvider = ({
 
   const handleRemoveFile = (fileID) => {
     setAccount(null);
-    return storage.removeFile(fileID);
+    storage.removeFile(fileID);
   };
 
   useEffect(() => {

--- a/feature-utils/poly-look/src/react-components/contexts/poly-import.jsx
+++ b/feature-utils/poly-look/src/react-components/contexts/poly-import.jsx
@@ -38,7 +38,7 @@ export const PolyImportProvider = ({
           return;
         }
         for (const file of storage.files) {
-          resolvedFiles.push(await file);
+          resolvedFiles.push(file);
         }
         setFiles(resolvedFiles);
         setIsLoading(false);

--- a/feature-utils/poly-look/src/react-components/contexts/poly-import.jsx
+++ b/feature-utils/poly-look/src/react-components/contexts/poly-import.jsx
@@ -32,14 +32,11 @@ export const PolyImportProvider = ({
     storage
       .refreshFiles()
       .then(async () => {
-        const resolvedFiles = [];
         if (!storage.files) {
           setFiles(null);
           return;
         }
-        for (const file of storage.files) {
-          resolvedFiles.push(file);
-        }
+        const resolvedFiles = await Promise.all(storage.files);
         setFiles(resolvedFiles);
         setIsLoading(false);
       })
@@ -48,17 +45,14 @@ export const PolyImportProvider = ({
 
   const handleRemoveFile = (fileID) => {
     setAccount(null);
-    storage.removeFile(fileID);
+    return storage.removeFile(fileID);
   };
 
   useEffect(() => {
     if (!pod) return;
     const storage = new FeatureFileStorage(pod, async () => {
-      const resolvedFiles = [];
-      for (const file of storage.files) {
-        resolvedFiles.push(await file);
-      }
-      setFiles(Object.values(resolvedFiles));
+      const resolvedFiles = await Promise.all(storage.files);
+      setFiles(resolvedFiles);
     });
     setStorage(storage);
   }, [pod]);


### PR DESCRIPTION
# ✍️ Description

While doing #1204 a bit of refactoring is needed; and I realized this return value is never used. Giving it its own PR since it's a change in API, and want it to be tested with the rest.

Also, some refactoring mainly eliminating `await` and `return` where they're not actually needed.

### 🏗️ Fixes PROD4PROD-1931

It contributes to cleaning the repository, and improve test coverage in `importer`; eliminating code that's not used will no doubt contribute to that.

♥️ Thank you!
