### PR TITLE
[:recycle:] `changeListener` moved to the constructor

### DIFF
--- a/feature-utils/poly-import/src/storage.js
+++ b/feature-utils/poly-import/src/storage.js
@@ -1,6 +1,6 @@
 export class FeatureFileStorage {
-    constructor(pod) {
-        this.changeListener = () => {};
+    constructor(pod, changeListener = () => {}) {
+        this._changeListener = changeListener;
         this._files = null;
         this._pod = pod;
     }
@@ -29,7 +29,7 @@ export class FeatureFileStorage {
         const { polyOut } = this._pod;
         await polyOut.removeArchive(file);
         await this.refreshFiles();
-        this.changeListener();
+        this._changeListener();
     }
 }
 

--- a/feature-utils/poly-look/src/react-components/contexts/poly-import.jsx
+++ b/feature-utils/poly-look/src/react-components/contexts/poly-import.jsx
@@ -53,14 +53,13 @@ export const PolyImportProvider = ({
 
   useEffect(() => {
     if (!pod) return;
-    const storage = new FeatureFileStorage(pod);
-    storage.changeListener = async () => {
+    const storage = new FeatureFileStorage(pod, async () => {
       const resolvedFiles = [];
       for (const file of storage.files) {
         resolvedFiles.push(await file);
       }
       setFiles(Object.values(resolvedFiles));
-    };
+    });
     setStorage(storage);
   }, [pod]);
 


### PR DESCRIPTION
# ✍️ Description

Assigning a value to an attribute violated encapsulation, which is easy to do in JS, but still. This is a cleaner API, with a private `changeListener` which is assigned when the object is built.

### 🏗️ Works with PROD4POD-1931

Still cleaning up and refactoring the importer, looking at improving coverage. Related to #1209 and #1204, but wanted it to be considered on its own.

Also it's a change of API, which is better if considered on its own.

♥️ Thank you!
