### PR TITLE
[:recycle:] {PROD4POD-1940} `polyLifecycle` is probably unused

### DIFF
--- a/platform/feature-api/api/src/pod-api/api.ts
+++ b/platform/feature-api/api/src/pod-api/api.ts
@@ -213,13 +213,6 @@ export interface Info {
 }
 
 /**
- * @hidden
- */
-export interface PolyLifecycle {
-    startFeature(id: string, background: boolean): Promise<void>;
-}
-
-/**
  * @class Endpoint is the API features communicate with in order to perform fetch requests
  */
 export interface Endpoint {

--- a/platform/feature-api/api/src/pod-api/api.ts
+++ b/platform/feature-api/api/src/pod-api/api.ts
@@ -338,9 +338,4 @@ export interface Pod {
      * `triplestore` is an interface to interact with the SPARQL-RDF database
      */
     readonly triplestore: Triplestore;
-
-    /**
-     * @hidden
-     */
-    readonly polyLifecycle?: PolyLifecycle;
 }

--- a/platform/feature-api/api/src/pod-api/api.ts
+++ b/platform/feature-api/api/src/pod-api/api.ts
@@ -216,7 +216,6 @@ export interface Info {
  * @hidden
  */
 export interface PolyLifecycle {
-    listFeatures(): Promise<Record<string, boolean>>;
     startFeature(id: string, background: boolean): Promise<void>;
 }
 

--- a/platform/feature-api/communication/src/remote-pod/async.ts
+++ b/platform/feature-api/communication/src/remote-pod/async.ts
@@ -1,7 +1,6 @@
 import {
     Pod,
     PolyOut,
-    PolyLifecycle,
     PolyIn,
     PolyNav,
     ExternalFile,

--- a/platform/feature-api/communication/src/remote-pod/async.ts
+++ b/platform/feature-api/communication/src/remote-pod/async.ts
@@ -131,20 +131,6 @@ class AsyncEndpoint implements Endpoint {
     }
 }
 
-class AsyncPolyLifecycle implements PolyLifecycle {
-    constructor(private readonly promise: Promise<PolyLifecycle | undefined>) {}
-
-    private async force(): Promise<PolyLifecycle> {
-        const lifecycle = await this.promise;
-        if (lifecycle) return lifecycle;
-        throw new Error("Lifecycle is not implemented");
-    }
-
-    async startFeature(id: string, background: boolean): Promise<void> {
-        return (await this.force()).startFeature(id, background);
-    }
-}
-
 export class AsyncPod implements Pod {
     readonly polyOut: PolyOut;
     readonly polyIn: PolyIn;

--- a/platform/feature-api/communication/src/remote-pod/async.ts
+++ b/platform/feature-api/communication/src/remote-pod/async.ts
@@ -152,7 +152,6 @@ export class AsyncPod implements Pod {
     readonly info: Info;
     readonly endpoint: Endpoint;
     readonly triplestore: Triplestore;
-    readonly polyLifecycle: PolyLifecycle;
 
     constructor(
         private readonly promise: Promise<Pod>,

--- a/platform/feature-api/communication/src/remote-pod/async.ts
+++ b/platform/feature-api/communication/src/remote-pod/async.ts
@@ -140,10 +140,6 @@ class AsyncPolyLifecycle implements PolyLifecycle {
         throw new Error("Lifecycle is not implemented");
     }
 
-    async listFeatures(): Promise<Record<string, boolean>> {
-        return (await this.force()).listFeatures();
-    }
-
     async startFeature(id: string, background: boolean): Promise<void> {
         return (await this.force()).startFeature(id, background);
     }

--- a/platform/feature-api/communication/src/remote-pod/async.ts
+++ b/platform/feature-api/communication/src/remote-pod/async.ts
@@ -166,8 +166,5 @@ export class AsyncPod implements Pod {
         this.triplestore = new AsyncTriplestore(
             promise.then((pod) => pod.triplestore)
         );
-        this.polyLifecycle = new AsyncPolyLifecycle(
-            promise.then((pod) => pod.polyLifecycle)
-        );
     }
 }

--- a/platform/feature-api/communication/src/remote-pod/remote.ts
+++ b/platform/feature-api/communication/src/remote-pod/remote.ts
@@ -304,8 +304,6 @@ export class RemoteServerPod implements ServerOf<PodBackend> {
     }
 
     polyLifecycle(): ServerOf<PolyLifecycleBackend> {
-        if (this.pod.polyLifecycle) return this.pod.polyLifecycle;
-
         return new DummyPolyLifecycle();
     }
 

--- a/platform/feature-api/communication/src/remote-pod/remote.ts
+++ b/platform/feature-api/communication/src/remote-pod/remote.ts
@@ -65,7 +65,6 @@ type PolyOutBackend = ObjectBackendSpec<{
 }>;
 
 type PolyLifecycleBackend = ObjectBackendSpec<{
-    listFeatures(): ValueBackendSpec<Record<string, boolean>>;
     startFeature(id: string, background: boolean): ValueBackendSpec<void>;
 }>;
 
@@ -200,7 +199,6 @@ export class RemoteClientPod implements Pod {
 
     get polyLifecycle(): PolyLifecycle {
         return {
-            listFeatures: () => this.rpcClient.polyLifecycle().listFeatures()(),
             startFeature: (id, background) =>
                 this.rpcClient.polyLifecycle().startFeature(id, background)(),
         };
@@ -251,10 +249,6 @@ export class RemoteClientPod implements Pod {
 // TODO move to pod-api?
 // TODO should this throw instead?
 class DummyPolyLifecycle implements PolyLifecycle {
-    async listFeatures(): Promise<Record<string, boolean>> {
-        return {};
-    }
-
     async startFeature(): Promise<void> {
         return;
     }

--- a/platform/feature-api/communication/src/remote-pod/remote.ts
+++ b/platform/feature-api/communication/src/remote-pod/remote.ts
@@ -1,6 +1,5 @@
 import {
     Pod,
-    PolyLifecycle,
     PolyIn,
     PolyOut,
     PolyNav,
@@ -64,10 +63,6 @@ type PolyOutBackend = ObjectBackendSpec<{
     removeArchive(fileId: string): ValueBackendSpec<void>;
 }>;
 
-type PolyLifecycleBackend = ObjectBackendSpec<{
-    startFeature(id: string, background: boolean): ValueBackendSpec<void>;
-}>;
-
 type PolyNavBackend = ObjectBackendSpec<{
     openUrl(url: string): ValueBackendSpec<void>;
     setActiveActions(actions: string[]): ValueBackendSpec<void>;
@@ -97,7 +92,6 @@ type EndpointBackend = ObjectBackendSpec<{
 type PodBackend = ObjectBackendSpec<{
     polyIn(): PolyInBackend;
     polyOut(): PolyOutBackend;
-    polyLifecycle(): PolyLifecycleBackend;
     polyNav(): PolyNavBackend;
     info(): InfoBackend;
     endpoint(): EndpointBackend;
@@ -197,13 +191,6 @@ export class RemoteClientPod implements Pod {
         })();
     }
 
-    get polyLifecycle(): PolyLifecycle {
-        return {
-            startFeature: (id, background) =>
-                this.rpcClient.polyLifecycle().startFeature(id, background)(),
-        };
-    }
-
     get polyNav(): PolyNav {
         return {
             openUrl: (url: string) => this.rpcClient.polyNav().openUrl(url)(),
@@ -243,14 +230,6 @@ export class RemoteClientPod implements Pod {
                     .endpoint()
                     .get(endpointId, contentType, authToken)(),
         };
-    }
-}
-
-// TODO move to pod-api?
-// TODO should this throw instead?
-class DummyPolyLifecycle implements PolyLifecycle {
-    async startFeature(): Promise<void> {
-        return;
     }
 }
 
@@ -301,10 +280,6 @@ export class RemoteServerPod implements ServerOf<PodBackend> {
 
     triplestore(): ServerOf<TriplestoreBackend> {
         return this.pod.triplestore;
-    }
-
-    polyLifecycle(): ServerOf<PolyLifecycleBackend> {
-        return new DummyPolyLifecycle();
     }
 
     polyNav(): ServerOf<PolyNavBackend> {

--- a/platform/feature-api/communication/src/remote-pod/tests/node/async.test.ts
+++ b/platform/feature-api/communication/src/remote-pod/tests/node/async.test.ts
@@ -38,10 +38,6 @@ describe("Async pod", () => {
                 startFeature: async (...args) => {
                     log.push(args);
                 },
-                listFeatures: async () => ({
-                    "test-on": true,
-                    "test-off": false,
-                }),
             };
             Object.assign(underlying, { polyLifecycle });
             pod = new AsyncPod(

--- a/platform/feature-api/communication/src/remote-pod/tests/node/async.test.ts
+++ b/platform/feature-api/communication/src/remote-pod/tests/node/async.test.ts
@@ -1,13 +1,7 @@
 import { Volume } from "memfs";
 import factory from "@rdfjs/dataset";
 import { AsyncPod } from "../../async";
-import {
-    Pod,
-    PolyLifecycle,
-    DefaultPod,
-    DataFactory,
-    podSpec,
-} from "@polypoly-eu/api";
+import { Pod, DefaultPod, DataFactory, podSpec } from "@polypoly-eu/api";
 
 describe("Async pod", () => {
     const underlying = new DefaultPod(factory.dataset(), new Volume().promises);

--- a/platform/feature-api/communication/src/remote-pod/tests/node/async.test.ts
+++ b/platform/feature-api/communication/src/remote-pod/tests/node/async.test.ts
@@ -26,34 +26,4 @@ describe("Async pod", () => {
 
         podSpec(new AsyncPod(delayed, new DataFactory(false)), "/");
     });
-
-    // TODO move to api, duplicated code
-    describe("Lifecycle", () => {
-        let pod: Pod;
-        let log: Array<(string | boolean)[]>;
-
-        beforeEach(() => {
-            log = [];
-            const polyLifecycle: PolyLifecycle = {
-                startFeature: async (...args) => {
-                    log.push(args);
-                },
-            };
-            Object.assign(underlying, { polyLifecycle });
-            pod = new AsyncPod(
-                Promise.resolve(underlying),
-                new DataFactory(false)
-            );
-        });
-
-        it("Starts feature", async () => {
-            await pod.polyLifecycle?.startFeature("hi", false);
-            await pod.polyLifecycle?.startFeature("yo", true);
-
-            expect(log).toEqual([
-                ["hi", false],
-                ["yo", true],
-            ]);
-        });
-    });
 });


### PR DESCRIPTION
# ✍️ Description

First hint is the fact that it's hidden in the documentation, but then their functions are not invoked anywhere or used in production, apparently. Its behavior is not documented, and its code has been sitting there for some time.


### 🏗️ Fixes [PROD4POD-1940](https://jira.polypoly.eu/browse/PROD4POD-1940)

> I created this one, but still

## ℹ️ Other information

I'll proceed cautiously here, since it might be used under some name we're not familiar with. So consider this a draft, although feedback is welcome. Anyway, this code was created by [this commit](https://github.com/polypoly-eu/polyPod/commit/2ef98b4b836cd4fae1d9b274bab1ca33598dffcc), which says `experimental`

WIP:
* [x] Eliminates `listFeatures`
* [x] Eliminates polyLifeCycle as a pod Property. 
* [x] Totally eliminates PolyLifeCycle as a class 

 ♥️ Thank you! 
