### PR TITLE
[:arrow_up:] Upgrade `actions/checkout` to v3

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: macOS-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - uses: actions/setup-node@v2
               with:
                   node-version: 16

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -22,7 +22,7 @@ jobs:
         runs-on: macOS-12
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
                   node-version: 18

--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -9,7 +9,7 @@ jobs:
     name: Run tests.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/.github/workflows/ktlint.yaml
+++ b/.github/workflows/ktlint.yaml
@@ -16,7 +16,7 @@ jobs:
   ktlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Downloads and installs ktlint
         run: |
           curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.43.0/ktlint && chmod a+x ktlint && sudo mv ktlint /usr/local/bin/

--- a/.github/workflows/rust_kernel_tests.yml
+++ b/.github/workflows/rust_kernel_tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -23,7 +23,7 @@ jobs:
       image: ghcr.io/realm/swiftlint:5.5-0.48.0
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Runs swiftlint
         working-directory: platform/ios
         run: swiftlint lint --config .swiftlint.yml --reporter github-actions-logging --strict


### PR DESCRIPTION
To avoid trouble with loss of support for node v12. It was causing warnings here and there,

![Captura de pantalla de 2022-10-11 08-48-31](https://user-images.githubusercontent.com/500/195016051-05ac8246-64bc-404d-b80f-105371911a63.png)


 ♥️ Thank you! 
