### PR TITLE
[PROD4POD-1945] FIX: Too many rerenders 

### DIFF
--- a/feature-utils/poly-look/src/react-components/filterChips.jsx
+++ b/feature-utils/poly-look/src/react-components/filterChips.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import Chip from "./chip.jsx";
 
 import "./filterChips.css";
@@ -61,13 +61,26 @@ const FilterChips = ({
         )
   );
 
-  const [initialDefaultChips, setInitialDefaultChips] =
-    useState(defaultActiveChips);
+  const isFirstRender = useRef(true);
+  const initialActiveChips = useRef(defaultActiveChips);
 
-  if (defaultActiveChips !== initialDefaultChips) {
-    setActiveChips(defaultActiveChips);
-    setInitialDefaultChips(defaultActiveChips);
-  }
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (
+      !(
+        initialActiveChips.current.length === defaultActiveChips.length &&
+        initialActiveChips.current.every(
+          (value, index) => value === defaultActiveChips[index]
+        )
+      )
+    ) {
+      initialActiveChips.current = defaultActiveChips;
+      setActiveChips(defaultActiveChips);
+    }
+  }, [defaultActiveChips]);
 
   const isChipActive = (id) => activeChips.indexOf(id) !== -1;
 

--- a/feature-utils/poly-look/src/react-components/filterChips.jsx
+++ b/feature-utils/poly-look/src/react-components/filterChips.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import Chip from "./chip.jsx";
 
 import "./filterChips.css";

--- a/feature-utils/poly-look/src/react-components/filterChips.jsx
+++ b/feature-utils/poly-look/src/react-components/filterChips.jsx
@@ -61,26 +61,9 @@ const FilterChips = ({
         )
   );
 
-  const isFirstRender = useRef(true);
-  const initialActiveChips = useRef(defaultActiveChips);
-
   useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
-    if (
-      !(
-        initialActiveChips.current.length === defaultActiveChips.length &&
-        initialActiveChips.current.every(
-          (value, index) => value === defaultActiveChips[index]
-        )
-      )
-    ) {
-      initialActiveChips.current = defaultActiveChips;
-      setActiveChips(defaultActiveChips);
-    }
-  }, [defaultActiveChips]);
+    setActiveChips(defaultActiveChips);
+  }, [JSON.stringify(defaultActiveChips)]);
 
   const isChipActive = (id) => activeChips.indexOf(id) !== -1;
 

--- a/features/polyExplorer/src/components/embeddedSankey/embeddedSankey.jsx
+++ b/features/polyExplorer/src/components/embeddedSankey/embeddedSankey.jsx
@@ -83,9 +83,7 @@ const EmbeddedSankey = ({ links, groups }) => {
             <p>{groups.source.label}</p>
             <FilterChips
                 chipsContent={sources}
-                defaultActiveChips={
-                    activeSources.length > 1 ? ["allChip"] : activeSources
-                }
+                defaultActiveChips={sources.length > 1 ? ["allChip"] : sources}
                 onChipClick={handleActiveSourceChange}
                 exclusive={false}
                 allChip={groups.source.all ? { translation: "All" } : null}


### PR DESCRIPTION
Fixes: https://jira.polypoly.eu/browse/PROD4POD-1945

The defaultChipsProp needs to update the activeChips state. The update was not done correctly. 

You need a ref to keep the initial active chips, and then an effect to change that ref, and watch for changes to the prop. 