### PR TITLE
Fix android gradle

### DIFF
--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/MainActivity.kt
@@ -40,8 +40,9 @@ class MainActivity : AppCompatActivity(), LifecycleEventObserver {
             // Ignore CoreAlreadyBootstrapped error, as it is not breaking.
             if ((ex as? CoreFailure)?.code
                 != CoreExceptionCode.CoreAlreadyBootstrapped
-            )
+            ) {
                 throw ex
+            }
         }
 
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)

--- a/platform/android/app/src/main/res/xml/network_security_config.xml
+++ b/platform/android/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="false">
-        <!--Even if cleartextTrafficPermitted is false it still forces me to add a domain. It does not make sense, But I am trying to make it build for release-->
-        <domain includeSubdomains="false" />
-    </domain-config>
+    <base-config cleartextTrafficPermitted="false"/>
 </network-security-config>

--- a/platform/android/app/src/main/res/xml/network_security_config.xml
+++ b/platform/android/app/src/main/res/xml/network_security_config.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="false">
+        <!--Even if cleartextTrafficPermitted is false it still forces me to add a domain. It does not make sense, But I am trying to make it build for release-->
+        <domain includeSubdomains="false" />
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
Fixes 

`Exception java.lang.RuntimeException: Unable to instantiate application android.app.Application: java.lang.RuntimeException: Failed to parse XML configuration from network_security_config
  at android.app.LoadedApk.makeApplication (LoadedApk.java:1268)
  at android.app.ActivityThread.handleBindApplication (ActivityThread.java:6690)
  at android.app.ActivityThread.access$1300 (ActivityThread.java:237)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1913)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:223)
  at android.app.ActivityThread.main (ActivityThread.java:7664)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:592)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:947)
Caused by java.lang.RuntimeException: Failed to parse XML configuration from network_security_config
  at [android.security.net](http://android.security.net/).config.XmlConfigSource.ensureInitialized (XmlConfigSource.java:89)
  at [android.security.net](http://android.security.net/).config.XmlConfigSource.getPerDomainConfigs (XmlConfigSource.java:55)
  at [android.security.net](http://android.security.net/).config.ManifestConfigSource.getPerDomainConfigs (ManifestConfigSource.java:45)
  at [android.security.net](http://android.security.net/).config.ApplicationConfig.ensureInitialized (ApplicationConfig.java:175)
  at [android.security.net](http://android.security.net/).config.ApplicationConfig.isCleartextTrafficPermitted (ApplicationConfig.java:130)
  at [android.security.net](http://android.security.net/).config.NetworkSecurityConfigProvider.handleNewApplication (NetworkSecurityConfigProvider.java:60)
  at android.app.LoadedApk.makeApplication (LoadedApk.java:1259)
Caused by [android.security.net](http://android.security.net/).config.XmlConfigSource$ParserException: Domain name missing at: Binary XML file line #5
  at [android.security.net](http://android.security.net/).config.XmlConfigSource.parseDomain (XmlConfigSource.java:159)
  at [android.security.net](http://android.security.net/).config.XmlConfigSource.parseConfigEntry (XmlConfigSource.java:256)
  at [android.security.net](http://android.security.net/).config.XmlConfigSource.parseNetworkSecurityConfig (XmlConfigSource.java:327)
  at [android.security.net](http://android.security.net/).config.XmlConfigSource.ensureInitialized (XmlConfigSource.java:83)`