### PR TITLE
[:arrow_up:] Upgrade Github's own actions to v3

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -16,7 +16,7 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v3
               with:
                   node-version: 16
                   cache: "npm"
@@ -25,7 +25,7 @@ jobs:
               run: ./build.js
               env:
                 POLYPOD_BUILD_PLATFORMS: android
-            - uses: actions/setup-java@v2
+            - uses: actions/setup-java@v3
               with:
                   distribution: 'zulu'
                   java-version: 11

--- a/.github/workflows/js-and-android-test.yml
+++ b/.github/workflows/js-and-android-test.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - name: Cache JS deps
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: |
@@ -73,7 +73,7 @@ jobs:
           distribution: "temurin"
           cache: "gradle"
       - name: Setup Gradle Dependencies Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}


### PR DESCRIPTION
# ✍️ Description

Actions have started showing warnings on deprecated stuff:

![Captura de pantalla de 2022-10-17 10-01-14](https://user-images.githubusercontent.com/500/196121948-227965cf-0f81-4e96-893e-d8a388507004.png)

Action versions were not really uniform; they've been updated to the latest version.

## ℹ️ Other information

[This is the relevant GitHub blog entry mentioned](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

♥️ Thank you! 
