### PR TITLE
[:recycle:] Eliminate unneeded coupling with zipFile :coffin:

### DIFF
--- a/feature-utils/poly-import/utils/zipfile-mock.js
+++ b/feature-utils/poly-import/utils/zipfile-mock.js
@@ -3,8 +3,7 @@ import { jsonStringifyWithUtfEscape } from "./json-encoding";
 //The minimum size of a .ZIP file is 22 bytes
 export const MINIMUM_FILE_SIZE = 22;
 export class ZipFileEntryMock {
-    constructor(zipFile, id, path, content) {
-        this.zipFile = zipFile;
+    constructor(id, path, content) {
         this._id = id;
         this._path = path;
         this.content = content;
@@ -18,12 +17,11 @@ export class ZipFileEntryMock {
     }
 
     async stat() {
-        const entryContent = this.zipFile.entries[this._id];
         return {
             getId: () => this._id,
             getTime: () => "",
-            getName: () => this._id.substr(this.zipFile.id.length),
-            getSize: () => entryContent.length,
+            getName: () => this._path,
+            getSize: () => this.content.length,
             isFile: () => true,
             isDirectory: () => false,
         };
@@ -70,12 +68,7 @@ export class ZipFileMock {
 
     addNamedEntry(fileName, stringContent) {
         const entryId = this.id + "/" + fileName;
-        const entry = new ZipFileEntryMock(
-            this,
-            entryId,
-            fileName,
-            stringContent
-        );
+        const entry = new ZipFileEntryMock(entryId, fileName, stringContent);
         this._entriesPathHash.set(fileName, entry);
     }
 


### PR DESCRIPTION
# ✍️ Description

Again, this was found wanting for #1218. This coupling was probably not needed, so that all information for an entry occurs in the entry itself, and it does not need to be handled by the hosting zipFile. Since this is a Mock, we don't really need more than that.

## ℹ️ Other information

Might include some tests, and additional spin-off of all ZipMockFile methods that create Entries.

♥️ Thank you!
