### PR TITLE
[♻] Add test for bubbles, refactor to avoid content error

### DIFF
--- a/features/facebookImport/src/model/analyses/ministories/json-files-bubbles.js
+++ b/features/facebookImport/src/model/analyses/ministories/json-files-bubbles.js
@@ -2,6 +2,7 @@ import React from "react";
 
 import { BubbleCluster } from "@polypoly-eu/poly-look";
 import { RootAnalysis, jsonDataEntities } from "@polypoly-eu/poly-analysis";
+import { json } from "d3";
 
 export default class JsonFilesBubblesAnalysis extends RootAnalysis {
     get title() {
@@ -9,8 +10,9 @@ export default class JsonFilesBubblesAnalysis extends RootAnalysis {
     }
 
     async _contentLinesForEntry(zipFile, jsonEntry) {
+        console.log(jsonEntry.getContent());
         const fileContent = new TextDecoder("utf-8").decode(
-            await zipFile.getContent(jsonEntry)
+            await jsonEntry.getContent()
         );
         const linesCount = fileContent
             .split("\n")

--- a/features/facebookImport/src/model/analyses/ministories/json-files-bubbles.js
+++ b/features/facebookImport/src/model/analyses/ministories/json-files-bubbles.js
@@ -9,8 +9,7 @@ export default class JsonFilesBubblesAnalysis extends RootAnalysis {
         return "Files Bubbles";
     }
 
-    async _contentLinesForEntry(zipFile, jsonEntry) {
-        console.log(jsonEntry.getContent());
+    async _contentLinesForEntry(jsonEntry) {
         const fileContent = new TextDecoder("utf-8").decode(
             await jsonEntry.getContent()
         );
@@ -21,7 +20,7 @@ export default class JsonFilesBubblesAnalysis extends RootAnalysis {
                     linesCount + (line.trim().length >= 2 ? 1 : 0),
                 0
             );
-        return { zipFile, zipEntry: jsonEntry, count: linesCount };
+        return { zipEntry: jsonEntry, count: linesCount };
     }
 
     async analyze({ zipFile, dataAccount }) {
@@ -33,7 +32,7 @@ export default class JsonFilesBubblesAnalysis extends RootAnalysis {
         const relevantEntries = await jsonDataEntities(zipFile);
         this._filesMessagesCount = await Promise.all(
             relevantEntries.map((jsonEntry) =>
-                this._contentLinesForEntry(zipFile, jsonEntry)
+                this._contentLinesForEntry(jsonEntry)
             )
         );
         this.active = true;

--- a/features/facebookImport/src/model/analyses/ministories/json-files-bubbles.js
+++ b/features/facebookImport/src/model/analyses/ministories/json-files-bubbles.js
@@ -2,7 +2,6 @@ import React from "react";
 
 import { BubbleCluster } from "@polypoly-eu/poly-look";
 import { RootAnalysis, jsonDataEntities } from "@polypoly-eu/poly-analysis";
-import { json } from "d3";
 
 export default class JsonFilesBubblesAnalysis extends RootAnalysis {
     get title() {

--- a/features/facebookImport/test/ministory/json-files-bubbles-analysis.test.js
+++ b/features/facebookImport/test/ministory/json-files-bubbles-analysis.test.js
@@ -42,6 +42,6 @@ describe("JSON files analysis for non-empty zip", () => {
 
     it("has the right message count", () => {
         console.log(analysis);
-        expect(analysis.filesMessagesCount).toHaveLength(8);
+        expect(analysis._filesMessagesCount).toHaveLength(8);
     });
 });

--- a/features/facebookImport/test/ministory/json-files-bubbles-analysis.test.js
+++ b/features/facebookImport/test/ministory/json-files-bubbles-analysis.test.js
@@ -20,7 +20,6 @@ async function analyzeZipWithFiles(files) {
         JSONFilesBubblesAnalysis,
         zipFile
     );
-    console.log(analysisResult);
     return analysisResult;
 }
 
@@ -36,8 +35,13 @@ describe("JSON files analysis for non-empty zip", () => {
         expect(status.isSuccess).toBe(true);
     });
 
-    it("has the right title", () => {
+    it("has the right type and title", () => {
         expect(analysis).toBeInstanceOf(JSONFilesBubblesAnalysis);
         expect(analysis.title).toBe("Files Bubbles");
     });
+
+    it("has the right message count", () => {
+        expect(analysis.filesMessagesCount).toHaveLength(8)M
+    });
+
 });

--- a/features/facebookImport/test/ministory/json-files-bubbles-analysis.test.js
+++ b/features/facebookImport/test/ministory/json-files-bubbles-analysis.test.js
@@ -37,6 +37,7 @@ describe("JSON files analysis for non-empty zip", () => {
     });
 
     it("has the right title", () => {
+        expect(analysis).toBeInstanceOf(JSONFilesBubblesAnalysis);
         expect(analysis.title).toBe("Files Bubbles");
     });
 });

--- a/features/facebookImport/test/ministory/json-files-bubbles-analysis.test.js
+++ b/features/facebookImport/test/ministory/json-files-bubbles-analysis.test.js
@@ -1,0 +1,42 @@
+import JSONFilesBubblesAnalysis from "../../src/model/analyses/ministories/json-files-bubbles";
+import commonStructure from "../../src/static/commonStructure";
+import { ZipFileMock } from "@polypoly-eu/poly-import";
+import { runAnalysisForExport } from "../utils/analyses-execution";
+
+const commonJsonFiles = commonStructure
+    .filter((path) => path.match(/\.json$/))
+    .map((jsonPath) => {
+        return jsonPath.substring(1);
+    });
+
+async function analyzeZipWithFiles(files) {
+    const zipFile = new ZipFileMock();
+    if (files.length > 0) {
+        files.forEach((jsonPath) => {
+            zipFile.addJsonEntry(jsonPath, { foo: "bar" });
+        });
+    }
+    const { analysisResult } = await runAnalysisForExport(
+        JSONFilesBubblesAnalysis,
+        zipFile
+    );
+    console.log(analysisResult);
+    return analysisResult;
+}
+
+describe("JSON files analysis for non-empty zip", () => {
+    let status;
+    let analysis;
+
+    beforeAll(async () => {
+        ({ status, analysis } = await analyzeZipWithFiles(commonJsonFiles));
+    });
+
+    it("reports successful status", () => {
+        expect(status.isSuccess).toBe(true);
+    });
+
+    it("has the right title", () => {
+        expect(analysis.title).toBe("Files Bubbles");
+    });
+});

--- a/features/facebookImport/test/ministory/json-files-bubbles-analysis.test.js
+++ b/features/facebookImport/test/ministory/json-files-bubbles-analysis.test.js
@@ -41,7 +41,6 @@ describe("JSON files analysis for non-empty zip", () => {
     });
 
     it("has the right message count", () => {
-        console.log(analysis);
-        expect(analysis._filesMessagesCount).toHaveLength(8);
+        expect(analysis._filesMessagesCount).toHaveLength(10);
     });
 });

--- a/features/facebookImport/test/ministory/json-files-bubbles-analysis.test.js
+++ b/features/facebookImport/test/ministory/json-files-bubbles-analysis.test.js
@@ -41,7 +41,7 @@ describe("JSON files analysis for non-empty zip", () => {
     });
 
     it("has the right message count", () => {
-        expect(analysis.filesMessagesCount).toHaveLength(8)M
+        console.log(analysis);
+        expect(analysis.filesMessagesCount).toHaveLength(8);
     });
-
 });


### PR DESCRIPTION
# ✍️ Description

This code was the only one using the construction `zipFile.getContent`, which apparently disappeared a some point in time. It's been refactored to work as intended, getting the content of a single `ZipEntry`. Adds a tests which fails if the original content was used.

### 🏗️ Fixes PROD4POD-1940

This was found while doing #1219, so it's a blocker for that one.

## ℹ️ Other information

Deep tests have not really been performed; they're mainly sanity tests. Rendering tests are not checked either. Better mocks would probably be needed for better tests.

(Unrelated) coupling with `zipFile` has been eliminated from the function, since it's no longer needed. The function was returning a data structure which included it, not doing that does not seem to affect the outcome.

♥️ Thank you!
