### PR TITLE
Importer Refactoring 5 - MultipleFilesImporter

### DIFF
--- a/features/facebookImport/src/model/analyses/ministories/messages-analysis.js
+++ b/features/facebookImport/src/model/analyses/ministories/messages-analysis.js
@@ -7,11 +7,11 @@ export default class MessagesAnalysis extends RootAnalysis {
     }
 
     async analyze({ dataAccount }) {
-        let messagesCount = dataAccount.messagesCount;
+        let messagesCount = dataAccount.messages?.messagesCount || 0;
         let messagesThreadsData = [];
         const usernames = new Set();
 
-        dataAccount.forEachMessageThread((messageThread) => {
+        dataAccount.messages?.forEachMessageThread((messageThread) => {
             var firstChatTimestamp = 0;
             var lastChatTimestamp = 0;
 

--- a/features/facebookImport/src/model/importers/direct-key-data-importer.js
+++ b/features/facebookImport/src/model/importers/direct-key-data-importer.js
@@ -15,7 +15,6 @@ export default class DirectKeyDataImporter extends Importer {
             this._dataKey,
             zipFile
         );
-        console.log(this._dataFileName);
 
         return {
             result:

--- a/features/facebookImport/src/model/importers/direct-key-data-importer.js
+++ b/features/facebookImport/src/model/importers/direct-key-data-importer.js
@@ -15,6 +15,7 @@ export default class DirectKeyDataImporter extends Importer {
             this._dataKey,
             zipFile
         );
+        console.log(this._dataFileName);
 
         return {
             result:

--- a/features/facebookImport/src/model/importers/messages-importer.js
+++ b/features/facebookImport/src/model/importers/messages-importer.js
@@ -1,3 +1,4 @@
+import MessageThreadsGroup from "../entities/message-threads-group.js";
 import MultipleFilesImporter from "./multiple-files-importer.js";
 
 export default class MessagesImporter extends MultipleFilesImporter {
@@ -7,10 +8,11 @@ export default class MessagesImporter extends MultipleFilesImporter {
         );
     }
 
-    _importRawDataResults(facebookAccount, dataResults) {
-        facebookAccount.messageThreadsGroup.addMessageThreadsFromData(
-            dataResults
-        );
+    _processRawDataResults(dataResults) {
+        const messageGroup = new MessageThreadsGroup();
+        if (dataResults.length > 0)
+            messageGroup.addMessageThreadsFromData(dataResults);
+        return messageGroup;
     }
 }
 

--- a/features/facebookImport/src/model/importers/multiple-files-importer.js
+++ b/features/facebookImport/src/model/importers/multiple-files-importer.js
@@ -76,9 +76,8 @@ export default class MultipleFilesImporter extends Importer {
                     new Status({
                         name: statusTypes.error,
                         message: `${
-                            (responses.length - successfulResponses.length) /
-                            responses.length
-                        } files importing failes`,
+                            successfulResponses.length + "/" + responses.length
+                        } files imported successfully`,
                     }),
                 statuses: responses.map(({ status }) => status),
                 importedFileNames,

--- a/features/facebookImport/src/model/importers/posts-importer.js
+++ b/features/facebookImport/src/model/importers/posts-importer.js
@@ -5,13 +5,14 @@ export default class PostsImporter extends MultipleFilesImporter {
         return /posts\/your_posts_[1-9][0-9]?.json$/.test(entryName);
     }
 
-    _importRawDataResults(facebookAccount, dataResults) {
-        dataResults.forEach((rawPosts) => {
-            const postsWithTimestamp = rawPosts.map((postData) => {
-                return { timestamp: postData.timestamp };
-            });
-            facebookAccount.addPosts(postsWithTimestamp);
-        });
+    _processRawDataResults(dataResults) {
+        return dataResults
+            .map((rawPosts) =>
+                rawPosts.map((postData) => ({
+                    timestamp: postData.timestamp,
+                }))
+            )
+            .flat();
     }
 }
 

--- a/features/facebookImport/test/importers/messages-importer.test.js
+++ b/features/facebookImport/test/importers/messages-importer.test.js
@@ -25,62 +25,62 @@ describe("Import messages from empty export", () => {
     });
 
     it("triggers missing files error", async () => {
-        const { result } = await runMessagesImporter(zipFile);
-        expectError(result, MissingFilesException, MessagesImporter);
+        const { report } = await runMessagesImporter(zipFile);
+        expectError(report, MissingFilesException, MessagesImporter);
     });
 });
 
 describe("Import message from export with three file errors", () => {
     let result = null;
-    let facebookAccount = null;
+    let report = null;
 
     beforeAll(async () => {
         const zipFile = zipFileWithThreeFileErrors();
-        ({ result, facebookAccount } = await runMessagesImporter(zipFile));
+        ({ report, result } = await runMessagesImporter(zipFile));
     });
 
     it("has two error status", async () => {
-        expect(result.status.length).toBe(3);
+        expect(report.statuses.length).toBe(3);
     });
 
     it("triggers syntax error", async () => {
-        expectErrorStatus(result.status[0], MissingContentImportException);
-        expectErrorStatus(result.status[1], SyntaxError);
-        expectErrorStatus(result.status[2], TypeError);
+        expectErrorStatus(report.statuses[0], MissingContentImportException);
+        expectErrorStatus(report.statuses[1], SyntaxError);
+        expectErrorStatus(report.statuses[2], TypeError);
     });
 
     it("has no imported messages", () => {
-        expect(facebookAccount.messageThreadsCount).toBe(0);
-        expect(facebookAccount.messagesCount).toBe(0);
+        expect(result.messageThreadsCount).toBe(0);
+        expect(result.messagesCount).toBe(0);
     });
 });
 
 describe("Import inbox messages", () => {
     let zipFile = null;
-    let result = null;
-    let facebookAccount = null;
+    let report = null;
+    let messageThreadsGroup = null;
     let firstMessageThread = null;
     let secondMessageThread = null;
 
     beforeAll(async () => {
         zipFile = zipFileWithMessageThreads();
 
-        const importingResult = await runMessagesImporter(zipFile);
-        result = importingResult.result;
-        facebookAccount = importingResult.facebookAccount;
+        const importingResponse = await runMessagesImporter(zipFile);
+        report = importingResponse.report;
+        messageThreadsGroup = importingResponse.result;
         [firstMessageThread, secondMessageThread] =
-            facebookAccount.messageThreadsGroup.messagesThreads;
+            messageThreadsGroup.messagesThreads;
     });
 
-    it("returns success status", () => expectImportSuccess(result));
+    it("returns success status", () => expectImportSuccess(report));
 
     it("has correct number of message threads", () =>
-        expect(facebookAccount.messageThreadsCount).toBe(
+        expect(messageThreadsGroup.messageThreadsCount).toBe(
             DATASET_EXPECTED_VALUES.numberOfMessageThreads
         ));
 
     it("has correct number of message", () =>
-        expect(facebookAccount.messagesCount).toBe(
+        expect(messageThreadsGroup.messagesCount).toBe(
             DATASET_EXPECTED_VALUES.numberOfMessages
         ));
 

--- a/features/facebookImport/test/importers/posts-importer.test.js
+++ b/features/facebookImport/test/importers/posts-importer.test.js
@@ -26,86 +26,85 @@ describe("Import posts from empty export", () => {
     });
 
     it("triggers missing files error", async () => {
-        const { result } = await runPostsImporter(zipFile);
-        expectError(result, MissingFilesException, PostsImporter);
+        const { report } = await runPostsImporter(zipFile);
+        expectError(report, MissingFilesException, PostsImporter);
     });
 });
 
 describe("Import posts from export with one file error", () => {
     let result = null;
-    let facebookAccount = null;
+    let report = null;
 
     beforeAll(async () => {
         const zipFile = zipFileWithFileError();
-        ({ result, facebookAccount } = await runPostsImporter(zipFile));
+        ({ result, report } = await runPostsImporter(zipFile));
     });
 
     it("has one error status", async () => {
-        expect(result.status.length).toBe(1);
+        expect(
+            report.statuses.filter((status) => !status.isSuccess).length
+        ).toBe(1);
     });
 
     it("triggers syntax error", async () => {
-        expectErrorStatus(result.status[0], SyntaxError);
+        expectErrorStatus(report.statuses[1], SyntaxError);
     });
 
     it("has correct number of entities from file one", () =>
-        expect(facebookAccount.posts.length).toBe(
-            DATASET_ONE_EXPECTED_VALUES.numberOfPosts
-        ));
+        expect(result.length).toBe(DATASET_ONE_EXPECTED_VALUES.numberOfPosts));
 });
 
 describe("Import posts from export with two file errors", () => {
     let result = null;
-    let facebookAccount = null;
+    let report = null;
 
     beforeAll(async () => {
         const zipFile = zipFileWithTwoFileErrors();
-        ({ result, facebookAccount } = await runPostsImporter(zipFile));
+        ({ result, report } = await runPostsImporter(zipFile));
     });
 
     it("has two error status", async () => {
-        expect(result.status.length).toBe(2);
+        expect(
+            report.statuses.filter((status) => !status.isSuccess).length
+        ).toBe(2);
     });
 
     it("triggers syntax error", async () => {
-        expectErrorStatus(result.status[0], MissingContentImportException);
-        expectErrorStatus(result.status[1], SyntaxError);
+        expectErrorStatus(report.statuses[0], MissingContentImportException);
+        expectErrorStatus(report.statuses[1], SyntaxError);
     });
 
-    it("has no imported posts", () =>
-        expect(facebookAccount.posts.length).toBe(0));
+    it("has no imported posts", () => expect(result.length).toBe(0));
 });
 
 describe("Import posts from export with one file", () => {
     let result = null;
-    let facebookAccount = null;
+    let report = null;
 
     beforeAll(async () => {
         const zipFile = zipFileWithOnePostsFiles();
-        ({ result, facebookAccount } = await runPostsImporter(zipFile));
+        ({ result, report } = await runPostsImporter(zipFile));
     });
 
-    it("returns success status", () => expectImportSuccess(result));
+    it("returns success status", () => expectImportSuccess(report));
 
     it("has correct number of entities", () =>
-        expect(facebookAccount.posts.length).toBe(
-            DATASET_ONE_EXPECTED_VALUES.numberOfPosts
-        ));
+        expect(result.length).toBe(DATASET_ONE_EXPECTED_VALUES.numberOfPosts));
 });
 
 describe("Import posts from export with two files", () => {
     let result = null;
-    let facebookAccount = null;
+    let report = null;
 
     beforeAll(async () => {
         const zipFile = zipFileWithTwoPostsFiles();
-        ({ result, facebookAccount } = await runPostsImporter(zipFile));
+        ({ result, report } = await runPostsImporter(zipFile));
     });
 
-    it("returns success status", () => expectImportSuccess(result));
+    it("returns success status", () => expectImportSuccess(report));
 
     it("has correct number of entities", () =>
-        expect(facebookAccount.posts.length).toBe(
+        expect(result.length).toBe(
             DATASET_ONE_EXPECTED_VALUES.numberOfPosts +
                 DATASET_TWO_EXPECTED_VALUES.numberOfPosts
         ));

--- a/features/facebookImport/test/utils/data-importing.js
+++ b/features/facebookImport/test/utils/data-importing.js
@@ -92,7 +92,7 @@ export async function runPersonalDataImporter(zipFile) {
 }
 
 export async function runMessagesImporter(zipFile) {
-    return runSingleOutdatedImporter(MessagesImporter, zipFile);
+    return runSingleImporter(MessagesImporter, zipFile);
 }
 
 export async function runRecentlyViewedAdsImporter(zipFile) {

--- a/features/facebookImport/test/utils/data-importing.js
+++ b/features/facebookImport/test/utils/data-importing.js
@@ -128,7 +128,7 @@ export async function runPostReactionsImporter(zipFile) {
 }
 
 export async function runPostsImporter(zipFile) {
-    return runSingleOutdatedImporter(PostsImporter, zipFile);
+    return runSingleImporter(PostsImporter, zipFile);
 }
 
 export async function runImportForDataset(importerClass, filePath, dataset) {


### PR DESCRIPTION



# Changing multipleFileImporters to fit the new structure

Some restructuring was needed here. We do not rely on the messageThreadsObject in facebookaccount any longer  but create our own and give it back.

Statuses describes the different statuses of each file import while status gives an overview of how many worked (error when one failed, but app still works).

Ongoing issue: Refactoring Importer Framework, see https://github.com/polypoly-eu/polyPod/pull/1190 for explanation