### PR TITLE
correct jsDocs following changes in #1231

### DIFF
--- a/feature-utils/poly-analysis/src/report/ministories-status-report.js
+++ b/feature-utils/poly-analysis/src/report/ministories-status-report.js
@@ -6,7 +6,7 @@ import React from "react";
  *
  * I provide the same API as an analysis that should be included in a report.
  *
- * @class
+ * @class MinistoriesStatusReport
  */
 export default class MinistoriesStatusReport {
     constructor({ ministories, title, description }) {

--- a/feature-utils/poly-look/src/css/index.js
+++ b/feature-utils/poly-look/src/css/index.js
@@ -13,6 +13,7 @@ import "./utils.css";
 import "swiper/swiper-bundle.css";
 
 /**
- * Doesn't really do anything except being a place where css files are referenced so that they're bundled
+ * Doesn't really do anything except being a place where css files are referenced so that they're bundled.
+ * @callback cssBundler
  */
 export const cssBundler = () => {};

--- a/feature-utils/poly-look/src/react-components/banners/banner.jsx
+++ b/feature-utils/poly-look/src/react-components/banners/banner.jsx
@@ -4,16 +4,17 @@ import { RoutingWrapper } from "../routing";
 import "./banner.css";
 
 /**
- * Banner component
- *
- * @param {String} [icon] Displays an icon next to the title if passed
- * @param {String} [title] Title of the banner
- * @param {String} [description] Text for the banner's description
- * @param {Object} [button] Content of the button. Also, displays the PolyButton at the bottom if passed.
- * @param {String} [button.route] String to route to ("back" leads back)
- * @param {History} [button.history] React router dom history for the RoutingWrapper component
- * @param {String} [button.label] Text for the button's label
- * @returns jsx
+ * Banner component.
+ * @callback Banner
+ * @param {Object} props
+ * @param {string} props.icon Displays an icon next to the title if passed
+ * @param {string} props.title Title of the banner
+ * @param {string} props.description Text for the banner's description
+ * @param {Object} props.button Content of the button. Also, displays the PolyButton at the bottom if passed.
+ * @param {string} props.button.route String to route to ("back" leads back)
+ * @param {History} props.button.history React router dom history for the RoutingWrapper component
+ * @param {String} props.button.label Text for the button's label
+ * @returns {JSX.Element}
  */
 export const Banner = ({ icon, title, description, button }) => {
   return (

--- a/feature-utils/poly-look/src/react-components/banners/notificationBanner.jsx
+++ b/feature-utils/poly-look/src/react-components/banners/notificationBanner.jsx
@@ -15,20 +15,23 @@ export const notificationTypes = {
 };
 
 /**
- * Notification Banner component - also used as a pop-up.
+ * Callback for handling the click event to close notification.
  *
- * @param {jsx} children JSX elements displayed inside the banner as a notification message.
- * @param {string} notificationType The notification type defines the styles and icon used in the component.
- * There are currently four notification options: standard, success, error and warning.
- * @param {callback} handleCloseNotification onClick function to close the notification.
- * @returns jsx
+ * @callback notificationCallback
+ * @param {React.MouseEventHandler<HTMLImageElement>} clickEvent - mouse event action.
  */
 
-export function NotificationBanner({
-  children,
-  notificationType,
-  handleCloseNotification,
-}) {
+/**
+ * Notification Banner component - also used as a pop-up.
+ * @component
+ * @param {Object} props
+ * @param {JSX} [props.children] JSX elements displayed inside the banner as a notification message.
+ * @param {String} [props.notificationType] The notification type defines the styles and icon used in the component.
+ * There are currently four notification options: standard, success, error and warning.
+ * @param {notificationCallback} [props.onClick] onClick function to close the notification.
+ * @returns {JSX.Element}
+ */
+export function NotificationBanner({ children, notificationType, onClick }) {
   const icons = {
     standard,
     success,
@@ -41,11 +44,7 @@ export function NotificationBanner({
         className={`notification-banner ${notificationTypes[notificationType]}`}
       >
         {children}
-        <img
-          src={icons[notificationType]}
-          alt="close"
-          onClick={handleCloseNotification}
-        />
+        <img src={icons[notificationType]} alt="close" onClick={onClick} />
       </div>
     </div>
   );

--- a/feature-utils/poly-look/src/react-components/banners/notificationBanner.jsx
+++ b/feature-utils/poly-look/src/react-components/banners/notificationBanner.jsx
@@ -28,10 +28,14 @@ export const notificationTypes = {
  * @param {JSX} [props.children] JSX elements displayed inside the banner as a notification message.
  * @param {String} [props.notificationType] The notification type defines the styles and icon used in the component.
  * There are currently four notification options: standard, success, error and warning.
- * @param {notificationCallback} [props.onClick] onClick function to close the notification.
+ * @param {notificationCallback} [props.handleCloseNotification] onClick function to close the notification.
  * @returns {JSX.Element}
  */
-export function NotificationBanner({ children, notificationType, onClick }) {
+export function NotificationBanner({
+  children,
+  notificationType,
+  handleCloseNotification,
+}) {
   const icons = {
     standard,
     success,
@@ -44,7 +48,11 @@ export function NotificationBanner({ children, notificationType, onClick }) {
         className={`notification-banner ${notificationTypes[notificationType]}`}
       >
         {children}
-        <img src={icons[notificationType]} alt="close" onClick={onClick} />
+        <img
+          src={icons[notificationType]}
+          alt="close"
+          onClick={handleCloseNotification}
+        />
       </div>
     </div>
   );

--- a/feature-utils/poly-look/src/react-components/banners/progressBanner.jsx
+++ b/feature-utils/poly-look/src/react-components/banners/progressBanner.jsx
@@ -4,12 +4,22 @@ import { IconButton } from "../buttons";
 
 import "./progressBanner.css";
 
-/** A banner with an dynamic icon, title, description and a button.
+/**
+ * Callback for handling the click event to close button.
+ *
+ * @callback buttonCallback
+ * @param {React.MouseEventHandler<HTMLDivElement>} clickEvent - mouse onClick action.
+ */
+
+/**
+ * It renders a progress banner with a title, description, and a dynamic icon
+ * that indicates the stage of the progress.
+ * @component
  * @param {Object} props
  * @param {number} [props.stage] - Used for changing the dynamic icon.
  * @param {string} [props.title] - String to be used for the title.
  * @param {string} [props.description] - String to be used for the description.
- * @param {callback} [props.onClick] - Button callback.
+ * @param {buttonCallback} [props.onClick] - Button callback.
  * @returns {JSX.Element}
  */
 export function ProgressBanner({ stage, title, description, onClick }) {

--- a/feature-utils/poly-look/src/react-components/banners/progressIcon.jsx
+++ b/feature-utils/poly-look/src/react-components/banners/progressIcon.jsx
@@ -1,7 +1,10 @@
 import React from "react";
 
-/** Icon containing a dynamic svg representing 4 stages that change color
- *  based on the stage prop.
+/**
+ * Renders a progress icon containing a dynamic svg with
+ * a number of segments equal to the number of stages in the process
+ * that change color based on the stage prop.
+ * @component
  * @param {Object} props
  * @param {number} [props.stage] - How many stages to fill in
  * using activeColor prop.

--- a/feature-utils/poly-look/src/react-components/buttons/iconButton.jsx
+++ b/feature-utils/poly-look/src/react-components/buttons/iconButton.jsx
@@ -7,14 +7,16 @@ import filter from "../../static/images/icons/filter.svg";
 import "./iconButton.css";
 
 /**
- * Icon button. Has a filled variant.
- * Any valid button HTML attributes are allowed.
+ * It takes an icon name and returns a button with that icon.
+ * Has a filled variant. Any valid button HTML attributes are allowed.
+ * @component
  * @param {Object} props
- * @param {string} [props.icon] - Button icon
+ * @param {string} props.icon - Button icon
  * Currently implemented options are: angleRight, question, filter.
  * @param {string} [props.fillDirection] - This option adds a background color
  * and a border radius to the direction specified.
  * Available options are left and right.
+ * @returns A button with an image inside of it.
  */
 const IconButton = ({ icon, fillDirection = "", ...otherProps }) => {
   const icons = {
@@ -41,4 +43,5 @@ const IconButton = ({ icon, fillDirection = "", ...otherProps }) => {
     </button>
   );
 };
+
 export default IconButton;

--- a/feature-utils/poly-look/src/react-components/buttons/polyButton.jsx
+++ b/feature-utils/poly-look/src/react-components/buttons/polyButton.jsx
@@ -1,23 +1,6 @@
 import React from "react";
 import "./polyButton.css";
 
-/**
- * Basic button.
- * In addition to `label` and `centered` any valid button HTML attributes
- * are allowed.
- * If either `iconLeft` or `iconRight` are specified, the button size will
- * be set to small.
- * @param {Object} props
- * @param {string} [props.label] - Button text
- * @param {boolean} [props.centered] - If the button should center itself.
- * @param {string} [props.type = "filled"] - Type of the button
- * @param {string} [props.size = "large"] - Size of the button
- * @param {JSX} [props.iconLeft] - Optional icon to be displayed on the left side
- * of the label.
- * @param {JSX} [props.iconRight] - Optional icon to be displayed on the right
- * side of the label.
- */
-
 const types = {
   filled: "filled",
   outline: "outline",
@@ -28,6 +11,23 @@ const sizes = {
   small: "small",
 };
 
+/**
+ * Basic button.
+ * In addition to `label` and `centered` any valid button HTML attributes
+ * are allowed.
+ * If either `iconLeft` or `iconRight` are specified, the button size will
+ * be set to small.
+ * @component
+ * @param {Object} props
+ * @param {string} [props.label] - Button text
+ * @param {boolean} [props.centered] - If the button should center itself.
+ * @param {string} [props.type = "filled"] - Type of the button
+ * @param {string} [props.size = "large"] - Size of the button
+ * @param {JSX} [props.iconLeft] - Optional icon to be displayed on the left side
+ * of the label.
+ * @param {JSX} [props.iconRight] - Optional icon to be displayed on the right
+ * side of the label.
+ */
 const PolyButton = ({
   label,
   type = "filled",

--- a/feature-utils/poly-look/src/react-components/cards/card.jsx
+++ b/feature-utils/poly-look/src/react-components/cards/card.jsx
@@ -4,9 +4,11 @@ import "./card.css";
 
 /**
  * Card component
- *
- * @param {jsx} children JSX elements displayed inside the card
- * @returns jsx
+ * It takes in children and returns a div with the class of card and the children
+ * inside of it.
+ * @component
+ * @param {JSX.Element} children JSX elements displayed inside the card
+ * @returns  {JSX.Element} A card component
  */
 const Card = ({ children }) => {
   return <div className="card">{children}</div>;

--- a/feature-utils/poly-look/src/react-components/cards/clickableCard.jsx
+++ b/feature-utils/poly-look/src/react-components/cards/clickableCard.jsx
@@ -3,13 +3,21 @@ import { PolyButton } from "../buttons";
 import "./card.css";
 
 /**
- * Clickable Card component
+ * Callback for handling the click event to close notification.
  *
- * @param {jsx} children JSX elements displayed inside the card
- * @param {Callback} onClick onClick function
- * @param {String} [buttonText] displays a button with the string at the bottom if passed
- * @param {String} [onlyButtonClickEvent] if a button is active, makes the button the only clickable part
- * @returns jsx
+ * @callback onClickCallback
+ * @param {React.MouseEventHandler<HTMLDivElement>} clickEvent - mouse event action.
+ */
+
+/**
+ * Clickable Card with a button component
+ * @component
+ * @param {Object} props
+ * @param {JSX.Element} [props.children] JSX elements displayed inside the card
+ * @param {onClickCallback} [props.onClick] onClick function
+ * @param {string} [props.buttonText] displays a button with the string at the bottom if passed
+ * @param {string} [props.onlyButtonClickEvent] if a button is active, makes the button the only clickable part
+ * @returns {JSX.Element}  A function that returns a div
  */
 const ClickableCard = ({
   children,

--- a/feature-utils/poly-look/src/react-components/chip.jsx
+++ b/feature-utils/poly-look/src/react-components/chip.jsx
@@ -7,10 +7,10 @@ import "./chip.css";
  * when clicked, it calls the handleClick function with the id prop as an argument
  * @component
  * @param {Object} props
- * @param {string} [props.id] - Text in chip's label, which is also acting as an if for the chip.
- * @param {string} [props.translation] - Translation for the text in chip's label.
- * @param {callback} [props.handleClick] - Chip's handleClick function (id of clicked chip).
- * @param {boolean} [props.active] - Indicates whether the chip is selected (active) or not.
+ * @param {string} props.id - Text in chip's label, which is also acting as an if for the chip.
+ * @param {string} props.translation - Translation for the text in chip's label.
+ * @param {callback} props.handleClick - Chip's handleClick function (id of clicked chip).
+ * @param {boolean} props.active - Indicates whether the chip is selected (active) or not.
  * @returns A React component
  */
 const Chip = ({ id, translation, handleClick, active }) => {

--- a/feature-utils/poly-look/src/react-components/chip.jsx
+++ b/feature-utils/poly-look/src/react-components/chip.jsx
@@ -2,13 +2,17 @@ import React from "react";
 import "./chip.css";
 
 /**
- * Individual chip
- * @param {string} [id] - Text in chip's label, which is also acting as an if for the chip.
- * @param {string} [translation] - Translation for the text in chip's label.
- * @param {callback} [handleClick] - Chip's handleClick function (id of clicked chip).
- * @param {boolean} [active] - Indicates whether the chip is selected (active) or not.
+ * Individual chip.
+ * It returns a button with a "chip" or "chip selected" depending on the active prop, and
+ * when clicked, it calls the handleClick function with the id prop as an argument
+ * @component
+ * @param {Object} props
+ * @param {string} [props.id] - Text in chip's label, which is also acting as an if for the chip.
+ * @param {string} [props.translation] - Translation for the text in chip's label.
+ * @param {callback} [props.handleClick] - Chip's handleClick function (id of clicked chip).
+ * @param {boolean} [props.active] - Indicates whether the chip is selected (active) or not.
+ * @returns A React component
  */
-
 const Chip = ({ id, translation, handleClick, active }) => {
   return (
     <button

--- a/feature-utils/poly-look/src/react-components/contexts/poly-import.jsx
+++ b/feature-utils/poly-look/src/react-components/contexts/poly-import.jsx
@@ -5,7 +5,7 @@ import {
   ZipFile,
 } from "@polypoly-eu/poly-import";
 
-//used until real storage is loaded
+// used until real storage is loaded
 const fakeStorage = {
   files: null,
   refreshFiles: async () => null,
@@ -15,6 +15,17 @@ const fakeStorage = {
 
 export const PolyImportContext = createContext();
 
+/**
+ * It takes a list of files, runs them through a list of importers, and returns an account.
+ * @const
+ * @callback PolyImportProvider
+ * @param {Object} props
+ * @param {Object} props.children
+ * @param {Object} props.parentContext
+ * @param {Object} props.dataImporters
+ * @param {Object} props.DataAccount
+ * @returns A function that returns a component.
+ */
 export const PolyImportProvider = ({
   children,
   parentContext,

--- a/feature-utils/poly-look/src/react-components/filterChips.jsx
+++ b/feature-utils/poly-look/src/react-components/filterChips.jsx
@@ -9,23 +9,33 @@ const othersId = "othersChip";
 const allId = "allChip";
 
 /**
+ * Callback for handling the click event on chip.
  *
+ * @callback onChipClickCallback
+ * @param {React.MouseEventHandler<HTMLDivElement>} clickEvent - chip onClick action.
+ */
+
+/**
  * Group of chips
- * @param { (string[] | Object[]) } chipsContent -  Content of the Chips
- * @param {Object} [chipsContent.id] - Id of the chip (if chipsContent is an array of strings they act as id)
- * @param {Object} [chipsContent.title] - Alternative for id of the chip (if chipsContent is an array of strings they act as id)
- * @param {Object} [chipsContent.translation] - Translation of the chip (if chipsContent is an array of strings they act as translation)
- * @param {string[]} [defaultActiveChips = []] - Chips that are active on load
- * @param {callback} onChipClick - Chips onClick function (id of clicked chip, all active chips ids)
- * @param {boolean} [exclusive = true] - Determines whether chips are active exclusively
- * @param {string} [theme] - Sets the theme in this component (preferably done in parent component)
- * @param {Object} [allChip] - Indicated whether an all chip exists (exclusive to the other chips, activates all)
- * @param {string} [allChip.translation = "All"] - Translation for chips text ("All")
- * @param {Object} [othersChip] - Indicated whether an others chip exists (groups multiple chips in "Others" chip)
- * @param {string} [othersChip.translation = "Others"] - Translation for chips text ("Others")
- * @param {string[]} [othersChip.ids] - Ids of the chips grouped by others
- * @param {boolean} [othersChip.exclusive] - Indicates whether the others chips is exclusive to the rest
- * @returns A `div` with the content
+ * It renders a list of chips, and when you click on a chip, it calls a callback function with the id
+ * of the chip that was clicked
+ * @component
+ * @param {Object} props
+ * @param {(Array.<string> | Array.<Object>)} props.chipsContent -  Content of the Chips
+ * @param {Object} props.chipsContent.id - Id of the chip (if chipsContent is an array of strings they act as id)
+ * @param {Object} props.chipsContent.title - Alternative for id of the chip (if chipsContent is an array of strings they act as id)
+ * @param {Object} props.chipsContent.translation - Translation of the chip (if chipsContent is an array of strings they act as translation)
+ * @param {Array.<string>} [props.defaultActiveChips = []] - Chips that are active on load
+ * @param {onChipClickCallback} props.onChipClick - Chips onClick function (id of clicked chip, all active chips ids)
+ * @param {boolean} [props.exclusive = true] - Determines whether chips are active exclusively
+ * @param {string} props.theme - Sets the theme in this component (preferably done in parent component)
+ * @param {Object} props.allChip - Indicated whether an all chip exists (exclusive to the other chips, activates all)
+ * @param {string} props.allChip.translation = "All" - Translation for chips text ("All")
+ * @param {Object} props.othersChip - Indicated whether an others chip exists (groups multiple chips in "Others" chip)
+ * @param {string} props.othersChip.translation = "Others" - Translation for chips text ("Others")
+ * @param {string[]} props.othersChip.ids - Ids of the chips grouped by others
+ * @param {boolean} props.othersChip.exclusive - Indicates whether the others chips is exclusive to the rest
+ * @returns  A function that returns a `div` component with the content
  */
 const FilterChips = ({
   chipsContent,

--- a/feature-utils/poly-look/src/react-components/fixedFooter.jsx
+++ b/feature-utils/poly-look/src/react-components/fixedFooter.jsx
@@ -3,11 +3,15 @@ import "./fixedFooter.css";
 
 /**
  * Fixed container at the bottom at the screen.
- * If the Screen content is too long and is covered by this footer, you might need to increese the padding-bottom of the screen to make the content visible.
- * @param {jsx} children JSX elements displayed inside the container.
- * @param {boolean} gradient Fade out band on the top of the container.
+ * If the Screen content is too long and is covered by this footer,
+ * you might need to increase the padding-bottom of the screen to make the content visible.
+ * @component
+ * @param {Object} props
+ * @param {JSX.Element} [props.children] JSX elements displayed inside the container.
+ * @param {boolean} [props.gradient] Fade out band on the top of the container.
+ * @returns {JSX.Element} A div with a className of either poly-fixed-footer-gradient or poly-fixed-footer
+ * depending on the value of gradient passed.
  */
-
 const FixedFooter = ({ children, gradient = true }) => {
   return (
     <div

--- a/feature-utils/poly-look/src/react-components/infoBox.jsx
+++ b/feature-utils/poly-look/src/react-components/infoBox.jsx
@@ -2,6 +2,12 @@ import React from "react";
 
 import "./infoBox.css";
 
+/**
+ * Returns a div with an image and a div with the textContent passed.
+ * @component
+ * @param {Object} props
+ * @param {Object} props.textContent - textContent div.
+ */
 const InfoBox = ({ textContent }) => {
   return (
     <div className="infobox">

--- a/feature-utils/poly-look/src/react-components/infographic/infographic.jsx
+++ b/feature-utils/poly-look/src/react-components/infographic/infographic.jsx
@@ -3,15 +3,17 @@ import * as d3 from "d3";
 import InfographicLegend from "./infographicLegend.jsx";
 import "./infographic.css";
 
-/** Renders an image and a numbered legend that contains descriptions
- *  for different elements in the image.
+/**
+ * Renders an SVG image and replaces numbered legends that contain descriptions
+ * with different HTML elements in the image.
+ * @component
  * @param {Object} props
- * @param {Object} [props.image] - Object containing the svg we want to use and translations
- * @param {Object} [props.image.svg] - the svg that we want to render
- * @param {Object} [props.image.texts] - an object where the key corresponds to a
+ * @param {Object} props.image - Object containing the svg we want to use and translations
+ * @param {Object} props.image.svg - the svg that we want to render
+ * @param {Object} props.image.texts - an object where the key corresponds to a
  * <text ../> id found in the svg while the value is a string that will replace the text.
- * @param {Array[string]} [props.explanation] - a simple array with descriptions
- * @param {Array[Object]} [props.legend] - an array of objects that will render an
+ * @param {Array.<String>} props.explanation - a simple array with descriptions
+ * @param {Array.<Object>} [props.legend] - an array of objects that will render an
  * InfographicLegend component. Check storybook for an example that showcases different
  * combinations.
  * @returns {JSX.Element}

--- a/feature-utils/poly-look/src/react-components/infographic/infographicLegend.jsx
+++ b/feature-utils/poly-look/src/react-components/infographic/infographicLegend.jsx
@@ -4,9 +4,11 @@ import { LineLegend, BlockLegend, CircleLegend } from "../legends.jsx";
 
 import "./infographicLegend.css";
 
-/** Augments the different legend components with tooltips.
+/**
+ * Augments the different legend components with tooltips.
+ * @component
  * @param {Object} props
- * @param {Array[Object]} [props.legend] - an array of objects that combines the different
+ * @param {Array.<Object>} [props.legend] - an array of objects that combines the different
  * props for the legend components and the Tooltip component.
  * @returns {JSX.Element}
  */

--- a/feature-utils/poly-look/src/react-components/infographic/tooltip.jsx
+++ b/feature-utils/poly-look/src/react-components/infographic/tooltip.jsx
@@ -1,13 +1,18 @@
 import React from "react";
 import "./tooltip.css";
 
-/** Small tooltip with pointer.
+/**
+ * Small tooltip with pointer.
+ * It takes in a label and a pointerDirection prop, and returns a div with a class of poly-tooltip
+ * @component
  * @param {Object} props
  * @param {string} [props.label] - tooltip label; preferably single letter/digit
  * as the tooltip is not designed for large texts.
  * @param {string} [props.pointerDirection] - where to position the pointer;
  * Currently only `down` and `left` options are implemented.
- * @returns {JSX.Element}
+ * @returns {JSX.Element} a div with a class of poly-tooltip, which contains a div with a class of either up, down, left, or right, which
+ * contains a div with a class of square, and a div with a class of either triangle-up, triangle-down,
+ * triangle-left, or triangle-right.
  */
 const Tooltip = ({ label, pointerDirection = "down" }) => {
   return (

--- a/feature-utils/poly-look/src/react-components/inputs/dropdown.jsx
+++ b/feature-utils/poly-look/src/react-components/inputs/dropdown.jsx
@@ -18,18 +18,18 @@ function filterOptions(options, text) {
  * @param {Object} props
  * @param {Object} [props.initialSelection] - input value, has to contain
  * an id and value, leave empty if the dropdown is not pre-populated
- * @param {callback} [props.onChange] - onChange event handler
- * @param {string} [props.name] - input name, also acts as id
- * @param {string} [props.helperText] - input helper text
- * @param {string} [props.label] - input label
- * @param {number} [props.tabIndex] - input tabIndex, needed to make sure the
+ * @param {callback} props.onChange - onChange event handler
+ * @param {string} props.name - input name, also acts as id
+ * @param {string} props.helperText - input helper text
+ * @param {string} props.label - input label
+ * @param {number} props.tabIndex - input tabIndex, needed to make sure the
  * focus/blur internal logic works
- * @param {boolean} [props.error] - indicates if the input is in an error
+ * @param {boolean} props.error - indicates if the input is in an error
  * state or not
- * @param {boolean} [props.disabled] - indicates if the input is disabled
- * @param {Array[Object]} [props.options] - array containing the dropdown options,
+ * @param {boolean} props.disabled - indicates if the input is disabled
+ * @param {Array.<Object>} props.options - array containing the dropdown options,
  * an option should have an id and a value
- * @param {string} [props.noMatch] - text to be shown when there is no match
+ * @param {string} props.noMatch - text to be shown when there is no match
  * @returns {JSX.Element}
  */
 

--- a/feature-utils/poly-look/src/react-components/list.jsx
+++ b/feature-utils/poly-look/src/react-components/list.jsx
@@ -6,8 +6,8 @@ import "./list.css";
  * A list of any jsx (HTML) elements that is scrollable
  * @component
  * @param {Object} props
- * @param {jsx} [props.children] Jsx children
- * @param {String} [props.className] CSS classes added to the main div
+ * @param {JSX.Element} props.children Jsx children
+ * @param {string} props.className CSS classes added to the main div
  * @returns {JSX.Element}
  */
 const List = ({ children, className }) => {

--- a/feature-utils/poly-look/src/react-components/list.jsx
+++ b/feature-utils/poly-look/src/react-components/list.jsx
@@ -4,10 +4,11 @@ import "./list.css";
 
 /**
  * A list of any jsx (HTML) elements that is scrollable
- *
- * @param {jsx} children Jsx children
- * @param {String} className CSS classes added to the main div
- * @returns jsx
+ * @component
+ * @param {Object} props
+ * @param {jsx} [props.children] Jsx children
+ * @param {String} [props.className] CSS classes added to the main div
+ * @returns {JSX.Element}
  */
 const List = ({ children, className }) => {
   return <div className={`list ${className}`}>{children}</div>;

--- a/feature-utils/poly-look/src/react-components/overlays/base.jsx
+++ b/feature-utils/poly-look/src/react-components/overlays/base.jsx
@@ -2,12 +2,13 @@ import React from "react";
 
 import "./base.css";
 
-/** Overlay base covering the whole screen
- *
- * @param {jsx} children - Overlay content
- * @param {String} className - CSS classes added to overlay
+/**
+ * Overlay base covering the whole screen
+ * @component
+ * @param {JSX.Element} children - Overlay content
+ * @param {string} className - CSS classes added to overlay
  * @param {boolean} centered - adds CSS class that centers content
- * @returns
+ * @returns a div with a className of base-overlay, className, and opaque
  */
 const BaseOverlay = ({ children, className, opaque }) => {
   return (

--- a/feature-utils/poly-look/src/react-components/overlays/loading.jsx
+++ b/feature-utils/poly-look/src/react-components/overlays/loading.jsx
@@ -3,11 +3,12 @@ import BaseOverlay from "./base.jsx";
 
 import "./loading.css";
 
-/** Overlay used when loading takes place
- *
- * @param {String} message - displayed below the image (GIF)
- * @param {String} loadingGif - link to image (GIF) in static files
- * @returns jsx
+/**
+ * Overlay used when loading takes place
+ * @component
+ * @param {string} message - displayed below the image (GIF)
+ * @param {string} loadingGif - link to image (GIF) in static files
+ * @returns {JSX.Element} a BaseOverlay component with a loading gif and a message
  */
 const LoadingOverlay = ({ message, loadingGif }) => (
   <BaseOverlay className="loading-overlay poly-content-centered">

--- a/feature-utils/poly-look/src/react-components/overlays/screen.jsx
+++ b/feature-utils/poly-look/src/react-components/overlays/screen.jsx
@@ -2,6 +2,16 @@ import React from "react";
 
 import "./screen.css";
 
+/**
+ * Screen is a function that returns a div with a poly-screen.
+ * @param {Object} props - The props for the selected screen
+ * @param {Object} props.children - The children for the selected screen
+ * @param {string} props.className - The className for the selected screen
+ * @param {Object} props.layout - The layout for the selected screen
+ * @param {Object} props.onScroll - The onScroll callback for the selected screen
+ * @param {Object} props.scrollingRef - The react element for scrollingRef of the screen
+ * @returns A div with the className of poly-screen, the className prop, and the layout prop.
+ */
 const Screen = ({ children, className, layout, onScroll, scrollingRef }) => {
   return (
     <div

--- a/feature-utils/poly-look/src/react-components/overlays/sideSheet.jsx
+++ b/feature-utils/poly-look/src/react-components/overlays/sideSheet.jsx
@@ -4,19 +4,25 @@ import { PolyButton, IconButton } from "../buttons";
 import "./sideSheet.css";
 
 /**
+ * Callback for handling the click event to close button.
  *
+ * @callback onCloseCallback
+ * @param {React.MouseEventHandler<HTMLDivElement>} clickEvent - mouse event action.
+ */
+
+/**
  * Generic container for HTRT content with close button(s).
+ * It renders a side sheet with a title, children, and an ok button.
  * Meant to be used in combination with SideSwiper.
  * @param {Object} props
- * @param {node} [props.children] - HTRT content.
- * @param {string} [props.okLabel] - Label used for the close button.
- * @param {callback} [props.onClose] - onClick event handler for the
+ * @param {Node} [props.children] - HTRT content.
+ * @param {String} [props.okLabel] - Label used for the close button.
+ * @param {onCloseCallback} [props.onClose] - onClick event handler for the
  * close buttons.
- * @param {string} [props.title = ""] - Optional title.
+ * @param {String} [props.title = ""] - Optional title.
  * Defaults to empty string;
  * @param {React.CSSProperties} [props.style] - Additional styles for
- * the component.
- * Defaults to empty object;
+ * the component. Defaults to empty object;
  * @returns {JSX.Element}
  */
 const SideSheet = ({

--- a/feature-utils/poly-look/src/react-components/overlays/sideSheet.jsx
+++ b/feature-utils/poly-look/src/react-components/overlays/sideSheet.jsx
@@ -15,14 +15,15 @@ import "./sideSheet.css";
  * It renders a side sheet with a title, children, and an ok button.
  * Meant to be used in combination with SideSwiper.
  * @param {Object} props
- * @param {Node} [props.children] - HTRT content.
- * @param {String} [props.okLabel] - Label used for the close button.
- * @param {onCloseCallback} [props.onClose] - onClick event handler for the
+ * @param {Node} props.children - HTRT content.
+ * @param {string} props.okLabel - Label used for the close button.
+ * @param {onCloseCallback} props.onClose - onClick event handler for the
  * close buttons.
- * @param {String} [props.title = ""] - Optional title.
+ * @param {string} [props.title = ""] - Optional title.
  * Defaults to empty string;
  * @param {React.CSSProperties} [props.style] - Additional styles for
  * the component. Defaults to empty object;
+ * @param {string} props.className - classname given
  * @returns {JSX.Element}
  */
 const SideSheet = ({

--- a/feature-utils/poly-look/src/react-components/overlays/sideSwiper.jsx
+++ b/feature-utils/poly-look/src/react-components/overlays/sideSwiper.jsx
@@ -18,7 +18,7 @@ import "./sideSwiper.css";
  * @component
  * @param {Object} props
  * @param {Boolean} [props.open] - Open or close the slide; defaults to false.
- * @param {onCloseCallback} [props.onClose] - Called after the exit animations end.
+ * @param {onCloseCallback} props.onClose - Called after the exit animations end.
  * @param {string} [props.leftDistance] - Contents distance from the left
  * of the screen. Can be any value that is compatible with CSS calc rule;
  * defaults to 15vw.
@@ -27,7 +27,7 @@ import "./sideSwiper.css";
  * @param {string} [props.animationDuration] - The duration of the animations.
  * Can be any value that is compatible with CSS transition-duration rule;
  * defaults to 0.6s.
- * @param {JSX.Element} [props.Component] - The component that will be animated.
+ * @param {JSX.Element} props.Component - The component that will be animated.
  * If this component can trigger the SideSwiper to close then it must have
  * an onClose callback as one of it's props.
  * If it has clickable elements, then Event.stopPropagation()

--- a/feature-utils/poly-look/src/react-components/overlays/sideSwiper.jsx
+++ b/feature-utils/poly-look/src/react-components/overlays/sideSwiper.jsx
@@ -3,19 +3,26 @@ import React, { useEffect, useState, useRef } from "react";
 import "./sideSwiper.css";
 
 /**
+ * Callback for handling the click event to close button.
  *
+ * @callback onCloseCallback
+ * @param {React.MouseEventHandler<HTMLDivElement>} clickEvent - mouse event action.
+ */
+
+/**
+ * It takes a component and renders it in a side swiper.
  * Generic container for HTRT side sheets or any other component that
  * slides from the right of the screen and can be closed either through
  * click, right or up sweep.
  * Note that during the in/out animations, interactions are disabled.
+ * @component
  * @param {Object} props
- * @param {boolean} [props.open] - Open or close the slide;
- * defaults to false.
- * @param {callback} [props.onClose] - Called after the exit animations end.
+ * @param {Boolean} [props.open] - Open or close the slide; defaults to false.
+ * @param {onCloseCallback} [props.onClose] - Called after the exit animations end.
  * @param {string} [props.leftDistance] - Contents distance from the left
  * of the screen. Can be any value that is compatible with CSS calc rule;
  * defaults to 15vw.
- * @param {Array[number]} [props.backdropColor] - The backdrop color as a rgba array;
+ * @param {Array.<Number>} [props.backdropColor] - The backdrop color as a rgba array;
  * defaults to [0, 0, 0, 0.3].
  * @param {string} [props.animationDuration] - The duration of the animations.
  * Can be any value that is compatible with CSS transition-duration rule;
@@ -28,7 +35,6 @@ import "./sideSwiper.css";
  * If the component has vertical scroll then it must accept custom styles.
  * @returns {JSX.Element}
  */
-
 const SideSwiper = ({
   open = false,
   onClose,

--- a/feature-utils/poly-look/src/react-components/popUps/errorPopup/errorPopup.jsx
+++ b/feature-utils/poly-look/src/react-components/popUps/errorPopup/errorPopup.jsx
@@ -7,6 +7,21 @@ const emailLink = `\
 polypod-feedback@polypoly.coop\
 </a>`;
 
+/**
+ * Callback for handling the click event to close button.
+ *
+ * @callback buttonCallback
+ * @param {React.MouseEventHandler<HTMLButtonElement>} clickEvent - mouse onClick action.
+ */
+
+/**
+ * It renders a popup with an error message and instructions on how to report the error
+ * @param {Object} props
+ * @param {Error} [props.error] the error raised
+ * @param {buttonCallback} [props.onClose] Button callback.
+ * @param {String} [props.text] The text popup message.
+ * @returns A React component.
+ */
 export default function ErrorPopup({ error, onClose, text }) {
   return (
     <div className="error-popup">

--- a/feature-utils/poly-look/src/react-components/routing/wrapper.jsx
+++ b/feature-utils/poly-look/src/react-components/routing/wrapper.jsx
@@ -2,16 +2,19 @@ import React from "react";
 import { INITIAL_HISTORY_STATE } from "../../constants";
 
 /**
- * Component that makes any children that have onClick properties a router onClick
+ * It takes a React component and returns a new React component that
+ * wraps the original component and adds a new onClick function to it
+ * for any children that have already onClick properties.
  * This will not override the onClick property of the children but give them a new one combining routing
- * and the previous onClick
- * This does not add any divs or ther HTML elements
- *
- * @param {jsx} children - React children in jsx format
- * @param {History} history - React router dom history
- * @param {String} route - String to route to ("back" leads back)
- * @param {Object} [stateChange] - Initial state overriding INITIAL_HISTORY_STATE property to which it defaults
- * @returns
+ * and the previous onClick.
+ * This does not add any divs or ther HTML elements.
+ * @component
+ * @param {Object} props
+ * @param {JSX.Element} [props.children] - React children in jsx format
+ * @param {Object} [props.history] - React router dom history
+ * @param {string} [props.route] - String to route to ("back" leads back)
+ * @param {Object} [props.stateChange] - Initial state overriding INITIAL_HISTORY_STATE property to which it defaults
+ * @returns A React component that takes in children, history, route, and stateChange as props.
  */
 const RoutingWrapper = ({ children, history, route, stateChange }) => {
   const onRoute = () => {

--- a/feature-utils/poly-look/src/react-components/routing/wrapper.jsx
+++ b/feature-utils/poly-look/src/react-components/routing/wrapper.jsx
@@ -10,10 +10,10 @@ import { INITIAL_HISTORY_STATE } from "../../constants";
  * This does not add any divs or ther HTML elements.
  * @component
  * @param {Object} props
- * @param {JSX.Element} [props.children] - React children in jsx format
- * @param {Object} [props.history] - React router dom history
- * @param {string} [props.route] - String to route to ("back" leads back)
- * @param {Object} [props.stateChange] - Initial state overriding INITIAL_HISTORY_STATE property to which it defaults
+ * @param {JSX.Element} props.children - React children in jsx format
+ * @param {Object} props.history - React router dom history
+ * @param {string} props.route - String to route to ("back" leads back)
+ * @param {Object} props.stateChange - Initial state overriding INITIAL_HISTORY_STATE property to which it defaults
  * @returns A React component that takes in children, history, route, and stateChange as props.
  */
 const RoutingWrapper = ({ children, history, route, stateChange }) => {

--- a/feature-utils/poly-look/src/react-components/slideshow/slideshow.jsx
+++ b/feature-utils/poly-look/src/react-components/slideshow/slideshow.jsx
@@ -4,9 +4,11 @@ import SwiperCore, { Pagination } from "swiper";
 
 import "./slideshow.css";
 
-/** Slideshow used to display images.
+/**
+ * It takes in an array of images and returns a slideshow.
+ * @component
  * @param {Object} props
- * @param {Array[string]} [props.images] - Array that contains the urls of the
+ * @param {Array.<String>} [props.images] - Array that contains the urls of the
  * images that will be displayed.
  * @returns {JSX.Element}
  */

--- a/feature-utils/poly-look/src/react-components/tabs.jsx
+++ b/feature-utils/poly-look/src/react-components/tabs.jsx
@@ -22,9 +22,9 @@ const Tab = () => {
  * Group of tabs, that might include a swiper.
  * @component
  * @param {Object} props
- * @param {Array.<Object>} [props.tabList] -  a list of elements that are going to be used as tabs
+ * @param {Array.<Object>} props.tabList -  a list of elements that are going to be used as tabs
  * @param {boolean} [props.swipe] - Use a Swiper component or not within the tab
- * @param {onTabCallback} [props.onTabChange] - called when a tab changes
+ * @param {onTabCallback} props.onTabChange - called when a tab changes
  */
 const Tabs = ({ children: tabList, swipe = true, onTabChange }) => {
   const [activeTabId, setActiveTabId] = useState(tabList[0].props.id);

--- a/feature-utils/poly-look/src/react-components/tabs.jsx
+++ b/feature-utils/poly-look/src/react-components/tabs.jsx
@@ -12,11 +12,19 @@ const Tab = () => {
 };
 
 /**
+ * Callback for handling the click event to tab button.
  *
- * Group of tabs, that might include a swiper
- * @param { Object[] } tabList -  a list of elements that are going to be used as tabs
- * @param {boolean} swipe - Use a Swiper component or not within the tab
- * @param {function()} onTabChange - called when a tab changes
+ * @callback onTabCallback
+ * @param {React.MouseEventHandler<HTMLDivElement>} clickEvent - mouse onClick action.
+ */
+
+/**
+ * Group of tabs, that might include a swiper.
+ * @component
+ * @param {Object} props
+ * @param {Array.<Object>} [props.tabList] -  a list of elements that are going to be used as tabs
+ * @param {boolean} [props.swipe] - Use a Swiper component or not within the tab
+ * @param {onTabCallback} [props.onTabChange] - called when a tab changes
  */
 const Tabs = ({ children: tabList, swipe = true, onTabChange }) => {
   const [activeTabId, setActiveTabId] = useState(tabList[0].props.id);

--- a/feature-utils/poly-look/src/visualisations/charts/bar-charts/verticalBarChart/verticalBarChart.js
+++ b/feature-utils/poly-look/src/visualisations/charts/bar-charts/verticalBarChart/verticalBarChart.js
@@ -15,10 +15,8 @@ const barValueMargin = 4;
 const gridXMargin = 12;
 
 /**
- * Visualizes data as a bar chart with vertically arrranged bars
- *
- * The scales are on the left and the bottom
- *
+ * Visualizes data as a bar chart with vertically arrranged bars.
+ * The scales are on the left and the bottom.
  * @class
  * @extends Chart
  * @param {CSS-selector} selector - A CSS selector, where the svg will be attached to

--- a/feature-utils/poly-look/src/visualisations/charts/bubble-charts/bubbleCluster/bubbleCluster.js
+++ b/feature-utils/poly-look/src/visualisations/charts/bubble-charts/bubbleCluster/bubbleCluster.js
@@ -122,11 +122,8 @@ const bubbleFontSize = (d) => {
 
 /**
  * Visualizes data as a cluster of bubbles where the value of the bubble is represented as the radius.
- *
  * The bubbles are being added in a spiral starting in the center of the cluster meaning sorted data will lead to all small bubbles in the middle or outside.
- *
- * Adding svg icons to a data point will load the svg instead of a bubble
- *
+ * Adding svg icons to a data point will load the svg instead of a bubble.
  * @class
  * @extends Chart
  * @param {CSS-selector} selector - A CSS selector, where the svg will be attached to

--- a/feature-utils/poly-look/src/visualisations/charts/treeMap/treeMap.js
+++ b/feature-utils/poly-look/src/visualisations/charts/treeMap/treeMap.js
@@ -12,10 +12,8 @@ const defaultPadding = 2,
   defaultOnUnfittingText = "";
 
 /**
- * Visualizes data as a tree map
- *
- * The data can be infinitely nested to visualize grouping
- *
+ * Visualizes data as a tree map.
+ * The data can be infinitely nested to visualize grouping.
  * @class
  * @extends Chart
  * @param {CSS-selector} selector - A CSS selector, where the svg will be attached to

--- a/feature-utils/poly-look/src/visualisations/d3-utils.js
+++ b/feature-utils/poly-look/src/visualisations/d3-utils.js
@@ -1,10 +1,8 @@
 import * as d3 from "d3";
 
 /**
- *  Wraps d3-texts on whitespaces
- *
- *  To be called like so: textSelection.call(wrapTexts)
- *
+ * Wraps d3-texts on whitespaces.
+ * To be called like so: textSelection.call(wrapTexts)
  * @param {d3-text-selection} texts
  */
 export function wrapTexts(texts) {
@@ -43,10 +41,9 @@ export function wrapTexts(texts) {
 }
 
 /**
- * Only keeps Day, Month and Yar from a date
- *
- * @param {Date} Date
- * @returns Date
+ * Returns the passed date in a %Y-%m-%d format.
+ * @param {Date} date - a js Date object.
+ * @returns {Date} - a Date in a %Y-%m-%d format.
  */
 export function trimTimeOfDate(jsDate) {
   const date = `${jsDate.getFullYear()}-${

--- a/feature-utils/poly-look/src/visualisations/wrappers/react/polyChart.jsx
+++ b/feature-utils/poly-look/src/visualisations/wrappers/react/polyChart.jsx
@@ -21,10 +21,12 @@ const charts = {
 };
 
 /**
- *
+ * It renders a chart of the type specified in the props, and it renders it in the div with the class
+ * name specified in the props
+ * @callback PolyChart
  * @param {Object} props - The props for the selected chart
  * @param {string} props.type - The type of the chart (e. "vertical-bar-chart")
- * @returns jsx-div with svg-chart attached
+ * @returns {JSX.Element} JSX div with svg-chart attached
  */
 export const PolyChart = (props) => {
   const chartRef = useRef();

--- a/features/facebookImport/src/model/analyses/ministories/about-pictures-data-analysis.js
+++ b/features/facebookImport/src/model/analyses/ministories/about-pictures-data-analysis.js
@@ -5,11 +5,20 @@ import analysisKeys from "../utils/analysisKeys";
 /**
  * Minimum number of picutures that should be present in
  * the export in order for this analysis to be active.
+ * @const PICTURES_THRESHOLD 1
  */
 const PICTURES_THRESHOLD = 1;
 
+/**
+ * It takes a zip file and a data account, and if the zip file contains more than a certain number of
+ * pictures, it adds a key to the data account's analyses object.
+ * @class AboutPicturesDataAnalysis
+ */
 export default class AboutPicturesDataAnalysis extends RootAnalysis {
     /**
+     * It takes a zip file, finds all the files in it that look like they might be photos, and returns a
+     * list of those files.
+     * 
      * Determine the pictures posted by the user.
      *
      * At the moment, since we do not import posts and albums,
@@ -30,6 +39,10 @@ export default class AboutPicturesDataAnalysis extends RootAnalysis {
      * For now we do not try to distinguish them from pictures
      * uploaded by a user, or do any other classification. We
      * simply include all pictures in that folder.
+
+     * @memberof AboutPicturesDataAnalysis
+     * @param zipFile - The zip file that was uploaded by the user.
+     * @returns An array of paths to the photos in the zip file.
      */
     async _userPicturesFromExport(zipFile) {
         const photoRegexes = [
@@ -41,6 +54,13 @@ export default class AboutPicturesDataAnalysis extends RootAnalysis {
             .filter((path) => photoRegexes.some((regex) => regex.test(path)));
     }
 
+    /**
+     * It takes a zip file and a data account, and if the zip file contains more than a certain number of
+     * pictures, it adds a key to the data account's analyses object.
+     * @param zipFile - The zip file that was uploaded by the user.
+     * @param dataAccount - The data account of the user.
+     * @memberof AboutPicturesDataAnalysis
+     */
     async analyze({ zipFile, dataAccount }) {
         const pictureEntries = await this._userPicturesFromExport(zipFile);
         if (pictureEntries.length >= PICTURES_THRESHOLD)

--- a/features/facebookImport/src/model/analyses/ministories/export-size-analysis.js
+++ b/features/facebookImport/src/model/analyses/ministories/export-size-analysis.js
@@ -1,5 +1,9 @@
 import { RootAnalysis } from "@polypoly-eu/poly-analysis";
 
+/**
+ * It's a simple analysis that displays the size of the exported file.
+ * @class ExportSizeAnalysis
+ */
 export default class ExportSizeAnalysis extends RootAnalysis {
     get title() {
         return "File size";

--- a/features/facebookImport/src/model/analyses/ministories/on-off-facebook-advertisers-analysis.js
+++ b/features/facebookImport/src/model/analyses/ministories/on-off-facebook-advertisers-analysis.js
@@ -2,11 +2,27 @@ import React from "react";
 import { linkRelatedAccountsWithOffFacebookCompanies } from "../utils/on-off-events-matching.js";
 import { RootAnalysis } from "@polypoly-eu/poly-analysis";
 
+/**
+ * It looks for advertisers that have both on- and off-Facebook events in the data
+ * @class OnOffFacebookAdvertisersAnalysis
+ */
 export default class OnOffFacebookAdvertisersAnalysis extends RootAnalysis {
+    /**
+     * It returns the title of the page.
+     * @methodof OnOffFacebookAdvertisersAnalysis
+     * @returns The title of the page.
+     */
     get title() {
         return "On and Off-Facebook Advertisers";
     }
 
+    /**
+     * It takes a data account, finds all the advertisers that have both on- and off-Facebook data, and
+     * returns a list of those advertisers
+     * @methodof OnOffFacebookAdvertisersAnalysis
+     * @param {dataAccount} - A data account of user
+     * @returns A list of advertisers
+     */
     async analyze({ dataAccount }) {
         const advertiserMatches =
             linkRelatedAccountsWithOffFacebookCompanies(dataAccount);
@@ -20,6 +36,11 @@ export default class OnOffFacebookAdvertisersAnalysis extends RootAnalysis {
         this.active = this._commonAdvertisersData.length > 0;
     }
 
+    /**
+     * It returns a React component that renders a paragraph and a table
+     * @methodof OnOffFacebookAdvertisersAnalysis
+     * @returns A React fragment.
+     */
     renderSummary() {
         return (
             <>

--- a/features/facebookImport/src/model/analyses/utils/performance-telemetry.js
+++ b/features/facebookImport/src/model/analyses/utils/performance-telemetry.js
@@ -5,7 +5,6 @@
 export class Telemetry {
     /**
      * Creates a new object with a creation time property set to the current time.
-     * @constructor
      * @methodof Telemetry
      */
     constructor() {

--- a/features/facebookImport/src/model/analyses/utils/performance-telemetry.js
+++ b/features/facebookImport/src/model/analyses/utils/performance-telemetry.js
@@ -1,13 +1,22 @@
 /**
  * An utility class for measuring time duration.
- *
- * @class
+ * @class Telemetry
  */
 export class Telemetry {
+    /**
+     * Creates a new object with a creation time property set to the current time.
+     * @constructor
+     * @methodof Telemetry
+     */
     constructor() {
         this._creationTime = performance.now();
     }
 
+    /**
+     * It returns the time elapsed since the object was created.
+     * @returns The difference between the current time and the time the object was created.
+     * @methodof Telemetry
+     */
     elapsedTime() {
         return performance.now() - this._creationTime;
     }

--- a/features/facebookImport/src/model/importers/utils/ads-locale.js
+++ b/features/facebookImport/src/model/importers/utils/ads-locale.js
@@ -3,6 +3,7 @@
  *
  * We use the title of the ads category to detect the language
  * by comparing it to a list of knows titles.
+ * @const AD_LOCALE
  */
 export const AD_LOCALE = {
     de: {
@@ -21,7 +22,10 @@ export const AD_LOCALE = {
 };
 
 /**
- * Attempt to detect the locale in which the given category name is written.
+ * It takes a category name as an argument and returns the locale object that has the same category
+ * name.
+ * @param categoryName - The name of the category you want to get the locale for.
+ * @returns The locale for the category name.
  */
 export function localeForCategoyName(categoryName) {
     return Object.values(AD_LOCALE).find(
@@ -29,6 +33,12 @@ export function localeForCategoyName(categoryName) {
     );
 }
 
+/**
+ * It extracts the name of the ad from the description
+ * @param description - The description of the ad.
+ * @param locale - the locale object
+ * @returns The name of the ad.
+ */
 export function extractNameFromAdDescription(description, locale) {
     const match = description.match(locale.nameRegex);
     if (match && match.length === 2) {

--- a/features/facebookImport/src/model/importers/utils/url-processing.js
+++ b/features/facebookImport/src/model/importers/utils/url-processing.js
@@ -1,10 +1,10 @@
 /**
- * Extract data from an url of the form:
+ * It takes a Facebook URL and returns an object with the account data (the URL and the URL ID).
+ * @param urlString - The URL of the Facebook post. e.g.:
  * "https://www.facebook.com/<id>/posts/<somethig-else>"
  * "https://www.facebook.com/<id>/photos/<somethig-else>".
  * "https://www.facebook.com/<id>/videos/<somethig-else>".
- *
- * Return this account data:
+ * @returns {{url: string, urlId: string}} - The account data, as an object with two properties: url and urlId.
  *  {
  *     url: "https://www.facebook.com/<id>";
  *     urlId: "<id>"
@@ -21,15 +21,14 @@ export function extractAccountDataFromStandardUrl(urlString) {
 }
 
 /**
- * Extract data from an url of the form:
- * "https://www.facebook.com/permalink.php?id=<id> <other parameters>"
- *
- * Return this account data:
- *  {
+ * It takes a Facebook permalink URL and returns the URL and raw ID of the account that posted the
+ * content
+ * @param urlString - The URL of the Facebook post, form of "https://www.facebook.com/permalink.php?id=<id> <other parameters>"
+ * @returns {{url: string, rawId: string}} - An object with two properties: url and rawId.
+ * {
  *     url: "https://www.facebook.com/<id>";
  *     rawId: "<id>"
- *  }
- *
+ * }
  */
 export function extractAccountDataFromPermlinkUrl(urlString) {
     if (!urlString.startsWith("https://www.facebook.com/permalink.php?")) {
@@ -48,6 +47,11 @@ const STRATEGIES = [
     extractAccountDataFromPermlinkUrl,
 ];
 
+/**
+ * Try each strategy until one of them returns a non-null value.
+ * @param urlString - The URL to extract the account data from.
+ * @returns A function that takes a urlString as an argument and returns the extractedData.
+ */
 export function extractAccountDataFromUrl(urlString) {
     for (const strategy of STRATEGIES) {
         const extractedData = strategy(urlString);

--- a/features/facebookImport/src/utils/formatTime.js
+++ b/features/facebookImport/src/utils/formatTime.js
@@ -9,15 +9,17 @@ const defaultDisplayOptions = {
 };
 
 /**
- * Formats time to a string
- * @param {number || string || object} time - Time as a number (seconds), string (UTC) or a Date object
- * @param {string = i18n-format} format
- * @param {object} options
- * @param {string} options.weekday - Weekday representation
- * @param {string = "numeric"} options.day - Day representation
- * @param {string = "long"} options.months - Months representation
- * @param {string = "numeric"} options.year - Year representation
- * @returns string
+ * Formats time to a string.
+ * @callback formatTime
+ * @param {number|string|object} time - The time to be formatted.
+ * Time as a number (representing seconds since epoch), string (UTC, in the format "YYYY-MM-DD") or a Date object.
+ * @param {string} [format] - The format of the date in i18n-format
+ * @param {object} [options]
+ * @param {string} [options.weekday] - Weekday representation
+ * @param {string} [options.day] - Day representation, defaults to "numeric"
+ * @param {string} [options.months] - Months representation, defaults to "long"
+ * @param {string} [options.year] - Year representation, defaults to "numeric"
+ * @returns A string representing the date and time in the format specified by the format parameter.
  */
 export const formatTime = (
     time,

--- a/features/google/src/model/importers/semantic-locations-importer.js
+++ b/features/google/src/model/importers/semantic-locations-importer.js
@@ -11,9 +11,15 @@ async function readFullPathJSONFile(entry) {
 }
 
 /**
+ * If the duration object has a startTimestamp property, return a new Date object initialized with the
+ * value of that property. Otherwise, if the duration object has a startTimestampMs property, return a
+ * new Date object initialized with the value of that property. Otherwise, throw an error.
+ *
  * We saw until now two different formats for timestamps:
  * - milliseconds: 1394270917000
  * - standard date: "2022-01-19T14:28:16.967Z"
+ * @param duration - The duration object from the API response.
+ * @returns A function that takes a duration object and returns a date object.
  */
 function extractStartTimestampFromDuration(duration) {
     if ("startTimestamp" in duration) return new Date(duration.startTimestamp);
@@ -23,6 +29,7 @@ function extractStartTimestampFromDuration(duration) {
         "No start timestamp found in keys: " + Object.keys(duration).toString()
     );
 }
+
 function extractEndTimestampFromDuration(duration) {
     if ("endTimestamp" in duration) return new Date(duration.endTimestamp);
     if ("endTimestampMs" in duration) return new Date(duration.endTimestampMs);
@@ -54,12 +61,12 @@ function createActivitySegment(jsonData) {
 
 /**
  * Extract from the given file entry the list of timeline objects grouped by their type.
- * We saw two types of timeline objects:
+ * It reads the JSON file and returns an object with two types of timeline objects:
  *  - Place Visits
  *  - Activity Segments
  *
- * @param {*} fileEntry
- * @returns
+ * @param fileEntry - The file entry of the JSON file to be parsed.
+ * @returns {{placeVisits:Array.<Object>, activitySegments:Array.<Object>}} - An object with two properties: placeVisits and activitySegments.
  */
 async function parseTimelineObjectsByTypeFromEntry(fileEntry) {
     const jsonContent = await readFullPathJSONFile(fileEntry);

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -362,13 +362,16 @@ class PodJsInfo implements Info {
     }
 }
 
+/**
+ * @interface NetworkResponse
+ */
 interface NetworkResponse {
     payload?: string;
     error?: string;
 }
 
 /**
- * BrowserNetwork makes network requests using XMLHttpRequest
+ * BrowserNetwork makes network requests using XMLHttpRequest.
  * @class BrowserNetwork
  */
 class BrowserNetwork {
@@ -377,6 +380,7 @@ class BrowserNetwork {
      * And returns the network response as a promise.
      * @param {string} url - The URL to which the request is sent.
      * @param {string} body - The body of the request.
+     * @param {boolean} allowInsecure - The boolean value whether allow insecure.
      * @param {string} [contentType] - The content type of the request.
      * @param {string} [authToken] - The token to use for authentication.
      * @returns A Promise of the Network Response of the call that was executed.
@@ -401,9 +405,10 @@ class BrowserNetwork {
     /**
      * It makes a GET request to the specified URL, and returns the response
      * @param {string} url - The URL to fetch.
+     * @param {boolean} allowInsecure - The boolean value whether allow insecure.
      * @param {string} [contentType] - The content type of the request.
      * @param {string} [authToken] - The token to use for authentication.
-     * @returns A promise.
+     * @returns A promise that resolves to the NetworkResponse
      */
     async httpGet(
         url: string,
@@ -421,13 +426,14 @@ class BrowserNetwork {
     }
 
     /**
-     * It makes a network request of type @type and returns the response
+     * It makes a network request of type passed and returns the response [[NetworkResponse]]
      * @param {string} type - The HTTP method to use.
      * @param {string} url - The URL to fetch.
+     * @param {boolean} allowInsecure - The boolean value whether allow insecure.
      * @param {string} [body] - The body of the request.
      * @param {string} [contentType] - The content type of the request.
      * @param {string} [authToken] - The token to use for authentication.
-     * @returns The promise is resolved with a NetworkResponse object.
+     * @returns {Promise<NetworkResponse>} The promise is resolved with a NetworkResponse object.
      */
     private async httpFetchRequest(
         type: string,

--- a/platform/podjs/src/browserPod.ts
+++ b/platform/podjs/src/browserPod.ts
@@ -540,7 +540,7 @@ function endpointErrorMessage(fetchType: string, errorlog: string): string {
 }
 
 /**
- * @class BrowserEndpoint
+ * @class BrowserEndpoint @implements [[Endpoint]]
  */
 class BrowserEndpoint implements Endpoint {
     endpointNetwork = new BrowserNetwork();
@@ -596,7 +596,7 @@ class BrowserEndpoint implements Endpoint {
 }
 
 /**
- * @class `BrowserPolyNavPolyNav`
+ * @class `BrowserPolyNavPolyNav` @implements [[PolyNav]]
  */
 class BrowserPolyNav implements PolyNav {
     actions?: { [key: string]: () => void };
@@ -779,7 +779,8 @@ function createNavBarFrame(title: string): HTMLElement {
 }
 
 /**
- * The @class BrowserPod is a Pod that uses the browser's local storage to store polyIn and polyOut data
+ * The @class BrowserPod @implements a [[Pod]]
+ * that uses the browser's local storage to store polyIn and polyOut data
  */
 export class BrowserPod implements Pod {
     public readonly dataFactory = dataFactory;


### PR DESCRIPTION
## Scope

Fixes the jsDocs mostly in react components (and in some `.js`), following the new structure of `/docs/documentation` in https://github.com/polypoly-eu/polyPod/pull/1231
so that documentation is generated without any errors.


## 🧪 How to Test 

Just need to run `./build.js doc` and check the generated documentation under `/docs/documentation/` folder.


## 📖 As future reference of jsDoc usage:

To annotate the params of a component: `@param {type} name - description`
For an _optional_ param should be:          `@param {type} [name] - description`

Potential `{type}` for: 
a general object:`Object`
string value:`string`
boolean value:`boolean`
array of objects:  `Array.<{type}>`
etc. 
or if we know the exact type, we can link to its class directly.

When the param is an object with different fields, should be _first_ annotated as:
`@param {Object} props`
and the rest children fields carry its name, so they're linked to it:
`@param {string} props.firstField - the first field of the object`

For a `callback` type we can firstly define it:
```
/**
 * Callback for X.
 * @callback nameCallback
 * @param {type} nameCallback - callback when ...
 */
```
and use it:
`@param {nameCallback} myCallbackParam - onClick function`


⚠️ also in the case of `export const` callbacks should be annotated specifically with `@callback <itsName>` (so its params are included into the documentation)
e.g. 
```
/**
 * It renders an empty chart.
 * @callback MyChart
 * @returns {JSX.Element} an empty JSX div
 */
export const MyChart = () => {
 ...
  return <div></div>;
};
```

A general example of a `ClickableCard`:
```
@component
@param {Object} props
@param {JSX.Element} props.children JSX elements displayed inside the card
@param {onClickCallback} props.onClick onClick function
@param {string} props.buttonText displays a button with the string at the bottom if passed
@param {string} [props.onClickEvent] if a button is active, makes the button the only clickable part. Defaults to false. 
@returns {JSX.Element}  A function that returns a div
 */
const ClickableCard = ({
  children,
  onClick,
  buttonText,
  onClickEvent = false,
}) => { (edited) 
```

For more detailed usage of jsdocs, please, consult the official [jsdoc](https://devdocs.io/jsdoc/) documentation :)


### 📸 Resulted documentation for poly-look:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/2449310/197778472-d85f4f03-4830-4b42-bf7b-4a20f5a0b295.png">

