### PR TITLE
:bug: sanitizes warning by removing newlines

### DIFF
--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/FeatureContainer.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/FeatureContainer.kt
@@ -415,7 +415,7 @@ class FeatureContainer(context: Context, attrs: AttributeSet? = null) :
         fun reportError(error: String) {
             logger.warn(
                 "Uncaught error from " +
-                    FeatureStorage.activeFeatureId + ": " + error
+                    FeatureStorage.activeFeatureId + ": " + error.replace("\n", " ")
             )
             errorHandler(error)
         }

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/logging/AndroidLogger.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/logging/AndroidLogger.kt
@@ -13,7 +13,7 @@ class AndroidLogger(val tag: String) : Logger {
 
     override fun warn(msg: String) {
         if (isWarnEnabled)
-            Log.w(tag, msg)
+            Log.w(tag, msg.replace("\n"," "))
     }
 
     override fun warn(format: String, arg: Any) {

--- a/platform/android/app/src/main/kotlin/coop/polypoly/polypod/logging/AndroidLogger.kt
+++ b/platform/android/app/src/main/kotlin/coop/polypoly/polypod/logging/AndroidLogger.kt
@@ -13,7 +13,7 @@ class AndroidLogger(val tag: String) : Logger {
 
     override fun warn(msg: String) {
         if (isWarnEnabled)
-            Log.w(tag, msg.replace("\n"," "))
+            Log.w(tag, msg.replace("\n", " "))
     }
 
     override fun warn(format: String, arg: Any) {


### PR DESCRIPTION
This might or might not be enough for https://github.com/polypoly-eu/polyPod/security/code-scanning/66. Let's see

## Scope

There are issue revealed by the CodeQL security scanning policy. This is limited only to those with high priority.
This limited approach might or might not solve the problem; a more extensive refactorization of logging might be needed. We'll get there if needed.

## 🏗️ Implementation 

"Log injection" starts with using a newline character to kinda "put" new lines into the log. This could affect mainly logs sent to us by users, I guess, which might cause some problems if it's done with malicious intent. At any rate, maintaining some level of health is desirable.